### PR TITLE
Configurable autocomplete view

### DIFF
--- a/packages/react-search-ui-views/src/Autocomplete.js
+++ b/packages/react-search-ui-views/src/Autocomplete.js
@@ -1,0 +1,133 @@
+import PropTypes from "prop-types";
+import React from "react";
+
+import { Result } from "./types";
+import { Suggestion } from "./types";
+
+function getRaw(result, value) {
+  if (!result[value] || !result[value].raw) return;
+  return result[value].raw;
+}
+
+function getSnippet(result, value) {
+  if (!result[value] || !result[value].snippet) return;
+  return result[value].snippet;
+}
+
+function Autocomplete({
+  autocompleteResults,
+  autocompletedResults,
+  autocompleteSuggestions,
+  autocompletedSuggestions,
+  getItemProps,
+  getMenuProps
+}) {
+  let index = 0;
+  return (
+    <div
+      {...getMenuProps({
+        className: "sui-search-box__autocomplete-container"
+      })}
+    >
+      <div>
+        {autocompleteResults.sectionTitle && (
+          <div className="sui-search-box__section-title">
+            {autocompleteResults.sectionTitle}
+          </div>
+        )}
+        <ul>
+          {autocompletedResults.map(result => {
+            index++;
+            const titleSnippet = getSnippet(
+              result,
+              autocompleteResults.titleField
+            );
+            const titleRaw = getRaw(result, autocompleteResults.titleField);
+            return (
+              // eslint-disable-next-line react/jsx-key
+              <li
+                {...getItemProps({
+                  key: result.id.raw,
+                  index: index - 1,
+                  item: result
+                })}
+              >
+                {titleSnippet ? (
+                  <span
+                    dangerouslySetInnerHTML={{
+                      __html: titleSnippet
+                    }}
+                  />
+                ) : (
+                  <span>{titleRaw}</span>
+                )}
+              </li>
+            );
+          })}
+        </ul>
+        {Object.entries(autocompletedSuggestions).map(
+          ([suggestionType, suggestions]) => {
+            return (
+              <>
+                {autocompleteSuggestions[suggestionType] &&
+                  autocompleteSuggestions[suggestionType].sectionTitle && (
+                    <div className="sui-search-box__section-title">
+                      {autocompleteSuggestions[suggestionType].sectionTitle}
+                    </div>
+                  )}
+                <ul>
+                  {suggestions.map(suggestion => {
+                    index++;
+                    return (
+                      // eslint-disable-next-line react/jsx-key
+                      <li
+                        {...getItemProps({
+                          key: suggestion.suggestion || suggestion.highlight,
+                          index: index - 1,
+                          item: suggestion
+                        })}
+                      >
+                        {suggestion.highlight ? (
+                          <span
+                            dangerouslySetInnerHTML={{
+                              __html: suggestion.highlight
+                            }}
+                          />
+                        ) : (
+                          <span>{suggestion.suggestion}</span>
+                        )}
+                      </li>
+                    );
+                  })}
+                </ul>
+              </>
+            );
+          }
+        )}
+      </div>
+    </div>
+  );
+}
+
+Autocomplete.propTypes = {
+  autocompleteResults: PropTypes.oneOfType([
+    PropTypes.bool,
+    PropTypes.shape({
+      titleField: PropTypes.string.isRequired,
+      urlField: PropTypes.string.isRequired,
+      linkTarget: PropTypes.string,
+      sectionTitle: PropTypes.string
+    })
+  ]),
+  autocompletedResults: PropTypes.arrayOf(Result).isRequired,
+  autocompleteSuggestions: PropTypes.objectOf(
+    PropTypes.shape({
+      sectionTitle: PropTypes.string.isRequired
+    })
+  ),
+  autocompletedSuggestions: PropTypes.objectOf(Suggestion).isRequired,
+  getItemProps: PropTypes.func.isRequired,
+  getMenuProps: PropTypes.func.isRequired
+};
+
+export default Autocomplete;

--- a/packages/react-search-ui-views/src/SearchBox.js
+++ b/packages/react-search-ui-views/src/SearchBox.js
@@ -9,17 +9,19 @@ import Autocomplete from "./Autocomplete";
 
 function SearchBox(props) {
   const {
-    useAutocomplete,
     autocompleteResults,
     autocompletedResults,
     autocompletedSuggestions,
+    autocompleteView,
     isFocused,
     inputProps,
     onChange,
     onSubmit,
+    useAutocomplete,
     value
   } = props;
   const focusedClass = isFocused ? "focus" : "";
+  const AutocompleteView = autocompleteView || Autocomplete;
 
   const onSelectAutocomplete =
     props.onSelectAutocomplete ||
@@ -68,7 +70,7 @@ function SearchBox(props) {
                 isOpen &&
                 (autocompletedResults.length > 0 ||
                   Object.entries(autocompletedSuggestions).length > 0) ? (
-                  <Autocomplete {...props} {...downshiftProps} />
+                  <AutocompleteView {...props} {...downshiftProps} />
                 ) : null}
               </div>
               <input
@@ -99,6 +101,7 @@ SearchBox.propTypes = {
     })
   ]),
   autocompletedResults: PropTypes.arrayOf(Result).isRequired,
+  autocompleteView: PropTypes.func,
   autocompleteSuggestions: PropTypes.objectOf(
     PropTypes.shape({
       sectionTitle: PropTypes.string.isRequired

--- a/packages/react-search-ui-views/src/SearchBox.js
+++ b/packages/react-search-ui-views/src/SearchBox.js
@@ -5,22 +5,13 @@ import Downshift from "downshift";
 import { Result } from "./types";
 import { Suggestion } from "./types";
 
-function getRaw(result, value) {
-  if (!result[value] || !result[value].raw) return;
-  return result[value].raw;
-}
-
-function getSnippet(result, value) {
-  if (!result[value] || !result[value].snippet) return;
-  return result[value].snippet;
-}
+import Autocomplete from "./Autocomplete";
 
 function SearchBox(props) {
   const {
     useAutocomplete,
     autocompleteResults,
     autocompletedResults,
-    autocompleteSuggestions,
     autocompletedSuggestions,
     isFocused,
     inputProps,
@@ -54,8 +45,8 @@ function SearchBox(props) {
       // this happens we lose control of it.
       itemToString={() => value}
     >
-      {({ closeMenu, getInputProps, getItemProps, getMenuProps, isOpen }) => {
-        let index = 0;
+      {downshiftProps => {
+        const { closeMenu, getInputProps, isOpen } = downshiftProps;
         let autocompleteClass = isOpen === true ? " autocomplete" : "";
         return (
           <form
@@ -77,97 +68,7 @@ function SearchBox(props) {
                 isOpen &&
                 (autocompletedResults.length > 0 ||
                   Object.entries(autocompletedSuggestions).length > 0) ? (
-                  <div
-                    {...getMenuProps({
-                      className: "sui-search-box__autocomplete-container"
-                    })}
-                  >
-                    <div>
-                      {autocompleteResults.sectionTitle && (
-                        <div className="sui-search-box__section-title">
-                          {autocompleteResults.sectionTitle}
-                        </div>
-                      )}
-                      <ul>
-                        {autocompletedResults.map(result => {
-                          index++;
-                          const titleSnippet = getSnippet(
-                            result,
-                            autocompleteResults.titleField
-                          );
-                          const titleRaw = getRaw(
-                            result,
-                            autocompleteResults.titleField
-                          );
-                          return (
-                            // eslint-disable-next-line react/jsx-key
-                            <li
-                              {...getItemProps({
-                                key: result.id.raw,
-                                index: index - 1,
-                                item: result
-                              })}
-                            >
-                              {titleSnippet ? (
-                                <span
-                                  dangerouslySetInnerHTML={{
-                                    __html: titleSnippet
-                                  }}
-                                />
-                              ) : (
-                                <span>{titleRaw}</span>
-                              )}
-                            </li>
-                          );
-                        })}
-                      </ul>
-                      {Object.entries(autocompletedSuggestions).map(
-                        ([suggestionType, suggestions]) => {
-                          return (
-                            <>
-                              {autocompleteSuggestions[suggestionType] &&
-                                autocompleteSuggestions[suggestionType]
-                                  .sectionTitle && (
-                                  <div className="sui-search-box__section-title">
-                                    {
-                                      autocompleteSuggestions[suggestionType]
-                                        .sectionTitle
-                                    }
-                                  </div>
-                                )}
-                              <ul>
-                                {suggestions.map(suggestion => {
-                                  index++;
-                                  return (
-                                    // eslint-disable-next-line react/jsx-key
-                                    <li
-                                      {...getItemProps({
-                                        key:
-                                          suggestion.suggestion ||
-                                          suggestion.highlight,
-                                        index: index - 1,
-                                        item: suggestion
-                                      })}
-                                    >
-                                      {suggestion.highlight ? (
-                                        <span
-                                          dangerouslySetInnerHTML={{
-                                            __html: suggestion.highlight
-                                          }}
-                                        />
-                                      ) : (
-                                        <span>{suggestion.suggestion}</span>
-                                      )}
-                                    </li>
-                                  );
-                                })}
-                              </ul>
-                            </>
-                          );
-                        }
-                      )}
-                    </div>
-                  </div>
+                  <Autocomplete {...props} {...downshiftProps} />
                 ) : null}
               </div>
               <input

--- a/packages/react-search-ui-views/stories/SearchBox.stories.js
+++ b/packages/react-search-ui-views/stories/SearchBox.stories.js
@@ -119,4 +119,13 @@ storiesOf("SearchBox", module)
       }}
       autocompleteSuggestions={{}}
     />
+  ))
+  .add("with custom autocomplete template", () => (
+    <Wrapper
+      autocompleteView={props => (
+        <div className="sui-search-box__autocomplete-container">
+          Custom View
+        </div>
+      )}
+    />
   ));

--- a/packages/react-search-ui/src/containers/SearchBox.js
+++ b/packages/react-search-ui/src/containers/SearchBox.js
@@ -8,6 +8,7 @@ import { Result } from "../types";
 export class SearchBoxContainer extends Component {
   static propTypes = {
     // Props
+    autocompleteView: PropTypes.func,
     autocompleteResults: PropTypes.oneOfType([
       PropTypes.bool,
       PropTypes.shape({


### PR DESCRIPTION
This PR adds an additional prop to the `SearchBox` component which lets you customize the view of
just the Autocomplete dropdown, without having to customize the entire view of SearchBox.

The prop is `autocompleteView`

ex:

```jsx
<SearchBox
    autocompleteResults={true}
    autocompleteView
    autocompleteView={props => (
        <div className="sui-search-box__autocomplete-container">
          Custom View
        </div>
      )}
/>
```
To test this you can run storybook:

```
cd packages/react-search-ui-views && npm run storybook
```

![latest](https://user-images.githubusercontent.com/1427475/55084277-5217c600-507b-11e9-9ad8-2215a6c97069.gif)


