### PR TITLE
SearchBox to Downshift + autocomplete

### DIFF
--- a/packages/react-search-ui-views/package-lock.json
+++ b/packages/react-search-ui-views/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@elastic/react-search-ui-views",
-	"version": "0.5.0",
+	"version": "0.5.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -4205,6 +4205,11 @@
 			"integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
 			"dev": true
 		},
+		"compute-scroll-into-view": {
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-1.0.11.tgz",
+			"integrity": "sha512-uUnglJowSe0IPmWOdDtrlHXof5CTIJitfJEyITHBW6zDVOGu9Pjk5puaLM73SLcwak0L4hEjO7Td88/a6P5i7A=="
+		},
 		"concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -4961,6 +4966,17 @@
 			"dev": true,
 			"requires": {
 				"dotenv": "^5.0.1"
+			}
+		},
+		"downshift": {
+			"version": "3.2.7",
+			"resolved": "https://registry.npmjs.org/downshift/-/downshift-3.2.7.tgz",
+			"integrity": "sha512-mbUO9ZFhMGtksIeVWRFFjNOPN237VsUqZSEYi0VS0Wj38XNLzpgOBTUcUjdjFeB8KVgmrcRa6GGFkTbACpG6FA==",
+			"requires": {
+				"@babel/runtime": "^7.1.2",
+				"compute-scroll-into-view": "^1.0.9",
+				"prop-types": "^15.6.0",
+				"react-is": "^16.5.2"
 			}
 		},
 		"duplexer": {
@@ -11567,8 +11583,7 @@
 		"react-is": {
 			"version": "16.6.0",
 			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.6.0.tgz",
-			"integrity": "sha512-q8U7k0Fi7oxF1HvQgyBjPwDXeMplEsArnKt2iYhuIF86+GBbgLHdAmokL3XUFjTd7Q363OSNG55FOGUdONVn1g==",
-			"dev": true
+			"integrity": "sha512-q8U7k0Fi7oxF1HvQgyBjPwDXeMplEsArnKt2iYhuIF86+GBbgLHdAmokL3XUFjTd7Q363OSNG55FOGUdONVn1g=="
 		},
 		"react-lifecycles-compat": {
 			"version": "3.0.4",

--- a/packages/react-search-ui-views/package.json
+++ b/packages/react-search-ui-views/package.json
@@ -71,6 +71,7 @@
     "@babel/polyfill": "^7.2.5",
     "autoprefixer": "^9.4.7",
     "deep-equal": "^1.0.1",
+    "downshift": "^3.2.7",
     "rc-pagination": "^1.17.3",
     "react-select": "^2.1.1"
   }

--- a/packages/react-search-ui-views/src/SearchBox.js
+++ b/packages/react-search-ui-views/src/SearchBox.js
@@ -1,25 +1,113 @@
 import PropTypes from "prop-types";
 import React from "react";
+import Downshift from "downshift";
 
 function SearchBox(props) {
-  const { isFocused, inputProps, onChange, onSubmit, value } = props;
+  const {
+    autocomplete,
+    autocompleteItems = [],
+    isFocused,
+    inputProps,
+    onChange,
+    onSelectAutocomplete,
+    onSubmit,
+    value
+  } = props;
   const focusedClass = isFocused ? "focus" : "";
 
+  // TODO Remove inline styles
   return (
-    <form className="sui-search-box" onSubmit={onSubmit}>
-      <input
-        className={`sui-search-box__text-input ${focusedClass}`}
-        onChange={onChange}
-        type="text"
-        value={value}
-        placeholder="Search your documents&#8230;"
-        {...inputProps}
-      />
-      <input
-        type="submit"
-        value="Search"
-        className="button sui-search-box__submit"
-      />
+    <form onSubmit={onSubmit}>
+      <Downshift
+        inputValue={value}
+        onChange={onSelectAutocomplete}
+        onInputValueChange={onChange}
+        itemToString={item => (item ? item.value : "")}
+      >
+        {({
+          getInputProps,
+          getItemProps,
+          getMenuProps,
+          isOpen,
+          highlightedIndex,
+          selectedItem
+        }) => {
+          let index = 0;
+          return (
+            <div
+              className="sui-search-box"
+              style={{ position: "relative", overflow: "visible" }}
+            >
+              <input
+                {...getInputProps({
+                  placeholder: "Search your documents",
+                  ...inputProps,
+                  className: `sui-search-box__text-input ${focusedClass}`
+                })}
+              />
+              <ul
+                {...getMenuProps({
+                  style: {
+                    position: "absolute",
+                    top: "100%",
+                    width: "100%"
+                  }
+                })}
+              >
+                {autocomplete && isOpen
+                  ? autocompleteItems.map((section, i) => {
+                      return (
+                        <div key={i}>
+                          {section.title && <div>{section.title}</div>}
+                          <ul>
+                            {section.items.map(item => {
+                              index++;
+                              return (
+                                // eslint-disable-next-line react/jsx-key
+                                <li
+                                  {...getItemProps({
+                                    key: item.id,
+                                    index: index - 1,
+                                    item,
+                                    style: {
+                                      backgroundColor:
+                                        highlightedIndex === index - 1
+                                          ? "lightgray"
+                                          : "white",
+                                      fontWeight:
+                                        selectedItem === item
+                                          ? "bold"
+                                          : "normal"
+                                    }
+                                  })}
+                                >
+                                  {item.snippet ? (
+                                    <span
+                                      dangerouslySetInnerHTML={{
+                                        __html: item.snippet
+                                      }}
+                                    />
+                                  ) : (
+                                    <span>{item.raw}</span>
+                                  )}
+                                </li>
+                              );
+                            })}
+                          </ul>
+                        </div>
+                      );
+                    })
+                  : null}
+              </ul>
+              <input
+                type="submit"
+                value="Search"
+                className="button sui-search-box__submit"
+              />
+            </div>
+          );
+        }}
+      </Downshift>
     </form>
   );
 }
@@ -28,6 +116,20 @@ SearchBox.propTypes = {
   onChange: PropTypes.func.isRequired,
   onSubmit: PropTypes.func.isRequired,
   value: PropTypes.string.isRequired,
+  autocomplete: PropTypes.bool,
+  autocompleteItems: PropTypes.arrayOf(
+    PropTypes.shape({
+      title: PropTypes.string,
+      items: PropTypes.arrayOf(
+        PropTypes.shape({
+          raw: PropTypes.string,
+          snippet: PropTypes.string,
+          value: PropTypes.any
+        })
+      )
+    })
+  ),
+  onSelectAutocomplete: PropTypes.func,
   inputProps: PropTypes.object,
   isFocused: PropTypes.bool
 };

--- a/packages/react-search-ui-views/src/__tests__/__snapshots__/SearchBox.test.js.snap
+++ b/packages/react-search-ui-views/src/__tests__/__snapshots__/SearchBox.test.js.snap
@@ -2,60 +2,81 @@
 
 exports[`passes through inputProps 1`] = `
 <form
-  className="sui-search-box"
   onSubmit={[Function]}
 >
-  <input
-    className="sui-search-box__text-input "
+  <Downshift
+    defaultHighlightedIndex={null}
+    defaultIsOpen={false}
+    environment={[Window]}
+    getA11yStatusMessage={[Function]}
+    inputValue="test"
+    itemToString={[Function]}
     onChange={[Function]}
-    placeholder="test"
-    type="text"
-    value="test"
-  />
-  <input
-    className="button sui-search-box__submit"
-    type="submit"
-    value="Search"
-  />
+    onInputValueChange={[Function]}
+    onOuterClick={[Function]}
+    onSelect={[Function]}
+    onStateChange={[Function]}
+    onUserAction={[Function]}
+    scrollIntoView={[Function]}
+    selectedItemChanged={[Function]}
+    stateReducer={[Function]}
+    suppressRefError={false}
+  >
+    <Component />
+  </Downshift>
 </form>
 `;
 
 exports[`renders correctly when \`isFocused\` is false 1`] = `
 <form
-  className="sui-search-box"
   onSubmit={[Function]}
 >
-  <input
-    className="sui-search-box__text-input "
+  <Downshift
+    defaultHighlightedIndex={null}
+    defaultIsOpen={false}
+    environment={[Window]}
+    getA11yStatusMessage={[Function]}
+    inputValue="test"
+    itemToString={[Function]}
     onChange={[Function]}
-    placeholder="Search your documents…"
-    type="text"
-    value="test"
-  />
-  <input
-    className="button sui-search-box__submit"
-    type="submit"
-    value="Search"
-  />
+    onInputValueChange={[Function]}
+    onOuterClick={[Function]}
+    onSelect={[Function]}
+    onStateChange={[Function]}
+    onUserAction={[Function]}
+    scrollIntoView={[Function]}
+    selectedItemChanged={[Function]}
+    stateReducer={[Function]}
+    suppressRefError={false}
+  >
+    <Component />
+  </Downshift>
 </form>
 `;
 
 exports[`renders correctly when \`isFocused\` is true 1`] = `
 <form
-  className="sui-search-box"
   onSubmit={[Function]}
 >
-  <input
-    className="sui-search-box__text-input focus"
+  <Downshift
+    defaultHighlightedIndex={null}
+    defaultIsOpen={false}
+    environment={[Window]}
+    getA11yStatusMessage={[Function]}
+    inputValue="test"
+    itemToString={[Function]}
     onChange={[Function]}
-    placeholder="Search your documents…"
-    type="text"
-    value="test"
-  />
-  <input
-    className="button sui-search-box__submit"
-    type="submit"
-    value="Search"
-  />
+    onInputValueChange={[Function]}
+    onOuterClick={[Function]}
+    onSelect={[Function]}
+    onStateChange={[Function]}
+    onUserAction={[Function]}
+    scrollIntoView={[Function]}
+    selectedItemChanged={[Function]}
+    stateReducer={[Function]}
+    suppressRefError={false}
+  >
+    <Component />
+  </Downshift>
 </form>
 `;

--- a/packages/react-search-ui-views/stories/SearchBox.stories.js
+++ b/packages/react-search-ui-views/stories/SearchBox.stories.js
@@ -10,15 +10,87 @@ const baseProps = {
   onSubmit: e => {
     e.preventDefault();
     action("submitted")();
-  }
+  },
+  value: ""
 };
 
+const autocompleteItems = [
+  {
+    title: "Results",
+    items: [
+      { id: "1", snippet: "<em>Bike</em> Cops", raw: "", value: "Bike Cops" },
+      { id: "2", snippet: "<em>Biker</em> Gang", raw: "", value: "Biker Gang" },
+      { id: "3", snippet: "<em>Biker</em> Bar", raw: "", value: "Biker Bar" },
+      {
+        id: "4",
+        snippet: "Best <em>bikes</em> of 2010",
+        raw: "",
+        value: "Best bikes of 2010"
+      },
+      {
+        id: "5",
+        snippet: "<em>Bike</em> seats and accessories",
+        raw: "",
+        value: "Bike seats and accessories"
+      }
+    ]
+  },
+  {
+    title: "Suggestions",
+    items: [
+      { id: "6", snippet: "", raw: "bike", value: "bike" },
+      { id: "7", snippet: "", raw: "bike police", value: "bike police" },
+      { id: "8", snippet: "", raw: "bike police go", value: "bike police go" },
+      { id: "9", snippet: "", raw: "fast bikes", value: "fast bikes" },
+      { id: "10", snippet: "", raw: "bike race", value: "bike race" }
+    ]
+  }
+];
+
+// This wrapper is here just to store "value" state somewhere, so
+// that when you type in the SearchBox, specifically for autocomplete,
+// something actually changes on the page.
+class Wrapper extends React.Component {
+  constructor() {
+    super();
+    this.state = {
+      value: ""
+    };
+  }
+
+  render() {
+    return (
+      <SearchBox
+        autocomplete={true}
+        autocompleteItems={autocompleteItems}
+        value={this.state.value}
+        onSelectAutocomplete={selection => {
+          action("selectAutocomplete")(selection);
+        }}
+        onSubmit={e => {
+          e.preventDefault();
+          action("submitted")();
+        }}
+        onChange={value => {
+          action("changed")();
+          this.setState({
+            value
+          });
+        }}
+        {...this.props}
+      />
+    );
+  }
+}
+
 storiesOf("SearchBox", module)
-  .add("no value", () => <SearchBox {...{ ...baseProps }} />)
-  .add("with value", () => <SearchBox {...{ value: "value", ...baseProps }} />)
-  .add("with focus", () => <SearchBox {...{ isFocused: true, ...baseProps }} />)
+  .add("no value", () => <SearchBox {...baseProps} />)
+  .add("with value", () => <SearchBox {...baseProps} value="value" />)
+  .add("with focus", () => <SearchBox {...baseProps} isFocused={true} />)
   .add("with inputProps", () => (
     <SearchBox
-      {...{ inputProps: { placeholder: "custom placeholder" }, ...baseProps }}
+      {...baseProps}
+      inputProps={{ placeholder: "custom placeholder" }}
     />
-  ));
+  ))
+  .add("with autocomplete", () => <Wrapper />);

--- a/packages/react-search-ui/src/containers/SearchBox.js
+++ b/packages/react-search-ui/src/containers/SearchBox.js
@@ -69,7 +69,7 @@ export class SearchBoxContainer extends Component {
     return (
       <View
         isFocused={isFocused}
-        onChange={e => this.handleChange(e.currentTarget.value)}
+        onChange={value => this.handleChange(value)}
         onSubmit={this.handleSubmit}
         value={searchTerm}
         inputProps={{

--- a/packages/react-search-ui/src/containers/__tests__/SearchBox.test.js
+++ b/packages/react-search-ui/src/containers/__tests__/SearchBox.test.js
@@ -50,11 +50,7 @@ it("will call back to setSearchTerm with refresh: false when input is changed", 
 
   expect(wrapper.find("SearchBox").prop("value")).toBe("test");
 
-  wrapper.find("SearchBox").prop("onChange")({
-    currentTarget: {
-      value: "new term"
-    }
-  });
+  wrapper.find("SearchBox").prop("onChange")("new term");
 
   const call = params.setSearchTerm.mock.calls[0];
   expect(call).toEqual([
@@ -70,11 +66,7 @@ it("will call back to setSearchTerm with refresh: true when input is changed and
 
   expect(wrapper.find("SearchBox").prop("value")).toBe("test");
 
-  wrapper.find("SearchBox").prop("onChange")({
-    currentTarget: {
-      value: "new term"
-    }
-  });
+  wrapper.find("SearchBox").prop("onChange")("new term");
 
   const call = params.setSearchTerm.mock.calls[0];
   expect(call).toEqual([
@@ -94,11 +86,7 @@ it("will call back to setSearchTerm with a specific debounce when input is chang
 
   expect(wrapper.find("SearchBox").prop("value")).toBe("test");
 
-  wrapper.find("SearchBox").prop("onChange")({
-    currentTarget: {
-      value: "new term"
-    }
-  });
+  wrapper.find("SearchBox").prop("onChange")("new term");
 
   const call = params.setSearchTerm.mock.calls[0];
   expect(call).toEqual([
@@ -118,11 +106,7 @@ it("will call back to setSearchTerm with a specific debounce when input is chang
 
   expect(wrapper.find("SearchBox").prop("value")).toBe("test");
 
-  wrapper.find("SearchBox").prop("onChange")({
-    currentTarget: {
-      value: "new term"
-    }
-  });
+  wrapper.find("SearchBox").prop("onChange")("new term");
 
   const call = params.setSearchTerm.mock.calls[0];
   expect(call).toEqual([


### PR DESCRIPTION
Downshift was added to enable autocomplete. I've added 3 new parameters
to the SearchBox view:

- autocomplete - Whether or not to show autocompletes
- autocompleteItems - Accepts array of "Sections", so that we can
have titles above various types of autocomplete, i.e, suggestions and
results
- onSelectAutocomplete - A callback to trigger when a selection
is made in the autocomplete.

![latest](https://user-images.githubusercontent.com/1427475/54227507-6df56680-44d6-11e9-9eeb-47196008d0f1.gif)

I'd like to merge this PR, then work on styling and building out the business logic concurrently in additional PRs.