### PR TITLE
Added configuration for autocomplete queries

### DIFF
--- a/examples/sandbox/src/App.js
+++ b/examples/sandbox/src/App.js
@@ -62,6 +62,25 @@ export default function App() {
             }
           }
         },
+        autocompleteQuery: {
+          results: {
+            search_fields: {
+              title: {},
+              description: {}
+            },
+            result_fields: {
+              title: {
+                snippet: {
+                  size: 100,
+                  fallback: true
+                }
+              },
+              nps_link: {
+                raw: {}
+              }
+            }
+          }
+        },
         apiConnector: connector
       }}
     >

--- a/packages/search-ui/src/SearchDriver.js
+++ b/packages/search-ui/src/SearchDriver.js
@@ -73,6 +73,7 @@ export default class SearchDriver {
 
   constructor({
     apiConnector,
+    autocompleteQuery = {},
     initialState,
     searchQuery = {},
     trackUrlState = true,
@@ -96,6 +97,7 @@ export default class SearchDriver {
     this.requestSequencer = new RequestSequencer();
     this.debounceManager = new DebounceManager();
     this.apiConnector = apiConnector;
+    this.autocompleteQuery = autocompleteQuery;
     this.searchQuery = searchQuery;
     this.subscriptions = [];
     this.trackUrlState = trackUrlState;
@@ -149,9 +151,10 @@ export default class SearchDriver {
 
   _updateAutocompleteResults = searchTerm => {
     const requestId = this.requestSequencer.next();
+    const autocompleteQueryResults = this.autocompleteQuery.results || {};
 
     return this.apiConnector
-      .autocompleteResults({ searchTerm }, {})
+      .autocompleteResults({ searchTerm }, autocompleteQueryResults)
       .then(autocompletedResults => {
         if (this.requestSequencer.isOldRequest(requestId)) return;
         this.requestSequencer.completed(requestId);

--- a/packages/search-ui/src/__tests__/SearchDriver.test.js
+++ b/packages/search-ui/src/__tests__/SearchDriver.test.js
@@ -25,7 +25,13 @@ function getSearchCalls(specificMockApiConnector) {
   return (specificMockApiConnector || mockApiConnector).search.mock.calls;
 }
 
+function getAutocompleteResultsCalls(specificMockApiConnector) {
+  return (specificMockApiConnector || mockApiConnector).autocompleteResults.mock
+    .calls;
+}
+
 beforeEach(() => {
+  mockApiConnector.autocompleteResults.mockClear();
   mockApiConnector.search.mockClear();
   mockApiConnector.click.mockClear();
 });
@@ -220,6 +226,35 @@ describe("searchQuery config", () => {
       subject({ search_fields });
       expect(getSearchCalls()[0][1].search_fields).toEqual(search_fields);
     });
+  });
+});
+
+describe("autocompleteQuery config", () => {
+  function subject(config) {
+    const driver = new SearchDriver({
+      ...params,
+      autocompleteQuery: {
+        results: config
+      }
+    });
+
+    driver.setSearchTerm("test", { refresh: false, autocompleteResults: true });
+  }
+
+  it("will pass through result_fields configuration", () => {
+    const result_fields = { test: {} };
+    subject({ result_fields });
+    expect(getAutocompleteResultsCalls()[0][1].result_fields).toEqual(
+      result_fields
+    );
+  });
+
+  it("will pass through search_fields configuration", () => {
+    const search_fields = { test: {} };
+    subject({ search_fields });
+    expect(getAutocompleteResultsCalls()[0][1].search_fields).toEqual(
+      search_fields
+    );
   });
 });
 


### PR DESCRIPTION
This PR adds support for configuring autocomplete queries.

Design is documented here: https://github.com/elastic/search-ui/issues/113

To test this, run the sandbox app and play around with the autocomplete: https://github.com/elastic/search-ui/tree/master/examples/sandbox

You should see our "result_fields" config has now provided snippets for the autocomplete.

![latest](https://user-images.githubusercontent.com/1427475/55031664-72954100-4fe5-11e9-8ee2-d1f4582b5a37.gif)
