### PR TITLE
Full Autocomplete support for Search Results

### DIFF
--- a/examples/sandbox/src/App.js
+++ b/examples/sandbox/src/App.js
@@ -72,6 +72,7 @@ export default function App() {
               header={
                 <SearchBox
                   autocompleteResults={{
+                    linkTarget: "_blank",
                     sectionTitle: "Results",
                     titleField: "title",
                     urlField: "nps_link"

--- a/examples/sandbox/src/App.js
+++ b/examples/sandbox/src/App.js
@@ -69,7 +69,15 @@ export default function App() {
         <div className="App">
           <ErrorBoundary>
             <Layout
-              header={<SearchBox autocompleteResults={true} />}
+              header={
+                <SearchBox
+                  autocompleteResults={{
+                    sectionTitle: "Results",
+                    titleField: "title",
+                    urlField: "nps_link"
+                  }}
+                />
+              }
               sideContent={
                 <div>
                   <Sorting

--- a/packages/react-search-ui-views/src/SearchBox.js
+++ b/packages/react-search-ui-views/src/SearchBox.js
@@ -5,6 +5,16 @@ import Downshift from "downshift";
 import { Result } from "./types";
 import { Suggestion } from "./types";
 
+function getRaw(result, value) {
+  if (!result[value] || !result[value].raw) return;
+  return result[value].raw;
+}
+
+function getSnippet(result, value) {
+  if (!result[value] || !result[value].snippet) return;
+  return result[value].snippet;
+}
+
 function SearchBox(props) {
   const {
     useAutocomplete,
@@ -24,9 +34,13 @@ function SearchBox(props) {
     props.onSelectAutocomplete ||
     (selection => {
       if (!selection.suggestion) {
-        const url = selection[autocompleteResults.urlField].raw;
-        const target = autocompleteResults.linkTarget || "_self";
-        window.open(url, target);
+        const url = selection[autocompleteResults.urlField]
+          ? selection[autocompleteResults.urlField].raw
+          : "";
+        if (url) {
+          const target = autocompleteResults.linkTarget || "_self";
+          window.open(url, target);
+        }
       }
     });
 
@@ -80,6 +94,14 @@ function SearchBox(props) {
                       <ul>
                         {autocompletedResults.map(result => {
                           index++;
+                          const titleSnippet = getSnippet(
+                            result,
+                            autocompleteResults.titleField
+                          );
+                          const titleRaw = getRaw(
+                            result,
+                            autocompleteResults.titleField
+                          );
                           return (
                             // eslint-disable-next-line react/jsx-key
                             <li
@@ -89,19 +111,14 @@ function SearchBox(props) {
                                 item: result
                               })}
                             >
-                              {result[autocompleteResults.titleField]
-                                .snippet ? (
+                              {titleSnippet ? (
                                 <span
                                   dangerouslySetInnerHTML={{
-                                    __html:
-                                      result[autocompleteResults.titleField]
-                                        .snippet
+                                    __html: titleSnippet
                                   }}
                                 />
                               ) : (
-                                <span>
-                                  {result[autocompleteResults.titleField].raw}
-                                </span>
+                                <span>{titleRaw}</span>
                               )}
                             </li>
                           );
@@ -174,12 +191,15 @@ SearchBox.propTypes = {
   onChange: PropTypes.func.isRequired,
   onSubmit: PropTypes.func.isRequired,
   value: PropTypes.string.isRequired,
-  autocompleteResults: PropTypes.shape({
-    titleField: PropTypes.string.isRequired,
-    urlField: PropTypes.string.isRequired,
-    linkTarget: PropTypes.string,
-    sectionTitle: PropTypes.string
-  }),
+  autocompleteResults: PropTypes.oneOfType([
+    PropTypes.bool,
+    PropTypes.shape({
+      titleField: PropTypes.string.isRequired,
+      urlField: PropTypes.string.isRequired,
+      linkTarget: PropTypes.string,
+      sectionTitle: PropTypes.string
+    })
+  ]),
   autocompletedResults: PropTypes.arrayOf(Result).isRequired,
   autocompleteSuggestions: PropTypes.objectOf(
     PropTypes.shape({

--- a/packages/react-search-ui-views/src/SearchBox.js
+++ b/packages/react-search-ui-views/src/SearchBox.js
@@ -12,7 +12,6 @@ function SearchBox(props) {
     autocompletedResults,
     autocompleteSuggestions,
     autocompletedSuggestions,
-    notifyAutocompleteResultClick,
     isFocused,
     inputProps,
     onChange,
@@ -21,23 +20,19 @@ function SearchBox(props) {
   } = props;
   const focusedClass = isFocused ? "focus" : "";
 
-  const onAutocompleteResultClick =
-    props.onAutocompleteResultClick ||
+  const onSelectAutocomplete =
+    props.onSelectAutocomplete ||
     (selection => {
-      const url = selection[autocompleteResults.urlField].raw;
-      window.open(url, "_blank");
+      if (!selection.suggestion) {
+        const url = selection[autocompleteResults.urlField].raw;
+        window.open(url, "_blank");
+      }
     });
 
   return (
     <Downshift
       inputValue={value}
-      onChange={selection => {
-        if (!selection.suggestion) {
-          // TODO This needs to be passed in.
-          notifyAutocompleteResultClick(selection);
-          onAutocompleteResultClick(selection);
-        }
-      }}
+      onChange={onSelectAutocomplete}
       onInputValueChange={onChange}
       stateReducer={(state, changes) => {
         return changes;
@@ -175,7 +170,6 @@ function SearchBox(props) {
 
 SearchBox.propTypes = {
   // Provided by container
-  notifyAutocompleteResultClick: PropTypes.func.isRequired,
   onChange: PropTypes.func.isRequired,
   onSubmit: PropTypes.func.isRequired,
   value: PropTypes.string.isRequired,
@@ -196,8 +190,7 @@ SearchBox.propTypes = {
   useAutocomplete: PropTypes.bool,
 
   // Specific configuration for this view only
-  // TODO
-  onAutocompleteResultClick: PropTypes.func
+  onSelectAutocomplete: PropTypes.func
 };
 
 export default SearchBox;

--- a/packages/react-search-ui-views/src/SearchBox.js
+++ b/packages/react-search-ui-views/src/SearchBox.js
@@ -22,25 +22,28 @@ function SearchBox(props) {
   const focusedClass = isFocused ? "focus" : "";
 
   return (
-    <form onSubmit={onSubmit}>
-      <Downshift
-        inputValue={value}
-        onChange={onSelectAutocomplete}
-        onInputValueChange={onChange}
-        itemToString={item =>
-          // TODO
-          item
-            ? item[autocompleteResults.titleField]
-              ? item[autocompleteResults.titleField].raw ||
-                item[autocompleteResults.titleField].snippet
-              : item.suggestion
-            : ""
-        }
-      >
-        {({ getInputProps, getItemProps, getMenuProps, isOpen }) => {
-          let index = 0;
-          let autocompleteClass = isOpen === true ? " autocomplete" : "";
-          return (
+    <Downshift
+      inputValue={value}
+      onChange={onSelectAutocomplete}
+      onInputValueChange={onChange}
+      stateReducer={(state, changes) => {
+        return changes;
+      }}
+      // Because when a selection is made, we don't really want to change
+      // the inputValue. This is supposed to be a "controlled" value, and when
+      // this happens we lose control of it.
+      itemToString={() => value}
+    >
+      {({ closeMenu, getInputProps, getItemProps, getMenuProps, isOpen }) => {
+        let index = 0;
+        let autocompleteClass = isOpen === true ? " autocomplete" : "";
+        return (
+          <form
+            onSubmit={e => {
+              closeMenu();
+              onSubmit(e);
+            }}
+          >
             <div className={"sui-search-box" + autocompleteClass}>
               <div className="sui-search-box__wrapper">
                 <input
@@ -147,10 +150,10 @@ function SearchBox(props) {
                 className="button sui-search-box__submit"
               />
             </div>
-          );
-        }}
-      </Downshift>
-    </form>
+          </form>
+        );
+      }}
+    </Downshift>
   );
 }
 

--- a/packages/react-search-ui-views/src/SearchBox.js
+++ b/packages/react-search-ui-views/src/SearchBox.js
@@ -12,19 +12,32 @@ function SearchBox(props) {
     autocompletedResults,
     autocompleteSuggestions,
     autocompletedSuggestions,
+    notifyAutocompleteResultClick,
     isFocused,
     inputProps,
     onChange,
-    onSelectAutocomplete,
     onSubmit,
     value
   } = props;
   const focusedClass = isFocused ? "focus" : "";
 
+  const onAutocompleteResultClick =
+    props.onAutocompleteResultClick ||
+    (selection => {
+      const url = selection[autocompleteResults.urlField].raw;
+      window.open(url, "_blank");
+    });
+
   return (
     <Downshift
       inputValue={value}
-      onChange={onSelectAutocomplete}
+      onChange={selection => {
+        if (!selection.suggestion) {
+          // TODO This needs to be passed in.
+          notifyAutocompleteResultClick(selection);
+          onAutocompleteResultClick(selection);
+        }
+      }}
       onInputValueChange={onChange}
       stateReducer={(state, changes) => {
         return changes;
@@ -53,12 +66,15 @@ function SearchBox(props) {
                     className: `sui-search-box__text-input ${focusedClass}`
                   })}
                 />
-                <div
-                  {...getMenuProps({
-                    className: "sui-search-box__autocomplete-container"
-                  })}
-                >
-                  {useAutocomplete && isOpen ? (
+                {useAutocomplete &&
+                isOpen &&
+                (autocompletedResults.length > 0 ||
+                  Object.entries(autocompletedSuggestions).length > 0) ? (
+                  <div
+                    {...getMenuProps({
+                      className: "sui-search-box__autocomplete-container"
+                    })}
+                  >
                     <div>
                       {autocompleteResults.sectionTitle && (
                         <div className="sui-search-box__section-title">
@@ -141,8 +157,8 @@ function SearchBox(props) {
                         }
                       )}
                     </div>
-                  ) : null}
-                </div>
+                  </div>
+                ) : null}
               </div>
               <input
                 type="submit"
@@ -158,10 +174,11 @@ function SearchBox(props) {
 }
 
 SearchBox.propTypes = {
+  // Provided by container
+  notifyAutocompleteResultClick: PropTypes.func.isRequired,
   onChange: PropTypes.func.isRequired,
   onSubmit: PropTypes.func.isRequired,
   value: PropTypes.string.isRequired,
-  useAutocomplete: PropTypes.bool,
   autocompleteResults: PropTypes.shape({
     titleField: PropTypes.string.isRequired,
     urlField: PropTypes.string.isRequired,
@@ -174,9 +191,13 @@ SearchBox.propTypes = {
     })
   ),
   autocompletedSuggestions: PropTypes.objectOf(Suggestion).isRequired,
-  onSelectAutocomplete: PropTypes.func,
   inputProps: PropTypes.object,
-  isFocused: PropTypes.bool
+  isFocused: PropTypes.bool,
+  useAutocomplete: PropTypes.bool,
+
+  // Specific configuration for this view only
+  // TODO
+  onAutocompleteResultClick: PropTypes.func
 };
 
 export default SearchBox;

--- a/packages/react-search-ui-views/src/SearchBox.js
+++ b/packages/react-search-ui-views/src/SearchBox.js
@@ -25,7 +25,8 @@ function SearchBox(props) {
     (selection => {
       if (!selection.suggestion) {
         const url = selection[autocompleteResults.urlField].raw;
-        window.open(url, "_blank");
+        const target = autocompleteResults.linkTarget || "_self";
+        window.open(url, target);
       }
     });
 
@@ -176,6 +177,7 @@ SearchBox.propTypes = {
   autocompleteResults: PropTypes.shape({
     titleField: PropTypes.string.isRequired,
     urlField: PropTypes.string.isRequired,
+    linkTarget: PropTypes.string,
     sectionTitle: PropTypes.string
   }),
   autocompletedResults: PropTypes.arrayOf(Result).isRequired,

--- a/packages/react-search-ui-views/src/SearchBox.js
+++ b/packages/react-search-ui-views/src/SearchBox.js
@@ -49,9 +49,6 @@ function SearchBox(props) {
       inputValue={value}
       onChange={onSelectAutocomplete}
       onInputValueChange={onChange}
-      stateReducer={(state, changes) => {
-        return changes;
-      }}
       // Because when a selection is made, we don't really want to change
       // the inputValue. This is supposed to be a "controlled" value, and when
       // this happens we lose control of it.

--- a/packages/react-search-ui-views/src/__tests__/SearchBox.test.js
+++ b/packages/react-search-ui-views/src/__tests__/SearchBox.test.js
@@ -5,6 +5,8 @@ import { shallow } from "enzyme";
 const requiredProps = {
   onChange: () => {},
   onSubmit: () => {},
+  autocompletedResults: [],
+  autocompletedSuggestions: {},
   value: "test"
 };
 

--- a/packages/react-search-ui-views/src/__tests__/__snapshots__/SearchBox.test.js.snap
+++ b/packages/react-search-ui-views/src/__tests__/__snapshots__/SearchBox.test.js.snap
@@ -1,82 +1,70 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`passes through inputProps 1`] = `
-<form
-  onSubmit={[Function]}
+<Downshift
+  defaultHighlightedIndex={null}
+  defaultIsOpen={false}
+  environment={[Window]}
+  getA11yStatusMessage={[Function]}
+  inputValue="test"
+  itemToString={[Function]}
+  onChange={[Function]}
+  onInputValueChange={[Function]}
+  onOuterClick={[Function]}
+  onSelect={[Function]}
+  onStateChange={[Function]}
+  onUserAction={[Function]}
+  scrollIntoView={[Function]}
+  selectedItemChanged={[Function]}
+  stateReducer={[Function]}
+  suppressRefError={false}
 >
-  <Downshift
-    defaultHighlightedIndex={null}
-    defaultIsOpen={false}
-    environment={[Window]}
-    getA11yStatusMessage={[Function]}
-    inputValue="test"
-    itemToString={[Function]}
-    onChange={[Function]}
-    onInputValueChange={[Function]}
-    onOuterClick={[Function]}
-    onSelect={[Function]}
-    onStateChange={[Function]}
-    onUserAction={[Function]}
-    scrollIntoView={[Function]}
-    selectedItemChanged={[Function]}
-    stateReducer={[Function]}
-    suppressRefError={false}
-  >
-    <Component />
-  </Downshift>
-</form>
+  <Component />
+</Downshift>
 `;
 
 exports[`renders correctly when \`isFocused\` is false 1`] = `
-<form
-  onSubmit={[Function]}
+<Downshift
+  defaultHighlightedIndex={null}
+  defaultIsOpen={false}
+  environment={[Window]}
+  getA11yStatusMessage={[Function]}
+  inputValue="test"
+  itemToString={[Function]}
+  onChange={[Function]}
+  onInputValueChange={[Function]}
+  onOuterClick={[Function]}
+  onSelect={[Function]}
+  onStateChange={[Function]}
+  onUserAction={[Function]}
+  scrollIntoView={[Function]}
+  selectedItemChanged={[Function]}
+  stateReducer={[Function]}
+  suppressRefError={false}
 >
-  <Downshift
-    defaultHighlightedIndex={null}
-    defaultIsOpen={false}
-    environment={[Window]}
-    getA11yStatusMessage={[Function]}
-    inputValue="test"
-    itemToString={[Function]}
-    onChange={[Function]}
-    onInputValueChange={[Function]}
-    onOuterClick={[Function]}
-    onSelect={[Function]}
-    onStateChange={[Function]}
-    onUserAction={[Function]}
-    scrollIntoView={[Function]}
-    selectedItemChanged={[Function]}
-    stateReducer={[Function]}
-    suppressRefError={false}
-  >
-    <Component />
-  </Downshift>
-</form>
+  <Component />
+</Downshift>
 `;
 
 exports[`renders correctly when \`isFocused\` is true 1`] = `
-<form
-  onSubmit={[Function]}
+<Downshift
+  defaultHighlightedIndex={null}
+  defaultIsOpen={false}
+  environment={[Window]}
+  getA11yStatusMessage={[Function]}
+  inputValue="test"
+  itemToString={[Function]}
+  onChange={[Function]}
+  onInputValueChange={[Function]}
+  onOuterClick={[Function]}
+  onSelect={[Function]}
+  onStateChange={[Function]}
+  onUserAction={[Function]}
+  scrollIntoView={[Function]}
+  selectedItemChanged={[Function]}
+  stateReducer={[Function]}
+  suppressRefError={false}
 >
-  <Downshift
-    defaultHighlightedIndex={null}
-    defaultIsOpen={false}
-    environment={[Window]}
-    getA11yStatusMessage={[Function]}
-    inputValue="test"
-    itemToString={[Function]}
-    onChange={[Function]}
-    onInputValueChange={[Function]}
-    onOuterClick={[Function]}
-    onSelect={[Function]}
-    onStateChange={[Function]}
-    onUserAction={[Function]}
-    scrollIntoView={[Function]}
-    selectedItemChanged={[Function]}
-    stateReducer={[Function]}
-    suppressRefError={false}
-  >
-    <Component />
-  </Downshift>
-</form>
+  <Component />
+</Downshift>
 `;

--- a/packages/react-search-ui-views/src/styles/themes/reference-ui/components/_search-box.scss
+++ b/packages/react-search-ui-views/src/styles/themes/reference-ui/components/_search-box.scss
@@ -1,11 +1,11 @@
-@include block('search-box') {
+@include block("search-box") {
   display: flex;
   position: relative;
   justify-content: center;
   align-items: stretch;
   font-family: $fontFamily;
 
-  @include element('submit') {
+  @include element("submit") {
     font-size: 14px;
     padding: 16px;
     margin-left: 10px;
@@ -31,7 +31,7 @@
     }
   }
 
-  @include element('wrapper') {
+  @include element("wrapper") {
     width: 100%;
     height: 100%;
     outline: none;
@@ -42,7 +42,7 @@
     position: relative;
   }
 
-  @include element('text-input') {
+  @include element("text-input") {
     border-radius: $borderRadius;
     border: 1px solid #ccc;
     padding: 16px;
@@ -68,7 +68,7 @@
     }
   }
 
-  @include element('autocomplete-container') {
+  @include element("autocomplete-container") {
     display: none;
     flex-direction: column;
     left: 0;
@@ -91,6 +91,7 @@
 
     .autocomplete & {
       display: flex;
+      z-index: 1;
     }
 
     ul {
@@ -129,7 +130,7 @@
       }
     }
 
-    li[aria-selected=true] {
+    li[aria-selected="true"] {
       background: $linkColor;
       color: $white;
 
@@ -140,7 +141,7 @@
     }
   }
 
-  @include element('section-title') {
+  @include element("section-title") {
     color: #888;
     font-size: 0.7em;
     letter-spacing: 1px;

--- a/packages/react-search-ui-views/src/types/FieldValue.js
+++ b/packages/react-search-ui-views/src/types/FieldValue.js
@@ -3,5 +3,8 @@ import PropTypes from "prop-types";
 export default PropTypes.oneOfType([
   PropTypes.string,
   PropTypes.number,
-  PropTypes.bool
+  PropTypes.bool,
+  PropTypes.arrayOf(
+    PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.bool])
+  )
 ]);

--- a/packages/react-search-ui-views/stories/SearchBox.stories.js
+++ b/packages/react-search-ui-views/stories/SearchBox.stories.js
@@ -90,7 +90,7 @@ class Wrapper extends React.Component {
           action("submitted")();
         }}
         onChange={value => {
-          action("changed")();
+          action("changed")(value);
           this.setState({
             value
           });

--- a/packages/react-search-ui/src/containers/SearchBox.js
+++ b/packages/react-search-ui/src/containers/SearchBox.js
@@ -15,6 +15,7 @@ export class SearchBoxContainer extends Component {
     }),
     debounceLength: PropTypes.number,
     inputProps: PropTypes.object,
+    onSelectAutocomplete: PropTypes.func,
     searchAsYouType: PropTypes.bool,
     view: PropTypes.func,
     // State
@@ -60,7 +61,7 @@ export class SearchBoxContainer extends Component {
         debounce: debounceLength || 200
       }),
       refresh: !!searchAsYouType,
-      autocompleteResults: !!autocomple teResults
+      autocompleteResults: !!autocompleteResults
     };
 
     setSearchTerm(value, options);
@@ -72,6 +73,7 @@ export class SearchBoxContainer extends Component {
       autocompleteResults,
       autocompletedResults,
       inputProps,
+      onSelectAutocomplete,
       searchTerm,
       view
     } = this.props;
@@ -84,9 +86,8 @@ export class SearchBoxContainer extends Component {
         autocompletedResults={autocompletedResults}
         autocompletedSuggestions={{}}
         isFocused={isFocused}
-        //TODO
-        notifyAutocompleteResultClick={console.log}
         onChange={value => this.handleChange(value)}
+        onSelectAutocomplete={onSelectAutocomplete}
         onSubmit={this.handleSubmit}
         useAutocomplete={!!autocompleteResults}
         value={searchTerm}

--- a/packages/react-search-ui/src/containers/SearchBox.js
+++ b/packages/react-search-ui/src/containers/SearchBox.js
@@ -3,16 +3,22 @@ import React, { Component } from "react";
 import { SearchBox } from "@elastic/react-search-ui-views";
 
 import { withSearch } from "..";
+import { Result } from "../types";
 
 export class SearchBoxContainer extends Component {
   static propTypes = {
     // Props
-    autocompleteResults: PropTypes.bool,
+    autocompleteResults: PropTypes.shape({
+      titleField: PropTypes.string.isRequired,
+      urlField: PropTypes.string.isRequired,
+      sectionTitle: PropTypes.string
+    }),
     debounceLength: PropTypes.number,
     inputProps: PropTypes.object,
     searchAsYouType: PropTypes.bool,
     view: PropTypes.func,
     // State
+    autocompletedResults: PropTypes.arrayOf(Result).isRequired,
     searchTerm: PropTypes.string.isRequired,
     // Actions
     setSearchTerm: PropTypes.func.isRequired
@@ -54,7 +60,7 @@ export class SearchBoxContainer extends Component {
         debounce: debounceLength || 200
       }),
       refresh: !!searchAsYouType,
-      autocompleteResults: !!autocompleteResults
+      autocompleteResults: !!autocomple teResults
     };
 
     setSearchTerm(value, options);
@@ -62,15 +68,27 @@ export class SearchBoxContainer extends Component {
 
   render() {
     const { isFocused } = this.state;
-    const { inputProps, searchTerm, view } = this.props;
+    const {
+      autocompleteResults,
+      autocompletedResults,
+      inputProps,
+      searchTerm,
+      view
+    } = this.props;
 
     const View = view || SearchBox;
 
     return (
       <View
+        autocompleteResults={autocompleteResults}
+        autocompletedResults={autocompletedResults}
+        autocompletedSuggestions={{}}
         isFocused={isFocused}
+        //TODO
+        notifyAutocompleteResultClick={console.log}
         onChange={value => this.handleChange(value)}
         onSubmit={this.handleSubmit}
+        useAutocomplete={!!autocompleteResults}
         value={searchTerm}
         inputProps={{
           onFocus: this.handleFocus,

--- a/packages/react-search-ui/src/containers/SearchBox.js
+++ b/packages/react-search-ui/src/containers/SearchBox.js
@@ -8,12 +8,15 @@ import { Result } from "../types";
 export class SearchBoxContainer extends Component {
   static propTypes = {
     // Props
-    autocompleteResults: PropTypes.shape({
-      titleField: PropTypes.string.isRequired,
-      urlField: PropTypes.string.isRequired,
-      linkTarget: PropTypes.string,
-      sectionTitle: PropTypes.string
-    }),
+    autocompleteResults: PropTypes.oneOfType([
+      PropTypes.bool,
+      PropTypes.shape({
+        titleField: PropTypes.string.isRequired,
+        urlField: PropTypes.string.isRequired,
+        linkTarget: PropTypes.string,
+        sectionTitle: PropTypes.string
+      })
+    ]),
     debounceLength: PropTypes.number,
     inputProps: PropTypes.object,
     onSelectAutocomplete: PropTypes.func,

--- a/packages/react-search-ui/src/containers/SearchBox.js
+++ b/packages/react-search-ui/src/containers/SearchBox.js
@@ -11,6 +11,7 @@ export class SearchBoxContainer extends Component {
     autocompleteResults: PropTypes.shape({
       titleField: PropTypes.string.isRequired,
       urlField: PropTypes.string.isRequired,
+      linkTarget: PropTypes.string,
       sectionTitle: PropTypes.string
     }),
     debounceLength: PropTypes.number,

--- a/packages/react-search-ui/src/containers/__tests__/SearchBox.test.js
+++ b/packages/react-search-ui/src/containers/__tests__/SearchBox.test.js
@@ -3,6 +3,8 @@ import { SearchBoxContainer } from "../SearchBox";
 import { shallow } from "enzyme";
 
 const params = {
+  autocompletedResults: [],
+  autocompletedSuggestions: {},
   searchTerm: "test",
   setSearchTerm: jest.fn()
 };
@@ -43,6 +45,28 @@ it("will keep focus prop in sync with view component", () => {
     ["onBlur"]();
 
   expect(wrapper.find("SearchBox").prop("isFocused")).toBe(false);
+});
+
+describe("useAutocomplete", () => {
+  it("will be true  if autocompleteResults configuration has been provided", () => {
+    const wrapper = shallow(
+      <SearchBoxContainer
+        {...params}
+        autocompleteResults={{
+          titleField: "title",
+          urlField: "nps_link"
+        }}
+      />
+    );
+    wrapper.find("SearchBox").prop("onChange")("new term");
+    expect(wrapper.find("SearchBox").prop("useAutocomplete")).toBe(true);
+  });
+
+  it("will be false if no autocomplete config has been provided", () => {
+    const wrapper = shallow(<SearchBoxContainer {...params} />);
+    wrapper.find("SearchBox").prop("onChange")("new term");
+    expect(wrapper.find("SearchBox").prop("useAutocomplete")).toBe(false);
+  });
 });
 
 it("will call back to setSearchTerm with refresh: false when input is changed", () => {
@@ -99,7 +123,10 @@ it("will call back to setSearchTerm with a specific debounce when input is chang
   const wrapper = shallow(
     <SearchBoxContainer
       {...params}
-      autocompleteResults={true}
+      autocompleteResults={{
+        titleField: "title",
+        urlField: "nps_link"
+      }}
       debounceLength={500}
     />
   );

--- a/packages/react-search-ui/src/containers/__tests__/__snapshots__/SearchBox.test.js.snap
+++ b/packages/react-search-ui/src/containers/__tests__/__snapshots__/SearchBox.test.js.snap
@@ -2,6 +2,8 @@
 
 exports[`renders correctly 1`] = `
 <SearchBox
+  autocompletedResults={Array []}
+  autocompletedSuggestions={Object {}}
   inputProps={
     Object {
       "onBlur": [Function],
@@ -11,6 +13,7 @@ exports[`renders correctly 1`] = `
   isFocused={false}
   onChange={[Function]}
   onSubmit={[Function]}
+  useAutocomplete={false}
   value="test"
 />
 `;

--- a/packages/react-search-ui/src/types/FieldValue.js
+++ b/packages/react-search-ui/src/types/FieldValue.js
@@ -3,5 +3,8 @@ import PropTypes from "prop-types";
 export default PropTypes.oneOfType([
   PropTypes.string,
   PropTypes.number,
-  PropTypes.bool
+  PropTypes.bool,
+  PropTypes.arrayOf(
+    PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.bool])
+  )
 ]);


### PR DESCRIPTION
This PR completes the remaining work for to have a basic working Autocomplete with Search Results.

Design is documented here: https://github.com/elastic/search-ui/issues/113

Remaining work is captured here: https://github.com/elastic/search-ui/pull/140

- Added working example to the Sandbox
- Closes the autocomplete Autocomplete any time a query is submitted
- Ensure the autocomplete value is not changed whenever a result is selected
- Support for boolean configuration of autocompleteResults (explained in design doc)
- Updated `FieldValue` type to expect Arrays of values from the server.

To test this, run the sandbox app and play around with the autocomplete: https://github.com/elastic/search-ui/tree/master/examples/sandbox

![latest](https://user-images.githubusercontent.com/1427475/54953467-a9545400-4f1e-11e9-8ed7-22a159ec2e62.gif)

To just play around with the view, you can run storybook:

```
cd packages/react-search-ui-views && npm run storybook
```

![latest](https://user-images.githubusercontent.com/1427475/54953554-e4ef1e00-4f1e-11e9-9fe2-60d3b5aaf9ce.gif)


