### PR TITLE
Reworked how query filters are maintained in the URL

### DIFF
--- a/packages/react-search-ui-views/src/types/ValueFilterValue.js
+++ b/packages/react-search-ui-views/src/types/ValueFilterValue.js
@@ -1,3 +1,3 @@
 import PropTypes from "prop-types";
 
-export default PropTypes.string;
+export default PropTypes.oneOfType([PropTypes.string, PropTypes.number]);

--- a/packages/react-search-ui/src/types/ValueFilterValue.js
+++ b/packages/react-search-ui/src/types/ValueFilterValue.js
@@ -1,3 +1,3 @@
 import PropTypes from "prop-types";
 
-export default PropTypes.string;
+export default PropTypes.oneOfType([PropTypes.string, PropTypes.number]);

--- a/packages/search-ui/src/URLManager.js
+++ b/packages/search-ui/src/URLManager.js
@@ -128,7 +128,7 @@ function stateToParams({
 }
 
 function stateToQueryString(state) {
-  return queryString.stringify(stateToParams(state), { indices: false });
+  return queryString.stringify(stateToParams(state));
 }
 
 /**

--- a/packages/search-ui/src/URLManager.js
+++ b/packages/search-ui/src/URLManager.js
@@ -1,13 +1,6 @@
 import createHistory from "history/createBrowserHistory";
 import queryString from "qs";
 
-function typeOfFilter(filterValue) {
-  const firstFilterValue = filterValue[0];
-  if (typeof firstFilterValue === "string") return "value";
-  if (firstFilterValue.to || firstFilterValue.from) return "range";
-  return "";
-}
-
 function isNumeric(num) {
   return !isNaN(num);
 }
@@ -26,35 +19,7 @@ function toInteger(num) {
 }
 
 function parseFiltersFromQueryParams(queryParams) {
-  const filters = Object.keys(queryParams).reduce((acc, paramName) => {
-    if (paramName.startsWith("fv-")) {
-      let paramValue = queryParams[paramName];
-      if (!paramValue) return acc;
-      const filterName = paramName.replace("fv-", "");
-      acc.push({
-        [filterName]: Array.isArray(paramValue) ? paramValue : [paramValue]
-      });
-    }
-    if (paramName.startsWith("fr-")) {
-      let paramValue = queryParams[paramName];
-      if (!paramValue) return acc;
-      const filterName = paramName.replace("fr-", "");
-      const value = Array.isArray(paramValue) ? paramValue : [paramValue];
-      acc.push({
-        [filterName]: value.map(v => {
-          const [from, to] = v.split("_");
-          return {
-            ...(from && { from: Number(from) }),
-            ...(to && { to: Number(to) })
-          };
-        })
-      });
-    }
-    return acc;
-  }, []);
-
-  if (filters.length === 0) return;
-  return filters;
+  return queryParams.filters;
 }
 
 function parseCurrentFromQueryParams(queryParams) {
@@ -104,21 +69,12 @@ function stateToParams({
 }) {
   const params = {};
 
-  filters.forEach(filter => {
-    const [key, value] = Object.entries(filter)[0];
-    const valueType = typeOfFilter(value);
-    if (valueType === "range") {
-      params[`fr-${key}`] = value.map(
-        rangeValue => `${rangeValue.from || ""}_${rangeValue.to || ""}`
-      );
-    } else {
-      params[`fv-${key}`] = value;
-    }
-  });
-
   if (current > 1) params.current = current;
   if (searchTerm) params.q = searchTerm;
   if (resultsPerPage) params.size = resultsPerPage;
+  if (filters && filters.length > 0) {
+    params["filters"] = filters;
+  }
   if (sortField) {
     params["sort-field"] = sortField;
     params["sort-direction"] = sortDirection;

--- a/packages/search-ui/src/URLManager.js
+++ b/packages/search-ui/src/URLManager.js
@@ -1,26 +1,7 @@
 import createHistory from "history/createBrowserHistory";
-import queryString from "qs";
+import queryString from "./queryString";
 
-function preserveTypesEncoder(value, encode) {
-  // Encode numbers to custom 'n_123_n' format so don't
-  // lose typing
-  if (isNumeric(value)) {
-    return `n_${value}_n`;
-  }
-  return encode(value);
-}
-
-function preserveTypesDecoder(value, decode) {
-  // numeric types are encoded like: 'n_123_n'
-  //eslint-disable-next-line
-  if (/n_[\d\.]*_n/.test(value)) {
-    const numericValueString = value.substring(2, value.length - 2);
-    return Number(numericValueString);
-  }
-  return decode(value);
-}
-
-function isNumeric(num) {
+function isNumericString(num) {
   return !isNaN(num);
 }
 
@@ -33,7 +14,7 @@ function toSingleValueInteger(num) {
 }
 
 function toInteger(num) {
-  if (!isNumeric(num)) return;
+  if (!isNumericString(num)) return;
   return parseInt(num, 10);
 }
 
@@ -103,9 +84,7 @@ function stateToParams({
 }
 
 function stateToQueryString(state) {
-  return queryString.stringify(stateToParams(state), {
-    encoder: preserveTypesEncoder
-  });
+  return queryString.stringify(stateToParams(state));
 }
 
 /**
@@ -133,12 +112,7 @@ export default class URLManager {
   }
 
   getStateFromURL() {
-    return paramsToState(
-      queryString.parse(this.history.location.search, {
-        ignoreQueryPrefix: true,
-        decoder: preserveTypesDecoder
-      })
-    );
+    return paramsToState(queryString.parse(this.history.location.search));
   }
 
   pushStateToURL(state) {
@@ -159,14 +133,7 @@ export default class URLManager {
       // it so that we don't break back / forward button.
       this.lastPushSearchString = "";
 
-      callback(
-        paramsToState(
-          queryString.parse(location.search, {
-            ignoreQueryPrefix: true,
-            decoder: preserveTypesDecoder
-          })
-        )
-      );
+      callback(paramsToState(queryString.parse(location.search)));
     });
   }
 }

--- a/packages/search-ui/src/__tests__/URLManager.test.js
+++ b/packages/search-ui/src/__tests__/URLManager.test.js
@@ -28,7 +28,7 @@ const basicParameterState = {
 };
 
 const basicParameterStateAsUrl =
-  "?fv-dependencies=underscore&fv-dependencies=another&fv-keywords=node&q=node&size=20&sort-direction=asc&sort-field=name";
+  "?filters[0][dependencies][0]=underscore&filters[0][dependencies][1]=another&filters[1][keywords][0]=node&q=node&size=20&sort-direction=asc&sort-field=name";
 
 const parameterStateWithRangeFilters = {
   filters: [
@@ -65,7 +65,7 @@ describe("#getStateFromURL", () => {
   it("will parse the current state from the URL", () => {
     const manager = createManager();
     manager.history.location.search =
-      "?fv-dependencies=underscore&fv-keywords=node&q=node&size=20&sort-direction=asc&sort-field=name";
+      "?filters%5B0%5D%5Bdependencies%5D%5B0%5D=underscore&filters%5B1%5D%5Bkeywords%5D%5B0%5D=node&q=node&size=20&sort-direction=asc&sort-field=name";
 
     const state = manager.getStateFromURL();
     expect(state).toMatchSnapshot();
@@ -74,7 +74,7 @@ describe("#getStateFromURL", () => {
   it("will parse range filter types", () => {
     const manager = createManager();
     manager.history.location.search =
-      "?fr-date=12_4000&fr-date=_4000&fr-cost=50_&fv-keywords=node";
+      "?filters[0][date][0][from]=12&filters[0][date][0][to]=4000&filters[0][date][1][to]=4000&filters[1][cost][0][from]=50&filters[2][keywords][0]=node";
 
     const state = manager.getStateFromURL();
     expect(state).toMatchSnapshot();
@@ -92,7 +92,7 @@ describe("#getStateFromURL", () => {
   it("will correctly handle multiple instances of the same parameter", () => {
     const manager = createManager();
     manager.history.location.search =
-      "fv-dependencies=underscore&fv-dependencies=another&fv-keywords=node&q=bad&q=node&size=bad&size=20&sort-direction=bad&sort-direction=asc&sort-field=bad&sort-field=name";
+      "filters[0][dependencies][0]=underscore&filters[0][dependencies][1]=another&filters[1][keywords][0]=node&q=bad&q=node&size=bad&size=20&sort-direction=bad&sort-direction=asc&sort-field=bad&sort-field=name";
 
     const state = manager.getStateFromURL();
     expect(state).toMatchSnapshot();
@@ -105,7 +105,7 @@ describe("#pushStateToURL", () => {
     manager.pushStateToURL(basicParameterState);
     const queryString = manager.history.push.mock.calls[0][0].search;
     expect(queryString).toEqual(
-      "?fv-dependencies%5B0%5D=underscore&fv-dependencies%5B1%5D=another&fv-keywords%5B0%5D=node&q=node&size=20&sort-field=name&sort-direction=asc"
+      "?q=node&size=20&filters%5B0%5D%5Bdependencies%5D%5B0%5D=underscore&filters%5B0%5D%5Bdependencies%5D%5B1%5D=another&filters%5B1%5D%5Bkeywords%5D%5B0%5D=node&sort-field=name&sort-direction=asc"
     );
   });
 
@@ -115,7 +115,7 @@ describe("#pushStateToURL", () => {
       manager.pushStateToURL(parameterStateWithRangeFilters);
       const queryString = manager.history.push.mock.calls[0][0].search;
       expect(queryString).toEqual(
-        "?fr-date%5B0%5D=12_4000&fr-date%5B1%5D=_4000&fr-cost%5B0%5D=50_&fv-keywords=node"
+        "?filters%5B0%5D%5Bdate%5D%5B0%5D%5Bfrom%5D=12&filters%5B0%5D%5Bdate%5D%5B0%5D%5Bto%5D=4000&filters%5B0%5D%5Bdate%5D%5B1%5D%5Bto%5D=4000&filters%5B1%5D%5Bcost%5D%5B0%5D%5Bfrom%5D=50&filters%5B2%5D%5Bkeywords%5D=node"
       );
     });
   });

--- a/packages/search-ui/src/__tests__/URLManager.test.js
+++ b/packages/search-ui/src/__tests__/URLManager.test.js
@@ -74,7 +74,7 @@ describe("#getStateFromURL", () => {
   it("will parse range filter types", () => {
     const manager = createManager();
     manager.history.location.search =
-      "?filters[0][date][0][from]=12&filters[0][date][0][to]=4000&filters[0][date][1][to]=4000&filters[1][cost][0][from]=50&filters[2][keywords][0]=node";
+      "?filters[0][date][0][from]=n_12_n&filters[0][date][0][to]=n_4000_n&filters[0][date][1][to]=n_4000_n&filters[1][cost][0][from]=n_50_n&filters[2][keywords][0]=node";
 
     const state = manager.getStateFromURL();
     expect(state).toMatchSnapshot();
@@ -105,7 +105,7 @@ describe("#pushStateToURL", () => {
     manager.pushStateToURL(basicParameterState);
     const queryString = manager.history.push.mock.calls[0][0].search;
     expect(queryString).toEqual(
-      "?q=node&size=20&filters%5B0%5D%5Bdependencies%5D%5B0%5D=underscore&filters%5B0%5D%5Bdependencies%5D%5B1%5D=another&filters%5B1%5D%5Bkeywords%5D%5B0%5D=node&sort-field=name&sort-direction=asc"
+      "?q=node&size=n_20_n&filters%5B0%5D%5Bdependencies%5D%5B0%5D=underscore&filters%5B0%5D%5Bdependencies%5D%5B1%5D=another&filters%5B1%5D%5Bkeywords%5D%5B0%5D=node&sort-field=name&sort-direction=asc"
     );
   });
 
@@ -115,7 +115,7 @@ describe("#pushStateToURL", () => {
       manager.pushStateToURL(parameterStateWithRangeFilters);
       const queryString = manager.history.push.mock.calls[0][0].search;
       expect(queryString).toEqual(
-        "?filters%5B0%5D%5Bdate%5D%5B0%5D%5Bfrom%5D=12&filters%5B0%5D%5Bdate%5D%5B0%5D%5Bto%5D=4000&filters%5B0%5D%5Bdate%5D%5B1%5D%5Bto%5D=4000&filters%5B1%5D%5Bcost%5D%5B0%5D%5Bfrom%5D=50&filters%5B2%5D%5Bkeywords%5D=node"
+        "?filters%5B0%5D%5Bdate%5D%5B0%5D%5Bfrom%5D=n_12_n&filters%5B0%5D%5Bdate%5D%5B0%5D%5Bto%5D=n_4000_n&filters%5B0%5D%5Bdate%5D%5B1%5D%5Bto%5D=n_4000_n&filters%5B1%5D%5Bcost%5D%5B0%5D%5Bfrom%5D=n_50_n&filters%5B2%5D%5Bkeywords%5D=node"
       );
     });
   });

--- a/packages/search-ui/src/__tests__/URLManager.test.js
+++ b/packages/search-ui/src/__tests__/URLManager.test.js
@@ -105,17 +105,19 @@ describe("#pushStateToURL", () => {
     manager.pushStateToURL(basicParameterState);
     const queryString = manager.history.push.mock.calls[0][0].search;
     expect(queryString).toEqual(
-      "?fv-dependencies=underscore&fv-dependencies=another&fv-keywords=node&q=node&size=20&sort-field=name&sort-direction=asc"
+      "?fv-dependencies%5B0%5D=underscore&fv-dependencies%5B1%5D=another&fv-keywords%5B0%5D=node&q=node&size=20&sort-field=name&sort-direction=asc"
     );
   });
 
-  it("will update the url with range filter types", () => {
-    const manager = createManager();
-    manager.pushStateToURL(parameterStateWithRangeFilters);
-    const queryString = manager.history.push.mock.calls[0][0].search;
-    expect(queryString).toEqual(
-      "?fr-date=12_4000&fr-date=_4000&fr-cost=50_&fv-keywords=node"
-    );
+  describe("filters", () => {
+    it("will update the url with range filter types", () => {
+      const manager = createManager();
+      manager.pushStateToURL(parameterStateWithRangeFilters);
+      const queryString = manager.history.push.mock.calls[0][0].search;
+      expect(queryString).toEqual(
+        "?fr-date%5B0%5D=12_4000&fr-date%5B1%5D=_4000&fr-cost%5B0%5D=50_&fv-keywords=node"
+      );
+    });
   });
 });
 

--- a/packages/search-ui/src/__tests__/preserveTypesEncoder.test.js
+++ b/packages/search-ui/src/__tests__/preserveTypesEncoder.test.js
@@ -1,0 +1,99 @@
+import preserveTypesEncoder from "../preserveTypesEncoder";
+
+describe("#decode", () => {
+  function subject(value) {
+    return preserveTypesEncoder.decode(
+      value,
+      () => "value from default decoder"
+    );
+  }
+
+  it("Will unpad an Integer value", () => {
+    const value = "n_1_n";
+    expect(subject(value)).toEqual(1);
+  });
+
+  it("Will unpad a float value", () => {
+    const value = "n_1.1_n";
+    expect(subject(value)).toEqual(1.1);
+  });
+
+  it("Will unpad a more difficult float value", () => {
+    const value = "n_0.6000000000000001_n";
+    expect(subject(value)).toEqual(0.6000000000000001);
+  });
+
+  it("Will unpad a true boolean value", () => {
+    const value = "b_true_b";
+    expect(subject(value)).toEqual(true);
+  });
+
+  it("Will unpad a false boolean value", () => {
+    const value = "b_false_b";
+    expect(subject(value)).toEqual(false);
+  });
+
+  it("Will defer to default decoder for String values that match inner, but not exactly", () => {
+    const value = "mob_true_bad";
+    expect(subject(value)).toEqual("value from default decoder");
+  });
+
+  it("Will defer to default decoder for String values that match beginning, but not exactly on end", () => {
+    const value = "b_true_bad";
+    expect(subject(value)).toEqual("value from default decoder");
+  });
+
+  it("Will defer to default decoder for String values that match end, but not exactly on beginning", () => {
+    const value = "mob_true_b";
+    expect(subject(value)).toEqual("value from default decoder");
+  });
+
+  it("Will defer to default decoder for String values that look like booleans", () => {
+    const value = "true";
+    expect(subject(value)).toEqual("value from default decoder");
+  });
+
+  it("Will defer to default decoder for String values", () => {
+    const value = "1";
+    expect(subject(value)).toEqual("value from default decoder");
+  });
+});
+
+describe("#encode", () => {
+  function subject(value) {
+    return preserveTypesEncoder.encode(
+      value,
+      () => "value from default encoder"
+    );
+  }
+
+  it("Will pad an Integer value", () => {
+    const value = 1;
+    expect(subject(value)).toEqual("n_1_n");
+  });
+
+  it("Will pad a float value", () => {
+    const value = 1.1;
+    expect(subject(value)).toEqual("n_1.1_n");
+  });
+
+  it("Will pad a more difficult float value", () => {
+    const value = 0.6000000000000001;
+    expect(subject(value)).toEqual("n_0.6000000000000001_n");
+  });
+
+  it("Will pad a boolean value", () => {
+    const value = true;
+    expect(subject(value)).toEqual("b_true_b");
+  });
+
+  it("Will defer to default encoder for String values that look like booleans", () => {
+    const value = "true";
+    expect(subject(value)).toEqual("value from default encoder");
+  });
+
+  it("Will defer to default encoder for String values", () => {
+    const value = "1";
+    expect(subject(value)).toEqual("value from default encoder");
+  });
+});

--- a/packages/search-ui/src/__tests__/queryString.test.js
+++ b/packages/search-ui/src/__tests__/queryString.test.js
@@ -1,0 +1,53 @@
+import queryString from "../queryString";
+
+const parsed = {
+  integer: 1,
+  float: 1.1,
+  bigFloat: 0.6000000000000001,
+  booleanTrue: true,
+  booleanFalse: true,
+  booleanString: "true",
+  integerString: "1",
+  object: {
+    integer: 1,
+    float: 1.1,
+    bigFloat: 0.6000000000000001,
+    booleanTrue: true,
+    booleanFalse: true,
+    booleanString: "true",
+    integerString: "1"
+  },
+  array: [
+    {
+      nestedArray: [
+        {
+          integer: 1,
+          float: 1.1
+        }
+      ]
+    }
+  ]
+};
+
+const stringified =
+  "integer=n_1_n&float=n_1.1_n&bigFloat=n_0.6000000000000001_n&booleanTrue=b_true_b&booleanFalse=b_true_b&booleanString=true&integerString=1&object%5Binteger%5D=n_1_n&object%5Bfloat%5D=n_1.1_n&object%5BbigFloat%5D=n_0.6000000000000001_n&object%5BbooleanTrue%5D=b_true_b&object%5BbooleanFalse%5D=b_true_b&object%5BbooleanString%5D=true&object%5BintegerString%5D=1&array%5B0%5D%5BnestedArray%5D%5B0%5D%5Binteger%5D=n_1_n&array%5B0%5D%5BnestedArray%5D%5B0%5D%5Bfloat%5D=n_1.1_n";
+
+describe("#parse", () => {
+  function subject(value) {
+    return queryString.parse(value);
+  }
+
+  it("will stringify parse an object correctly", () => {
+    expect(subject(stringified)).toEqual(parsed);
+  });
+});
+
+describe("#stringify", () => {
+  function subject(value) {
+    return queryString.stringify(value);
+  }
+
+  it("will stringify an object correctly", () => {
+    expect(subject(parsed)).toEqual(stringified);
+  });
+});

--- a/packages/search-ui/src/__tests__/queryString.test.js
+++ b/packages/search-ui/src/__tests__/queryString.test.js
@@ -32,13 +32,62 @@ const parsed = {
 const stringified =
   "integer=n_1_n&float=n_1.1_n&bigFloat=n_0.6000000000000001_n&booleanTrue=b_true_b&booleanFalse=b_true_b&booleanString=true&integerString=1&object%5Binteger%5D=n_1_n&object%5Bfloat%5D=n_1.1_n&object%5BbigFloat%5D=n_0.6000000000000001_n&object%5BbooleanTrue%5D=b_true_b&object%5BbooleanFalse%5D=b_true_b&object%5BbooleanString%5D=true&object%5BintegerString%5D=1&array%5B0%5D%5BnestedArray%5D%5B0%5D%5Binteger%5D=n_1_n&array%5B0%5D%5BnestedArray%5D%5B0%5D%5Bfloat%5D=n_1.1_n";
 
+const appSearchFiltersParsed = {
+  filters: {
+    all: [
+      // Range with type Number
+      {
+        visitors: {
+          from: 1,
+          to: 100
+        }
+      },
+      // Range with type Date
+      {
+        date_established: {
+          from: "1900-01-01T12:00:00+00:00",
+          to: "1950-01-01T00:00:00+00:00"
+        }
+      },
+      // Geo with type Geolocation
+      {
+        location: {
+          center: "37.386483, -122.083842",
+          distance: 300,
+          unit: "km"
+        }
+      },
+      // Value with type Text
+      { world_heritage_site: "true" },
+      // Value with type Date
+      { created_date: "1900-01-01T12:00:00+00:00" },
+      // Value with Type Number
+      { visitors: 100 },
+      // Combining with "all"
+      { category: "fun" },
+      { category: "healthy" },
+      // Nested "or"s
+      { category: ["gradeA", "gradeB"] }
+    ]
+  }
+};
+
+const appSearchFiltersStringified =
+  "filters%5Ball%5D%5B0%5D%5Bvisitors%5D%5Bfrom%5D=n_1_n&filters%5Ball%5D%5B0%5D%5Bvisitors%5D%5Bto%5D=n_100_n&filters%5Ball%5D%5B1%5D%5Bdate_established%5D%5Bfrom%5D=1900-01-01T12%3A00%3A00%2B00%3A00&filters%5Ball%5D%5B1%5D%5Bdate_established%5D%5Bto%5D=1950-01-01T00%3A00%3A00%2B00%3A00&filters%5Ball%5D%5B2%5D%5Blocation%5D%5Bcenter%5D=37.386483%2C%20-122.083842&filters%5Ball%5D%5B2%5D%5Blocation%5D%5Bdistance%5D=n_300_n&filters%5Ball%5D%5B2%5D%5Blocation%5D%5Bunit%5D=km&filters%5Ball%5D%5B3%5D%5Bworld_heritage_site%5D=true&filters%5Ball%5D%5B4%5D%5Bcreated_date%5D=1900-01-01T12%3A00%3A00%2B00%3A00&filters%5Ball%5D%5B5%5D%5Bvisitors%5D=n_100_n&filters%5Ball%5D%5B6%5D%5Bcategory%5D=fun&filters%5Ball%5D%5B7%5D%5Bcategory%5D=healthy&filters%5Ball%5D%5B8%5D%5Bcategory%5D%5B0%5D=gradeA&filters%5Ball%5D%5B8%5D%5Bcategory%5D%5B1%5D=gradeB";
+
 describe("#parse", () => {
   function subject(value) {
     return queryString.parse(value);
   }
 
-  it("will stringify parse an object correctly", () => {
+  it("will parse an object correctly", () => {
     expect(subject(stringified)).toEqual(parsed);
+  });
+
+  it("will parse an app search filters object correctly", () => {
+    expect(subject(appSearchFiltersStringified)).toEqual(
+      appSearchFiltersParsed
+    );
   });
 });
 
@@ -49,5 +98,11 @@ describe("#stringify", () => {
 
   it("will stringify an object correctly", () => {
     expect(subject(parsed)).toEqual(stringified);
+  });
+
+  it("will stringify app search filters object correctly", () => {
+    expect(subject(appSearchFiltersParsed)).toEqual(
+      appSearchFiltersStringified
+    );
   });
 });

--- a/packages/search-ui/src/preserveTypesEncoder.js
+++ b/packages/search-ui/src/preserveTypesEncoder.js
@@ -1,0 +1,40 @@
+function isTypeNumber(value) {
+  return value && typeof value === "number";
+}
+
+function isTypeBoolean(value) {
+  return value && typeof value === "boolean";
+}
+
+function toBoolean(value) {
+  if (value === "true") return true;
+  if (value === "false") return false;
+  throw "Invalid type parsed as Boolean value";
+}
+
+/* Encoder for qs library which preserve number types on the URL. Numbers
+are padded with "n_{number}_n", and booleans with "b_{boolean}_b"*/
+
+export default {
+  encode(value, encode) {
+    if (isTypeNumber(value)) {
+      return `n_${value}_n`;
+    }
+    if (isTypeBoolean(value)) {
+      return `b_${value}_b`;
+    }
+    return encode(value);
+  },
+  decode(value, decode) {
+    //eslint-disable-next-line
+    if (/n_[\d\.]*_n/.test(value)) {
+      const numericValueString = value.substring(2, value.length - 2);
+      return Number(numericValueString);
+    }
+    if (/^b_(true|false)*_b$/.test(value)) {
+      const booleanValueString = value.substring(2, value.length - 2);
+      return toBoolean(booleanValueString);
+    }
+    return decode(value);
+  }
+};

--- a/packages/search-ui/src/queryString.js
+++ b/packages/search-ui/src/queryString.js
@@ -1,0 +1,16 @@
+import queryString from "qs";
+import preserveTypesEncoder from "./preserveTypesEncoder";
+
+export default {
+  parse(string) {
+    return queryString.parse(string, {
+      ignoreQueryPrefix: true,
+      decoder: preserveTypesEncoder.decode
+    });
+  },
+  stringify(object) {
+    return queryString.stringify(object, {
+      encoder: preserveTypesEncoder.encode
+    });
+  }
+};


### PR DESCRIPTION
Fixes #42 #44 

The URL scheme I had for filters was insufficient. It needs to be able to handle the following scenarios:

```
{
  “all”: [{
     // Range with type Number
     {"visitors": {
        "from": 1,
        "to": 100
     }},
     // Range with type Date
     {"date_established": {
       "from": "1900-01-01T12:00:00+00:00",
       "to": "1950-01-01T00:00:00+00:00"
     }},
     // Geo with type Geolocation
     {"location": {
       "center": "37.386483, -122.083842",
       "distance": 300,
       "unit": "km"
     }},
     // Value with type Text
     {"world_heritage_site": "true"},
     // Value with type Date
     {“created_date”: "1900-01-01T12:00:00+00:00"},
     // Value with Type Number
     {“visitors”: 100},
     // Combining with "all"
     {“category”: ”fun”},
     {“category”: ”healthy”}
     // Nested "or"s
     {“category”: [”gradeA”, “gradeB”]} 
  }],
  // Combining with "any"
  “or”: { … },
  // Combining with "none"
   “none”: { … },
}
```

So, the query string need to be aware of the value type of filters, the Filter type, and OR vs AND vs NONE filters. Rather than coming up with some complicated schema for this in the query string, I chose to simply serialize the entire object using the [qs](https://github.com/ljharb/qs) library.

The only thing the qs library DOESN'T support is maintaining type. Meaning, if you serialize the Integer 1 to the query string, when deserialized it is serialized to the String "1".

To work around that, I added a custom encoder and decoder to simply maintain type by padding Number and Boolean values with "n_{value}_n" and "b_{value}_b" respectively.

For example, if I were to convert the object above using this new serializer, it would look like this:

```
filters[all][0][visitors][from]=n_1_n&filters[all][0][visitors][to]=n_100_n&filters[all][1][date_established][from]=1900-01-01T12%3A00%3A00%2B00%3A00&filters[all][1][date_established][to]=1950-01-01T00%3A00%3A00%2B00%3A00&filters[all][2][location][center]=37.386483%2C -122.083842&filters[all][2][location][distance]=n_300_n&filters[all][2][location][unit]=km&filters[all][3][world_heritage_site]=true&filters[all][4][created_date]=1900-01-01T12%3A00%3A00%2B00%3A00&filters[all][5][visitors]=n_100_n&filters[all][6][category]=fun&filters[all][7][category]=healthy&filters[all][8][category][0]=gradeA&filters[all][8][category][1]=gradeB
```

Note that while this DOES fix the issue with numeric value filters mentioned in #42, this does not fix existing issues in Search UI with Geo, Date Range, OR, and NONE filters. However, it does make the query string flexible enough to handle any of those use cases in the future.

![latest](https://user-images.githubusercontent.com/1427475/51624387-b6e26300-1f08-11e9-9b5b-e1516f1f8a34.gif)

