### PR TITLE
 Consolidated search config into "searchQuery"

### DIFF
--- a/examples/sandbox/src/App.js
+++ b/examples/sandbox/src/App.js
@@ -26,41 +26,43 @@ export default function App() {
   return (
     <SearchProvider
       config={{
-        apiConnector: connector,
-        search_fields: {
-          title: {},
-          description: {}
-        },
-        result_fields: {
-          title: {
-            snippet: {
-              size: 100,
-              fallback: true
+        searchQuery: {
+          search_fields: {
+            title: {},
+            description: {}
+          },
+          result_fields: {
+            title: {
+              snippet: {
+                size: 100,
+                fallback: true
+              }
+            },
+            nps_link: {
+              raw: {}
+            },
+            description: {
+              snippet: {
+                size: 100,
+                fallback: true
+              }
             }
           },
-          nps_link: {
-            raw: {}
-          },
-          description: {
-            snippet: {
-              size: 100,
-              fallback: true
+          disjunctiveFacets: ["acres"],
+          facets: {
+            states: { type: "value", size: 30 },
+            acres: {
+              type: "range",
+              ranges: [
+                { from: -1, name: "Any" },
+                { from: 0, to: 1000, name: "Small" },
+                { from: 1001, to: 100000, name: "Medium" },
+                { from: 100001, name: "Large" }
+              ]
             }
           }
         },
-        disjunctiveFacets: ["acres"],
-        facets: {
-          states: { type: "value", size: 30 },
-          acres: {
-            type: "range",
-            ranges: [
-              { from: -1, name: "Any" },
-              { from: 0, to: 1000, name: "Small" },
-              { from: 1001, to: 100000, name: "Medium" },
-              { from: 100001, name: "Large" }
-            ]
-          }
-        }
+        apiConnector: connector
       }}
     >
       {_ => (

--- a/packages/search-ui-app-search-connector/src/responseAdapter.js
+++ b/packages/search-ui-app-search-connector/src/responseAdapter.js
@@ -52,7 +52,13 @@ export function adaptResponse(response) {
   return {
     ...(facets && { facets: adaptFacets(facets) }),
     requestId,
-    results: response.rawResults,
+    results: response.rawResults.map(r => {
+      // eslint-disable-next-line
+      const { _meta, ...rest } = r;
+      return {
+        ...rest
+      };
+    }),
     ...(totalPages !== undefined && { totalPages }),
     ...(totalResults !== undefined && { totalResults })
   };

--- a/packages/search-ui/src/SearchDriver.js
+++ b/packages/search-ui/src/SearchDriver.js
@@ -72,13 +72,8 @@ export default class SearchDriver {
 
   constructor({
     apiConnector,
-    conditionalFacets,
-    disjunctiveFacets,
-    disjunctiveFacetsAnalyticsTags,
-    facets,
     initialState,
-    result_fields,
-    search_fields,
+    searchQuery = {},
     trackUrlState = true,
     urlPushDebounceLength = 500
   }) {
@@ -100,12 +95,7 @@ export default class SearchDriver {
     this.requestSequencer = new RequestSequencer();
     this.debounceManager = new DebounceManager();
     this.apiConnector = apiConnector;
-    this.conditionalFacets = conditionalFacets;
-    this.disjunctiveFacets = disjunctiveFacets;
-    this.disjunctiveFacetsAnalyticsTags = disjunctiveFacetsAnalyticsTags;
-    this.facets = facets;
-    this.result_fields = result_fields;
-    this.search_fields = search_fields;
+    this.searchQuery = searchQuery;
     this.subscriptions = [];
     this.trackUrlState = trackUrlState;
     this.urlPushDebounceLength = urlPushDebounceLength;
@@ -189,15 +179,12 @@ export default class SearchDriver {
     const requestId = this.requestSequencer.next();
 
     const queryConfig = {
-      disjunctiveFacets: this.disjunctiveFacets,
-      disjunctiveFacetsAnalyticsTags: this.disjunctiveFacetsAnalyticsTags,
+      ...this.searchQuery,
       facets: removeConditionalFacets(
-        this.facets,
-        this.conditionalFacets,
+        this.searchQuery.facets,
+        this.searchQuery.conditionalFacets,
         filters
-      ),
-      result_fields: this.result_fields,
-      search_fields: this.search_fields
+      )
     };
 
     const requestState = filterSearchParameters(this.state);

--- a/packages/search-ui/src/__tests__/SearchDriver.test.js
+++ b/packages/search-ui/src/__tests__/SearchDriver.test.js
@@ -113,94 +113,113 @@ it("will not sync initial state to the URL if trackURLState is set to false", ()
   expect(URLManager.mock.instances).toHaveLength(0);
 });
 
-describe("conditional facets", () => {
-  function subject(conditional) {
-    const driver = new SearchDriver({
-      ...params,
-      initialState: {
-        filters: [{ field: "initial", values: ["value"], type: "all" }],
-        searchTerm: "test"
-      },
-      facets: {
+describe("searchQuery config", () => {
+  describe("conditional facets", () => {
+    function subject(conditional) {
+      const driver = new SearchDriver({
+        ...params,
+        initialState: {
+          filters: [{ field: "initial", values: ["value"], type: "all" }],
+          searchTerm: "test"
+        },
+        searchQuery: {
+          facets: {
+            initial: {
+              type: "value"
+            }
+          },
+          conditionalFacets: {
+            initial: conditional
+          }
+        }
+      });
+
+      driver.setSearchTerm("test");
+    }
+
+    it("will fetch a conditional facet that passes its check", () => {
+      subject(filters => !!filters);
+
+      // 'initial' WAS included in request to server
+      expect(getSearchCalls()[1][1].facets).toEqual({
         initial: {
           type: "value"
         }
-      },
-      conditionalFacets: {
-        initial: conditional
-      }
+      });
     });
 
-    driver.setSearchTerm("test");
-  }
+    it("will not fetch a conditional facet that fails its check", () => {
+      subject(filters => !filters);
 
-  it("will fetch a conditional facet that passes its check", () => {
-    subject(filters => !!filters);
-
-    // 'initial' WAS included in request to server
-    expect(getSearchCalls()[1][1].facets).toEqual({
-      initial: {
-        type: "value"
-      }
+      // 'initial' was NOT included in request to server
+      expect(getSearchCalls()[1][1].facets).toEqual({});
     });
   });
 
-  it("will not fetch a conditional facet that fails its check", () => {
-    subject(filters => !filters);
-
-    // 'initial' was NOT included in request to server
-    expect(getSearchCalls()[1][1].facets).toEqual({});
-  });
-});
-
-// disjunctiveFacetsAnalyticsTags
-describe("pass through values", () => {
-  function subject({
-    disjunctiveFacets,
-    disjunctiveFacetsAnalyticsTags,
-    result_fields,
-    search_fields
-  }) {
-    const driver = new SearchDriver({
-      ...params,
-      facets: {
-        initial: {
-          type: "value"
-        }
-      },
+  describe("pass through values", () => {
+    function subject({
       disjunctiveFacets,
       disjunctiveFacetsAnalyticsTags,
       result_fields,
       search_fields
+    }) {
+      const driver = new SearchDriver({
+        ...params,
+        searchQuery: {
+          facets: {
+            initial: {
+              type: "value"
+            }
+          },
+          disjunctiveFacets,
+          disjunctiveFacetsAnalyticsTags,
+          result_fields,
+          search_fields
+        }
+      });
+
+      driver.setSearchTerm("test");
+    }
+
+    it("will pass through facet configuration", () => {
+      const facets = {
+        initial: {
+          type: "value"
+        }
+      };
+      subject({ facets });
+      expect(getSearchCalls()[0][1].facets).toEqual({
+        initial: {
+          type: "value"
+        }
+      });
     });
 
-    driver.setSearchTerm("test");
-  }
+    it("will pass through disjunctive facet configuration", () => {
+      const disjunctiveFacets = ["initial"];
+      subject({ disjunctiveFacets });
+      expect(getSearchCalls()[0][1].disjunctiveFacets).toEqual(["initial"]);
+    });
 
-  it("will pass through disjunctive facet configuration", () => {
-    const disjunctiveFacets = ["initial"];
-    subject({ disjunctiveFacets });
-    expect(getSearchCalls()[0][1].disjunctiveFacets).toEqual(["initial"]);
-  });
+    it("will pass through disjunctive facet analytics tags", () => {
+      const disjunctiveFacetsAnalyticsTags = ["Test"];
+      subject({ disjunctiveFacetsAnalyticsTags });
+      expect(getSearchCalls()[0][1].disjunctiveFacetsAnalyticsTags).toEqual([
+        "Test"
+      ]);
+    });
 
-  it("will pass through disjunctive facet analytics tags", () => {
-    const disjunctiveFacetsAnalyticsTags = ["Test"];
-    subject({ disjunctiveFacetsAnalyticsTags });
-    expect(getSearchCalls()[0][1].disjunctiveFacetsAnalyticsTags).toEqual([
-      "Test"
-    ]);
-  });
+    it("will pass through result_fields configuration", () => {
+      const result_fields = { test: {} };
+      subject({ result_fields });
+      expect(getSearchCalls()[0][1].result_fields).toEqual(result_fields);
+    });
 
-  it("will pass through result_fields configuration", () => {
-    const result_fields = { test: {} };
-    subject({ result_fields });
-    expect(getSearchCalls()[0][1].result_fields).toEqual(result_fields);
-  });
-
-  it("will pass through search_fields configuration", () => {
-    const search_fields = { test: {} };
-    subject({ search_fields });
-    expect(getSearchCalls()[0][1].search_fields).toEqual(search_fields);
+    it("will pass through search_fields configuration", () => {
+      const search_fields = { test: {} };
+      subject({ search_fields });
+      expect(getSearchCalls()[0][1].search_fields).toEqual(search_fields);
+    });
   });
 });
 


### PR DESCRIPTION
This keeps query related configuration in one place. In the future
we'll be adding to adjust autocompleteQuery and suggestQuery as
well.

There's a lot of whitespace in this PR, I mainly just nested some configuration options under a "searchQuery" property.