### PR TITLE
Added autocomplete results to state

### DIFF
--- a/examples/sandbox/src/App.js
+++ b/examples/sandbox/src/App.js
@@ -69,7 +69,7 @@ export default function App() {
         <div className="App">
           <ErrorBoundary>
             <Layout
-              header={<SearchBox />}
+              header={<SearchBox autocompleteResults={true} />}
               sideContent={
                 <div>
                   <Sorting

--- a/packages/react-search-ui/src/containers/SearchBox.js
+++ b/packages/react-search-ui/src/containers/SearchBox.js
@@ -7,6 +7,7 @@ import { withSearch } from "..";
 export class SearchBoxContainer extends Component {
   static propTypes = {
     // Props
+    autocompleteResults: PropTypes.bool,
     debounceLength: PropTypes.number,
     inputProps: PropTypes.object,
     searchAsYouType: PropTypes.bool,
@@ -41,15 +42,21 @@ export class SearchBoxContainer extends Component {
   };
 
   handleChange = value => {
-    const { searchAsYouType, setSearchTerm, debounceLength } = this.props;
-    const options = searchAsYouType
-      ? {
-          refresh: true,
-          debounce: debounceLength || 200
-        }
-      : {
-          refresh: false
-        };
+    const {
+      autocompleteResults,
+      searchAsYouType,
+      setSearchTerm,
+      debounceLength
+    } = this.props;
+
+    const options = {
+      ...((autocompleteResults || searchAsYouType) && {
+        debounce: debounceLength || 200
+      }),
+      refresh: !!searchAsYouType,
+      autocompleteResults: !!autocompleteResults
+    };
+
     setSearchTerm(value, options);
   };
 

--- a/packages/react-search-ui/src/containers/__tests__/SearchBox.test.js
+++ b/packages/react-search-ui/src/containers/__tests__/SearchBox.test.js
@@ -57,7 +57,10 @@ it("will call back to setSearchTerm with refresh: false when input is changed", 
   });
 
   const call = params.setSearchTerm.mock.calls[0];
-  expect(call).toEqual(["new term", { refresh: false }]);
+  expect(call).toEqual([
+    "new term",
+    { refresh: false, autocompleteResults: false }
+  ]);
 });
 
 it("will call back to setSearchTerm with refresh: true when input is changed and searchAsYouType is true", () => {
@@ -74,7 +77,10 @@ it("will call back to setSearchTerm with refresh: true when input is changed and
   });
 
   const call = params.setSearchTerm.mock.calls[0];
-  expect(call).toEqual(["new term", { refresh: true, debounce: 200 }]);
+  expect(call).toEqual([
+    "new term",
+    { refresh: true, debounce: 200, autocompleteResults: false }
+  ]);
 });
 
 it("will call back to setSearchTerm with a specific debounce when input is changed and searchAsYouType is true and a debounce is provided", () => {
@@ -95,7 +101,34 @@ it("will call back to setSearchTerm with a specific debounce when input is chang
   });
 
   const call = params.setSearchTerm.mock.calls[0];
-  expect(call).toEqual(["new term", { refresh: true, debounce: 500 }]);
+  expect(call).toEqual([
+    "new term",
+    { refresh: true, debounce: 500, autocompleteResults: false }
+  ]);
+});
+
+it("will call back to setSearchTerm with a specific debounce when input is changed and autocompleteResults is true and a debounce is provided", () => {
+  const wrapper = shallow(
+    <SearchBoxContainer
+      {...params}
+      autocompleteResults={true}
+      debounceLength={500}
+    />
+  );
+
+  expect(wrapper.find("SearchBox").prop("value")).toBe("test");
+
+  wrapper.find("SearchBox").prop("onChange")({
+    currentTarget: {
+      value: "new term"
+    }
+  });
+
+  const call = params.setSearchTerm.mock.calls[0];
+  expect(call).toEqual([
+    "new term",
+    { refresh: false, debounce: 500, autocompleteResults: true }
+  ]);
 });
 
 it("will call back setSearchTerm with refresh: true when form is submitted", () => {

--- a/packages/search-ui-app-search-connector/src/AppSearchAPIConnector.js
+++ b/packages/search-ui-app-search-connector/src/AppSearchAPIConnector.js
@@ -50,4 +50,16 @@ export default class AppSearchAPIConnector {
     const response = await this.client.search(query, options);
     return adaptResponse(response);
   }
+
+  async autocompleteResults({ searchTerm }, queryConfig) {
+    const { query, ...optionsFromState } = adaptRequest({ searchTerm });
+    const withQueryConfigOptions = { ...queryConfig, ...optionsFromState };
+    const options = {
+      ...withQueryConfigOptions,
+      ...this.additionalOptions(withQueryConfigOptions)
+    };
+
+    const response = await this.client.search(query, options);
+    return adaptResponse(response);
+  }
 }

--- a/packages/search-ui-app-search-connector/src/__tests__/AppSearchAPIConnector.test.js
+++ b/packages/search-ui-app-search-connector/src/__tests__/AppSearchAPIConnector.test.js
@@ -110,4 +110,22 @@ describe("AppSearchAPIConnector", () => {
       });
     });
   });
+
+  describe("autocompleteResults", () => {
+    function subject(state = {}, additionalOptions) {
+      if (!state.searchTerm) state.searchTerm = "searchTerm";
+
+      const connector = new AppSearchAPIConnector({
+        ...params,
+        additionalOptions
+      });
+
+      return connector.autocompleteResults(state);
+    }
+
+    it("will return updated search state", async () => {
+      const state = await subject();
+      expect(state).toEqual(resultState);
+    });
+  });
 });

--- a/packages/search-ui/src/SearchDriver.js
+++ b/packages/search-ui/src/SearchDriver.js
@@ -33,6 +33,7 @@ export const DEFAULT_STATE = {
   sortField: "",
   // Result State -- This state represents state that is updated automatically
   // as the result of changing input state.
+  autocompletedResults: [],
   error: "",
   isLoading: false,
   facets: {},
@@ -146,6 +147,21 @@ export default class SearchDriver {
     }
   }
 
+  _updateAutocompleteResults = searchTerm => {
+    const requestId = this.requestSequencer.next();
+
+    return this.apiConnector
+      .autocompleteResults({ searchTerm }, {})
+      .then(autocompletedResults => {
+        if (this.requestSequencer.isOldRequest(requestId)) return;
+        this.requestSequencer.completed(requestId);
+
+        this._setState({
+          autocompletedResults: autocompletedResults.results
+        });
+      });
+  };
+
   _updateSearchResults = (
     searchParameters,
     { skipPushToUrl = false, ignoreIsLoadingCheck = false } = {}
@@ -220,7 +236,6 @@ export default class SearchDriver {
         }
       },
       error => {
-        console.error(error);
         this._setState({
           error: `An unexpected error occurred: ${error.message}`
         });

--- a/packages/search-ui/src/actions/setSearchTerm.js
+++ b/packages/search-ui/src/actions/setSearchTerm.js
@@ -5,12 +5,13 @@
  *
  * @param searchTerm String
  * @param options Object Additional objects
+ * @param options.autocompleteResults Fetch autocomplete results?
  * @param options.refresh Boolean Refresh search results?
- * @param options.wait Boolean Refresh search results?
+ * @param options.debounce Length to debounce API calls
  */
 export default function setSearchTerm(
   searchTerm,
-  { refresh = true, debounce = 0 } = {}
+  { autocompleteResults = false, refresh = true, debounce = 0 } = {}
 ) {
   this._setState({ searchTerm });
 
@@ -23,6 +24,14 @@ export default function setSearchTerm(
         filters: []
       },
       { ignoreIsLoadingCheck: true }
+    );
+  }
+
+  if (autocompleteResults) {
+    this.debounceManager.runWithDebounce(
+      debounce,
+      this._updateAutocompleteResults,
+      searchTerm
     );
   }
 }

--- a/packages/search-ui/src/test/helpers.js
+++ b/packages/search-ui/src/test/helpers.js
@@ -10,6 +10,9 @@ const searchResponse = {
 
 export function getMockApiConnector() {
   return {
+    autocompleteResults: jest
+      .fn()
+      .mockReturnValue({ then: cb => cb(searchResponse) }),
     search: jest.fn().mockReturnValue({ then: cb => cb(searchResponse) }),
     click: jest.fn().mockReturnValue({ then: () => {} })
   };


### PR DESCRIPTION
https://github.com/elastic/search-ui/issues/105

- Added an option to `SearchBox` called `autocompleteResults`.
- Added a flag to `setSearchTerm` called `autocompleteResults`.
- Added a new connector method called `autocompleteResults`.
- Added a new state property called `autocompletedResults` (Note the "d").

When the `autocompelteResults` flag is true, a new API request will be invoked to fetch results for and populate `autocompletedResults`.

So basically, if you fire up the sandbox application and start typing, since the `autocompleteResults` flag is set to `true`, you will see API requests being fired off, and the results will actually be populated in state.

This makes them available for us to build a view to consume them, which will be added in a future PR.

![latest](https://user-images.githubusercontent.com/1427475/54057704-ac7ede80-41c1-11e9-8ad5-4130e30a6273.gif)

