### PR TITLE
Fixed this error: "ReferenceError: regeneratorRuntime is not defined"

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ npx lerna version 0.2.1 --no-push
 
 git push --tags
 
-## Go through PR approval and merge to master
+# Go through PR approval and rebase+merge to master. Do not create a merge commit, it will throw off the `lerna changed` command
 
 git checkout master
 git pull

--- a/examples/sandbox/package.json
+++ b/examples/sandbox/package.json
@@ -1,13 +1,13 @@
 {
   "name": "sandbox",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "private": true,
   "dependencies": {
-    "@elastic/react-search-ui": "^0.5.0",
-    "@elastic/react-search-ui-views": "^0.5.0",
-    "@elastic/search-ui": "^0.5.0",
-    "@elastic/search-ui-app-search-connector": "^0.5.0",
-    "@elastic/search-ui-site-search-connector": "^0.5.0",
+    "@elastic/react-search-ui": "^0.5.1",
+    "@elastic/react-search-ui-views": "^0.5.1",
+    "@elastic/search-ui": "^0.5.1",
+    "@elastic/search-ui-app-search-connector": "^0.5.1",
+    "@elastic/search-ui-site-search-connector": "^0.5.1",
     "react": "^16.8.1",
     "react-dom": "^16.8.1",
     "react-scripts": "2.1.5"

--- a/lerna.json
+++ b/lerna.json
@@ -3,7 +3,7 @@
     "examples/*",
     "packages/*"
   ],
-  "version": "0.5.0",
+  "version": "0.5.1",
   "command": {
     "publish": {
       "ignoreChanges": [

--- a/packages/react-search-ui-views/CHANGELOG.md
+++ b/packages/react-search-ui-views/CHANGELOG.md
@@ -31,3 +31,7 @@ Breaking Changes:
   and `results`. If you were working directly with either of these types of data
   you will likely need to rework your solution. The data model can be seen
   here: https://github.com/elastic/search-ui/tree/8ddad47165d17c768a024a134059f215f9096365/packages/react-search-ui-views/src/types.
+
+## 0.5.1 (March 7, 2019)
+
+Fixed this error: "ReferenceError: regeneratorRuntime is not defined"

--- a/packages/react-search-ui-views/babel.config.js
+++ b/packages/react-search-ui-views/babel.config.js
@@ -2,7 +2,13 @@ const presets = [
   [
     "@babel/env",
     {
+      // Because we are using @babel/polyfill, because we have old browser
+      // targets set, this will optimize the polyfills that are actually
+      // imported.
+      useBuiltIns: "entry",
       targets: {
+        // Setting target browsers like this, if they span back far enough,
+        // requires adding @babel/polyfill
         browsers: ["last 2 versions", "> 5%"]
       },
       modules: process.env.BABEL_MODULES

--- a/packages/react-search-ui-views/package-lock.json
+++ b/packages/react-search-ui-views/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@elastic/react-search-ui-views",
-	"version": "0.4.0",
+	"version": "0.5.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -937,6 +937,15 @@
 				"@babel/helper-plugin-utils": "^7.0.0",
 				"@babel/helper-regex": "^7.0.0",
 				"regexpu-core": "^4.1.3"
+			}
+		},
+		"@babel/polyfill": {
+			"version": "7.2.5",
+			"resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.2.5.tgz",
+			"integrity": "sha512-8Y/t3MWThtMLYr0YNC/Q76tqN1w30+b0uQMeFUYauG2UGTR19zyUtFrAzT23zNtBxPp+LbE5E/nwV/q/r3y6ug==",
+			"requires": {
+				"core-js": "^2.5.7",
+				"regenerator-runtime": "^0.12.0"
 			}
 		},
 		"@babel/preset-env": {

--- a/packages/react-search-ui-views/package.json
+++ b/packages/react-search-ui-views/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elastic/react-search-ui-views",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "A collection of React UI components for building search experiences",
   "license": "Apache-2.0",
   "main": "lib",

--- a/packages/react-search-ui-views/package.json
+++ b/packages/react-search-ui-views/package.json
@@ -68,6 +68,7 @@
     "rimraf": "^2.6.2"
   },
   "dependencies": {
+    "@babel/polyfill": "^7.2.5",
     "autoprefixer": "^9.4.7",
     "deep-equal": "^1.0.1",
     "rc-pagination": "^1.17.3",

--- a/packages/react-search-ui-views/src/index.js
+++ b/packages/react-search-ui-views/src/index.js
@@ -1,3 +1,5 @@
+import "@babel/polyfill";
+
 export { default as ErrorBoundary } from "./ErrorBoundary";
 export { default as Facets } from "./Facets";
 export { default as MultiCheckboxFacet } from "./MultiCheckboxFacet";

--- a/packages/react-search-ui/CHANGELOG.md
+++ b/packages/react-search-ui/CHANGELOG.md
@@ -27,3 +27,7 @@ Breaking Changes:
   and `results`. If you were working directly with any of these types of state
   you will likely need to rework your solution. The data model can be seen
   here: https://github.com/elastic/search-ui/tree/8ddad47165d17c768a024a134059f215f9096365/packages/react-search-ui/src/types.
+
+## 0.5.1 (March 7, 2019)
+
+Fixed this error: "ReferenceError: regeneratorRuntime is not defined"

--- a/packages/react-search-ui/babel.config.js
+++ b/packages/react-search-ui/babel.config.js
@@ -2,7 +2,13 @@ const presets = [
   [
     "@babel/env",
     {
+      // Because we are using @babel/polyfill, because we have old browser
+      // targets set, this will optimize the polyfills that are actually
+      // imported.
+      useBuiltIns: "entry",
       targets: {
+        // Setting target browsers like this, if they span back far enough,
+        // requires adding @babel/polyfill
         browsers: ["last 2 versions", "> 5%"]
       },
       modules: process.env.BABEL_MODULES

--- a/packages/react-search-ui/package-lock.json
+++ b/packages/react-search-ui/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@elastic/react-search-ui",
-	"version": "0.4.0",
+	"version": "0.5.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -105,6 +105,15 @@
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
 				"@babel/plugin-syntax-jsx": "^7.0.0"
+			}
+		},
+		"@babel/polyfill": {
+			"version": "7.2.5",
+			"resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.2.5.tgz",
+			"integrity": "sha512-8Y/t3MWThtMLYr0YNC/Q76tqN1w30+b0uQMeFUYauG2UGTR19zyUtFrAzT23zNtBxPp+LbE5E/nwV/q/r3y6ug==",
+			"requires": {
+				"core-js": "^2.5.7",
+				"regenerator-runtime": "^0.12.0"
 			}
 		},
 		"@babel/preset-react": {
@@ -1070,8 +1079,7 @@
 		"core-js": {
 			"version": "2.5.7",
 			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
-			"integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw==",
-			"dev": true
+			"integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw=="
 		},
 		"core-util-is": {
 			"version": "1.0.2",
@@ -5359,6 +5367,11 @@
 			"requires": {
 				"util.promisify": "^1.0.0"
 			}
+		},
+		"regenerator-runtime": {
+			"version": "0.12.1",
+			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
+			"integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg=="
 		},
 		"regex-cache": {
 			"version": "0.4.4",

--- a/packages/react-search-ui/package.json
+++ b/packages/react-search-ui/package.json
@@ -31,6 +31,7 @@
     "url": "https://github.com/elastic/search-ui/issues"
   },
   "dependencies": {
+    "@babel/polyfill": "^7.2.5",
     "@elastic/react-search-ui-views": "^0.5.0",
     "@elastic/search-ui": "^0.5.0",
     "debounce-fn": "^1.0.0"

--- a/packages/react-search-ui/package.json
+++ b/packages/react-search-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elastic/react-search-ui",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "A React library for building search experiences",
   "license": "Apache-2.0",
   "main": "lib",
@@ -32,8 +32,8 @@
   },
   "dependencies": {
     "@babel/polyfill": "^7.2.5",
-    "@elastic/react-search-ui-views": "^0.5.0",
-    "@elastic/search-ui": "^0.5.0",
+    "@elastic/react-search-ui-views": "^0.5.1",
+    "@elastic/search-ui": "^0.5.1",
     "debounce-fn": "^1.0.0"
   },
   "peerDependencies": {

--- a/packages/search-ui-app-search-connector/CHANGELOG.md
+++ b/packages/search-ui-app-search-connector/CHANGELOG.md
@@ -17,3 +17,7 @@ Breaking Changes:
   created a custom connector, you will need to rework your solution. More details
   on this are documented in the "Creating your own Connector" section of
   the README.
+
+## 0.5.1 (March 7, 2019)
+
+Fixed this error: "ReferenceError: regeneratorRuntime is not defined"

--- a/packages/search-ui-app-search-connector/babel.config.js
+++ b/packages/search-ui-app-search-connector/babel.config.js
@@ -2,7 +2,13 @@ const presets = [
   [
     "@babel/env",
     {
+      // Because we are using @babel/polyfill, because we have old browser
+      // targets set, this will optimize the polyfills that are actually
+      // imported.
+      useBuiltIns: "entry",
       targets: {
+        // Setting target browsers like this, if they span back far enough,
+        // requires adding @babel/polyfill
         browsers: ["last 2 versions", "> 5%"]
       },
       modules: process.env.BABEL_MODULES

--- a/packages/search-ui-app-search-connector/package-lock.json
+++ b/packages/search-ui-app-search-connector/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@elastic/search-ui-app-search-connector",
-	"version": "0.4.0",
+	"version": "0.5.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -40,6 +40,15 @@
 				"chalk": "^2.0.0",
 				"esutils": "^2.0.2",
 				"js-tokens": "^4.0.0"
+			}
+		},
+		"@babel/polyfill": {
+			"version": "7.2.5",
+			"resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.2.5.tgz",
+			"integrity": "sha512-8Y/t3MWThtMLYr0YNC/Q76tqN1w30+b0uQMeFUYauG2UGTR19zyUtFrAzT23zNtBxPp+LbE5E/nwV/q/r3y6ug==",
+			"requires": {
+				"core-js": "^2.5.7",
+				"regenerator-runtime": "^0.12.0"
 			}
 		},
 		"abab": {
@@ -927,8 +936,7 @@
 		"core-js": {
 			"version": "2.5.7",
 			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
-			"integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw==",
-			"dev": true
+			"integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw=="
 		},
 		"core-util-is": {
 			"version": "1.0.2",
@@ -4830,6 +4838,11 @@
 			"requires": {
 				"util.promisify": "^1.0.0"
 			}
+		},
+		"regenerator-runtime": {
+			"version": "0.12.1",
+			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
+			"integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg=="
 		},
 		"regex-cache": {
 			"version": "0.4.4",

--- a/packages/search-ui-app-search-connector/package.json
+++ b/packages/search-ui-app-search-connector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elastic/search-ui-app-search-connector",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "A Search UI connector for Elastic's App Search Service",
   "license": "Apache-2.0",
   "main": "lib",

--- a/packages/search-ui-app-search-connector/package.json
+++ b/packages/search-ui-app-search-connector/package.json
@@ -37,6 +37,7 @@
     "rimraf": "^2.6.2"
   },
   "dependencies": {
+    "@babel/polyfill": "^7.2.5",
     "swiftype-app-search-javascript": "^2.2.0"
   }
 }

--- a/packages/search-ui-app-search-connector/src/index.js
+++ b/packages/search-ui-app-search-connector/src/index.js
@@ -1,1 +1,3 @@
+import "@babel/polyfill";
+
 export { default } from "./AppSearchAPIConnector";

--- a/packages/search-ui-elasticsearch-connector/CHANGELOG.md
+++ b/packages/search-ui-elasticsearch-connector/CHANGELOG.md
@@ -11,3 +11,7 @@
 - #114
 
 As of version 0.5.0 this connector is no longer compatible with Search UI.
+
+## 0.5.1 (March 7, 2019)
+
+Fixed this error: "ReferenceError: regeneratorRuntime is not defined"

--- a/packages/search-ui-elasticsearch-connector/babel.config.js
+++ b/packages/search-ui-elasticsearch-connector/babel.config.js
@@ -2,7 +2,13 @@ const presets = [
   [
     "@babel/env",
     {
+      // Because we are using @babel/polyfill, because we have old browser
+      // targets set, this will optimize the polyfills that are actually
+      // imported.
+      useBuiltIns: "entry",
       targets: {
+        // Setting target browsers like this, if they span back far enough,
+        // requires adding @babel/polyfill
         browsers: ["last 2 versions", "> 5%"]
       },
       modules: process.env.BABEL_MODULES

--- a/packages/search-ui-elasticsearch-connector/package-lock.json
+++ b/packages/search-ui-elasticsearch-connector/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@elastic/search-ui-elasticsearch-connector",
-	"version": "0.4.0",
+	"version": "0.5.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -40,6 +40,15 @@
 				"chalk": "^2.0.0",
 				"esutils": "^2.0.2",
 				"js-tokens": "^4.0.0"
+			}
+		},
+		"@babel/polyfill": {
+			"version": "7.2.5",
+			"resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.2.5.tgz",
+			"integrity": "sha512-8Y/t3MWThtMLYr0YNC/Q76tqN1w30+b0uQMeFUYauG2UGTR19zyUtFrAzT23zNtBxPp+LbE5E/nwV/q/r3y6ug==",
+			"requires": {
+				"core-js": "^2.5.7",
+				"regenerator-runtime": "^0.12.0"
 			}
 		},
 		"abab": {
@@ -934,8 +943,7 @@
 		"core-js": {
 			"version": "2.5.7",
 			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
-			"integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw==",
-			"dev": true
+			"integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw=="
 		},
 		"core-util-is": {
 			"version": "1.0.2",
@@ -4878,6 +4886,11 @@
 			"requires": {
 				"util.promisify": "^1.0.0"
 			}
+		},
+		"regenerator-runtime": {
+			"version": "0.12.1",
+			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
+			"integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg=="
 		},
 		"regex-cache": {
 			"version": "0.4.4",

--- a/packages/search-ui-elasticsearch-connector/package.json
+++ b/packages/search-ui-elasticsearch-connector/package.json
@@ -37,6 +37,7 @@
     "rimraf": "^2.6.2"
   },
   "dependencies": {
+    "@babel/polyfill": "^7.2.5",
     "elasticsearch": "^15.2.0"
   }
 }

--- a/packages/search-ui-elasticsearch-connector/package.json
+++ b/packages/search-ui-elasticsearch-connector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elastic/search-ui-elasticsearch-connector",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "A Search UI connector for elasticsearch",
   "license": "Apache-2.0",
   "main": "lib",

--- a/packages/search-ui-elasticsearch-connector/src/index.js
+++ b/packages/search-ui-elasticsearch-connector/src/index.js
@@ -1,1 +1,3 @@
+import "@babel/polyfill";
+
 export { default } from "./ElasticsearchAPIConnector";

--- a/packages/search-ui-site-search-connector/CHANGELOG.md
+++ b/packages/search-ui-site-search-connector/CHANGELOG.md
@@ -17,3 +17,7 @@ Breaking Changes:
   created a custom connector, you will need to rework your solution. More details
   on this are documented in the "Creating your own Connector" section of
   the README.
+
+## 0.5.1 (March 7, 2019)
+
+Fixed this error: "ReferenceError: regeneratorRuntime is not defined"

--- a/packages/search-ui-site-search-connector/babel.config.js
+++ b/packages/search-ui-site-search-connector/babel.config.js
@@ -2,7 +2,13 @@ const presets = [
   [
     "@babel/env",
     {
+      // Because we are using @babel/polyfill, because we have old browser
+      // targets set, this will optimize the polyfills that are actually
+      // imported.
+      useBuiltIns: "entry",
       targets: {
+        // Setting target browsers like this, if they span back far enough,
+        // requires adding @babel/polyfill
         browsers: ["last 2 versions", "> 5%"]
       },
       modules: process.env.BABEL_MODULES

--- a/packages/search-ui-site-search-connector/package-lock.json
+++ b/packages/search-ui-site-search-connector/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@elastic/search-ui-site-search-connector",
-	"version": "0.4.0",
+	"version": "0.5.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -40,6 +40,15 @@
 				"chalk": "^2.0.0",
 				"esutils": "^2.0.2",
 				"js-tokens": "^4.0.0"
+			}
+		},
+		"@babel/polyfill": {
+			"version": "7.2.5",
+			"resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.2.5.tgz",
+			"integrity": "sha512-8Y/t3MWThtMLYr0YNC/Q76tqN1w30+b0uQMeFUYauG2UGTR19zyUtFrAzT23zNtBxPp+LbE5E/nwV/q/r3y6ug==",
+			"requires": {
+				"core-js": "^2.5.7",
+				"regenerator-runtime": "^0.12.0"
 			}
 		},
 		"abab": {
@@ -927,8 +936,7 @@
 		"core-js": {
 			"version": "2.5.7",
 			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
-			"integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw==",
-			"dev": true
+			"integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw=="
 		},
 		"core-util-is": {
 			"version": "1.0.2",
@@ -4825,6 +4833,11 @@
 			"requires": {
 				"util.promisify": "^1.0.0"
 			}
+		},
+		"regenerator-runtime": {
+			"version": "0.12.1",
+			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
+			"integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg=="
 		},
 		"regex-cache": {
 			"version": "0.4.4",

--- a/packages/search-ui-site-search-connector/package.json
+++ b/packages/search-ui-site-search-connector/package.json
@@ -35,5 +35,8 @@
     "jest": "^23.6.0",
     "npm-run-all": "^4.1.5",
     "rimraf": "^2.6.2"
+  },
+  "dependencies": {
+    "@babel/polyfill": "^7.2.5"
   }
 }

--- a/packages/search-ui-site-search-connector/package.json
+++ b/packages/search-ui-site-search-connector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elastic/search-ui-site-search-connector",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "A Search UI connector for Elastic's Site Search Service",
   "license": "Apache-2.0",
   "main": "lib",

--- a/packages/search-ui-site-search-connector/src/index.js
+++ b/packages/search-ui-site-search-connector/src/index.js
@@ -1,1 +1,3 @@
+import "@babel/polyfill";
+
 export { default } from "./SiteSearchAPIConnector";

--- a/packages/search-ui/CHANGELOG.md
+++ b/packages/search-ui/CHANGELOG.md
@@ -35,3 +35,7 @@ Breaking Changes:
   created a custom connector, you will need to rework your solution. More details
   on this are documented in the "Creating your own Connector" section of
   the README.
+
+## 0.5.1 (March 7, 2019)
+
+Fixed this error: "ReferenceError: regeneratorRuntime is not defined"

--- a/packages/search-ui/babel.config.js
+++ b/packages/search-ui/babel.config.js
@@ -2,7 +2,13 @@ const presets = [
   [
     "@babel/env",
     {
+      // Because we are using @babel/polyfill, because we have old browser
+      // targets set, this will optimize the polyfills that are actually
+      // imported.
+      useBuiltIns: "entry",
       targets: {
+        // Setting target browsers like this, if they span back far enough,
+        // requires adding @babel/polyfill
         browsers: ["last 2 versions", "> 5%"]
       },
       modules: process.env.BABEL_MODULES

--- a/packages/search-ui/package-lock.json
+++ b/packages/search-ui/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@elastic/search-ui",
-	"version": "0.4.0",
+	"version": "0.5.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -40,6 +40,15 @@
 				"chalk": "^2.0.0",
 				"esutils": "^2.0.2",
 				"js-tokens": "^4.0.0"
+			}
+		},
+		"@babel/polyfill": {
+			"version": "7.2.5",
+			"resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.2.5.tgz",
+			"integrity": "sha512-8Y/t3MWThtMLYr0YNC/Q76tqN1w30+b0uQMeFUYauG2UGTR19zyUtFrAzT23zNtBxPp+LbE5E/nwV/q/r3y6ug==",
+			"requires": {
+				"core-js": "^2.5.7",
+				"regenerator-runtime": "^0.12.0"
 			}
 		},
 		"abab": {
@@ -935,8 +944,7 @@
 		"core-js": {
 			"version": "2.5.7",
 			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
-			"integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw==",
-			"dev": true
+			"integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw=="
 		},
 		"core-util-is": {
 			"version": "1.0.2",
@@ -4873,6 +4881,11 @@
 			"requires": {
 				"util.promisify": "^1.0.0"
 			}
+		},
+		"regenerator-runtime": {
+			"version": "0.12.1",
+			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
+			"integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg=="
 		},
 		"regex-cache": {
 			"version": "0.4.4",

--- a/packages/search-ui/package.json
+++ b/packages/search-ui/package.json
@@ -37,6 +37,7 @@
     "rimraf": "^2.6.2"
   },
   "dependencies": {
+    "@babel/polyfill": "^7.2.5",
     "date-fns": "^1.29.0",
     "debounce-fn": "^1.0.0",
     "deep-equal": "^1.0.1",

--- a/packages/search-ui/package.json
+++ b/packages/search-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elastic/search-ui",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "A Headless Search UI library",
   "license": "Apache-2.0",
   "main": "lib",

--- a/packages/search-ui/src/index.js
+++ b/packages/search-ui/src/index.js
@@ -1,1 +1,3 @@
+import "@babel/polyfill";
+
 export { default as SearchDriver } from "./SearchDriver";


### PR DESCRIPTION
When using @babel/preset-env to target old browser versions, it's
necessary to also include `@babel/polyfill`. I included that as a
dependency and set "useBuiltins" to "entry" which instructs
Preset to NOT include all of @babel/polyfill's polyfills, instead, only
the ones which are actually required by the target browsers.

Basically, the line "import "@babel/polyfill";" get transpiled to
individual "import xyz from "core-js" statements.

"core-js" is the underlying library that contains the polyfills.
