### PR TITLE
Added click tracking to autocompelte

### DIFF
--- a/examples/sandbox/src/App.js
+++ b/examples/sandbox/src/App.js
@@ -94,7 +94,9 @@ export default function App() {
                     linkTarget: "_blank",
                     sectionTitle: "Results",
                     titleField: "title",
-                    urlField: "nps_link"
+                    urlField: "nps_link",
+                    shouldTrackClickThrough: true,
+                    clickThroughTags: ["test"]
                   }}
                 />
               }
@@ -118,7 +120,13 @@ export default function App() {
                   <Facet field="acres" label="Acres" view={SingleSelectFacet} />
                 </div>
               }
-              bodyContent={<Results titleField="title" urlField="nps_link" />}
+              bodyContent={
+                <Results
+                  titleField="title"
+                  urlField="nps_link"
+                  shouldTrackClickThrough={true}
+                />
+              }
               bodyHeader={
                 <React.Fragment>
                   <PagingInfo />

--- a/packages/react-search-ui-views/src/Autocomplete.js
+++ b/packages/react-search-ui-views/src/Autocomplete.js
@@ -68,7 +68,7 @@ function Autocomplete({
         {Object.entries(autocompletedSuggestions).map(
           ([suggestionType, suggestions]) => {
             return (
-              <>
+              <React.Fragment key={suggestionType}>
                 {autocompleteSuggestions[suggestionType] &&
                   autocompleteSuggestions[suggestionType].sectionTitle && (
                     <div className="sui-search-box__section-title">
@@ -100,7 +100,7 @@ function Autocomplete({
                     );
                   })}
                 </ul>
-              </>
+              </React.Fragment>
             );
           }
         )}
@@ -120,12 +120,13 @@ Autocomplete.propTypes = {
     })
   ]),
   autocompletedResults: PropTypes.arrayOf(Result).isRequired,
+  autocompletedSuggestions: PropTypes.objectOf(PropTypes.arrayOf(Suggestion))
+    .isRequired,
   autocompleteSuggestions: PropTypes.objectOf(
     PropTypes.shape({
       sectionTitle: PropTypes.string.isRequired
     })
   ),
-  autocompletedSuggestions: PropTypes.objectOf(Suggestion).isRequired,
   getItemProps: PropTypes.func.isRequired,
   getMenuProps: PropTypes.func.isRequired
 };

--- a/packages/react-search-ui-views/src/SearchBox.js
+++ b/packages/react-search-ui-views/src/SearchBox.js
@@ -15,6 +15,7 @@ function SearchBox(props) {
     autocompleteView,
     isFocused,
     inputProps,
+    notifyAutocompleteSelected,
     onChange,
     onSubmit,
     useAutocomplete,
@@ -26,6 +27,7 @@ function SearchBox(props) {
   const onSelectAutocomplete =
     props.onSelectAutocomplete ||
     (selection => {
+      notifyAutocompleteSelected(selection);
       if (!selection.suggestion) {
         const url = selection[autocompleteResults.urlField]
           ? selection[autocompleteResults.urlField].raw
@@ -101,13 +103,15 @@ SearchBox.propTypes = {
     })
   ]),
   autocompletedResults: PropTypes.arrayOf(Result).isRequired,
+  autocompletedSuggestions: PropTypes.objectOf(PropTypes.arrayOf(Suggestion))
+    .isRequired,
+  notifyAutocompleteSelected: PropTypes.func.isRequired,
   autocompleteView: PropTypes.func,
   autocompleteSuggestions: PropTypes.objectOf(
     PropTypes.shape({
       sectionTitle: PropTypes.string.isRequired
     })
   ),
-  autocompletedSuggestions: PropTypes.objectOf(Suggestion).isRequired,
   inputProps: PropTypes.object,
   isFocused: PropTypes.bool,
   useAutocomplete: PropTypes.bool,

--- a/packages/react-search-ui-views/src/__tests__/Autocomplete.test.js
+++ b/packages/react-search-ui-views/src/__tests__/Autocomplete.test.js
@@ -1,0 +1,56 @@
+import React from "react";
+import { Autocomplete } from "..";
+import { shallow } from "enzyme";
+
+const props = {
+  autocompleteResults: {
+    sectionTitle: "Results",
+    titleField: "title",
+    urlField: "nps_link",
+    linkTarget: "_blank"
+  },
+  autocompletedResults: [
+    {
+      id: { raw: "1" },
+      title: { snippet: "<em>Bike</em> Cops" }
+    },
+    {
+      id: { raw: "2" },
+      title: { snippet: "<em>Biker</em> Gang" }
+    },
+    {
+      id: { raw: "3" },
+      title: { snippet: "<em>Biker</em> Bar" }
+    }
+  ],
+  autocompleteSuggestions: {
+    documents: {
+      sectionTitle: "Suggested"
+    },
+    popular_queries: {
+      sectionTitle: "Popular"
+    }
+  },
+  autocompletedSuggestions: {
+    documents: [
+      { highlight: "", suggestion: "bike" },
+      { highlight: "", suggestion: "bike police" },
+      { highlight: "", suggestion: "bike police go" }
+    ],
+    popular_queries: [
+      {
+        highlight: "",
+        suggestion: "how do i know when my bike needs new tires?"
+      },
+      { highlight: "", suggestion: "what is a banana bike?" },
+      { highlight: "", suggestion: "is it cool to ride a bike?" }
+    ]
+  },
+  getItemProps: props => props,
+  getMenuProps: props => props
+};
+
+it("renders correctly", () => {
+  const wrapper = shallow(<Autocomplete {...props} />);
+  expect(wrapper).toMatchSnapshot();
+});

--- a/packages/react-search-ui-views/src/__tests__/SearchBox.test.js
+++ b/packages/react-search-ui-views/src/__tests__/SearchBox.test.js
@@ -7,17 +7,20 @@ const requiredProps = {
   onSubmit: () => {},
   autocompletedResults: [],
   autocompletedSuggestions: {},
+  notifyAutocompleteSelected: () => {},
   value: "test"
 };
 
-it("renders correctly when `isFocused` is true", () => {
-  const wrapper = shallow(<SearchBox {...requiredProps} isFocused={true} />);
+it("renders correctly", () => {
+  const wrapper = shallow(<SearchBox {...requiredProps} />);
   expect(wrapper).toMatchSnapshot();
 });
 
-it("renders correctly when `isFocused` is false", () => {
-  const wrapper = shallow(<SearchBox {...requiredProps} />);
-  expect(wrapper).toMatchSnapshot();
+it("applies 'focused' class when `isFocused` is true", () => {
+  const wrapper = shallow(<SearchBox {...requiredProps} isFocused={true} />);
+  const downshift = wrapper.dive("Downshift");
+  const input = downshift.find(".sui-search-box__text-input");
+  expect(input.hasClass("focus")).toBe(true);
 });
 
 it("passes through inputProps", () => {

--- a/packages/react-search-ui-views/src/__tests__/__snapshots__/Autocomplete.test.js.snap
+++ b/packages/react-search-ui-views/src/__tests__/__snapshots__/Autocomplete.test.js.snap
@@ -1,0 +1,181 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders correctly 1`] = `
+<div
+  className="sui-search-box__autocomplete-container"
+>
+  <div>
+    <div
+      className="sui-search-box__section-title"
+    >
+      Results
+    </div>
+    <ul>
+      <li
+        index={0}
+        item={
+          Object {
+            "id": Object {
+              "raw": "1",
+            },
+            "title": Object {
+              "snippet": "<em>Bike</em> Cops",
+            },
+          }
+        }
+        key="1"
+      >
+        <span
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "<em>Bike</em> Cops",
+            }
+          }
+        />
+      </li>
+      <li
+        index={1}
+        item={
+          Object {
+            "id": Object {
+              "raw": "2",
+            },
+            "title": Object {
+              "snippet": "<em>Biker</em> Gang",
+            },
+          }
+        }
+        key="2"
+      >
+        <span
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "<em>Biker</em> Gang",
+            }
+          }
+        />
+      </li>
+      <li
+        index={2}
+        item={
+          Object {
+            "id": Object {
+              "raw": "3",
+            },
+            "title": Object {
+              "snippet": "<em>Biker</em> Bar",
+            },
+          }
+        }
+        key="3"
+      >
+        <span
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "<em>Biker</em> Bar",
+            }
+          }
+        />
+      </li>
+    </ul>
+    <div
+      className="sui-search-box__section-title"
+    >
+      Suggested
+    </div>
+    <ul>
+      <li
+        index={3}
+        item={
+          Object {
+            "highlight": "",
+            "suggestion": "bike",
+          }
+        }
+        key="bike"
+      >
+        <span>
+          bike
+        </span>
+      </li>
+      <li
+        index={4}
+        item={
+          Object {
+            "highlight": "",
+            "suggestion": "bike police",
+          }
+        }
+        key="bike police"
+      >
+        <span>
+          bike police
+        </span>
+      </li>
+      <li
+        index={5}
+        item={
+          Object {
+            "highlight": "",
+            "suggestion": "bike police go",
+          }
+        }
+        key="bike police go"
+      >
+        <span>
+          bike police go
+        </span>
+      </li>
+    </ul>
+    <div
+      className="sui-search-box__section-title"
+    >
+      Popular
+    </div>
+    <ul>
+      <li
+        index={6}
+        item={
+          Object {
+            "highlight": "",
+            "suggestion": "how do i know when my bike needs new tires?",
+          }
+        }
+        key="how do i know when my bike needs new tires?"
+      >
+        <span>
+          how do i know when my bike needs new tires?
+        </span>
+      </li>
+      <li
+        index={7}
+        item={
+          Object {
+            "highlight": "",
+            "suggestion": "what is a banana bike?",
+          }
+        }
+        key="what is a banana bike?"
+      >
+        <span>
+          what is a banana bike?
+        </span>
+      </li>
+      <li
+        index={8}
+        item={
+          Object {
+            "highlight": "",
+            "suggestion": "is it cool to ride a bike?",
+          }
+        }
+        key="is it cool to ride a bike?"
+      >
+        <span>
+          is it cool to ride a bike?
+        </span>
+      </li>
+    </ul>
+  </div>
+</div>
+`;

--- a/packages/react-search-ui-views/src/__tests__/__snapshots__/SearchBox.test.js.snap
+++ b/packages/react-search-ui-views/src/__tests__/__snapshots__/SearchBox.test.js.snap
@@ -23,30 +23,7 @@ exports[`passes through inputProps 1`] = `
 </Downshift>
 `;
 
-exports[`renders correctly when \`isFocused\` is false 1`] = `
-<Downshift
-  defaultHighlightedIndex={null}
-  defaultIsOpen={false}
-  environment={[Window]}
-  getA11yStatusMessage={[Function]}
-  inputValue="test"
-  itemToString={[Function]}
-  onChange={[Function]}
-  onInputValueChange={[Function]}
-  onOuterClick={[Function]}
-  onSelect={[Function]}
-  onStateChange={[Function]}
-  onUserAction={[Function]}
-  scrollIntoView={[Function]}
-  selectedItemChanged={[Function]}
-  stateReducer={[Function]}
-  suppressRefError={false}
->
-  <Component />
-</Downshift>
-`;
-
-exports[`renders correctly when \`isFocused\` is true 1`] = `
+exports[`renders correctly 1`] = `
 <Downshift
   defaultHighlightedIndex={null}
   defaultIsOpen={false}

--- a/packages/react-search-ui-views/src/index.js
+++ b/packages/react-search-ui-views/src/index.js
@@ -1,5 +1,6 @@
 import "@babel/polyfill";
 
+export { default as Autocomplete } from "./Autocomplete";
 export { default as ErrorBoundary } from "./ErrorBoundary";
 export { default as Facets } from "./Facets";
 export { default as MultiCheckboxFacet } from "./MultiCheckboxFacet";

--- a/packages/react-search-ui/src/containers/Result.js
+++ b/packages/react-search-ui/src/containers/Result.js
@@ -1,0 +1,94 @@
+import PropTypes from "prop-types";
+import React, { Component } from "react";
+import { Result } from "@elastic/react-search-ui-views";
+
+import { withSearch } from "..";
+import { Result as ResultType } from "../types";
+
+function getRaw(result, value) {
+  if (!result[value] || !result[value].raw) return;
+  return result[value].raw;
+}
+
+function getSnippet(result, value) {
+  if (!result[value] || !result[value].snippet) return;
+  return result[value].snippet;
+}
+
+function htmlEscape(str) {
+  return String(str)
+    .replace(/&/g, "&amp;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+/*
+  Our `Result` component expects result fields to be formatted in an object
+  like:
+  {
+    field1: "value1",
+    field2: "value2"
+  }
+*/
+function formatResultFields(result) {
+  return Object.keys(result).reduce((acc, n) => {
+    // Fallback to raw values here, because non-string fields
+    // will not have a snippet fallback. Raw values MUST be html escaped.
+    let value = result[n].snippet || htmlEscape(result[n].raw);
+    value = Array.isArray(value) ? value.join(", ") : value;
+    acc[n] = value;
+    return acc;
+  }, {});
+}
+export class ResultContainer extends Component {
+  static propTypes = {
+    // Props
+    clickThroughTags: PropTypes.arrayOf(PropTypes.string),
+    titleField: PropTypes.string,
+    urlField: PropTypes.string,
+    view: PropTypes.func,
+    result: ResultType.isRequired,
+    shouldTrackClickThrough: PropTypes.bool,
+    // Actions
+    trackClickThrough: PropTypes.func
+  };
+
+  static defaultProps = {
+    clickThroughTags: [],
+    shouldTrackClickThrough: true
+  };
+
+  handleClickLink = id => {
+    const {
+      clickThroughTags,
+      shouldTrackClickThrough,
+      trackClickThrough
+    } = this.props;
+
+    if (shouldTrackClickThrough) {
+      trackClickThrough(id, clickThroughTags);
+    }
+  };
+
+  render() {
+    const { result, titleField, urlField, view } = this.props;
+    const View = view || Result;
+
+    return (
+      <View
+        fields={formatResultFields(result)}
+        key={`result-${getRaw(result, "id")}`}
+        onClickLink={() => this.handleClickLink(getRaw(result, "id"))}
+        title={
+          getSnippet(result, titleField) ||
+          htmlEscape(getRaw(result, titleField))
+        }
+        url={getRaw(result, urlField)}
+      />
+    );
+  }
+}
+
+export default withSearch(ResultContainer);

--- a/packages/react-search-ui/src/containers/Results.js
+++ b/packages/react-search-ui/src/containers/Results.js
@@ -3,6 +3,7 @@ import React, { Component } from "react";
 import { Result, Results } from "@elastic/react-search-ui-views";
 
 import { withSearch } from "..";
+import { Result as ResultContainer } from ".";
 import { Result as ResultType } from "../types";
 
 function getRaw(result, value) {
@@ -10,58 +11,34 @@ function getRaw(result, value) {
   return result[value].raw;
 }
 
-function getSnippet(result, value) {
-  if (!result[value] || !result[value].snippet) return;
-  return result[value].snippet;
-}
-
-function htmlEscape(str) {
-  return String(str)
-    .replace(/&/g, "&amp;")
-    .replace(/"/g, "&quot;")
-    .replace(/'/g, "&#39;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;");
-}
-
-/*
-  Our `Result` component expects result fields to be formatted in an object
-  like:
-  {
-    field1: "value1",
-    field2: "value2"
-  }
-*/
-function formatResultFields(result) {
-  return Object.keys(result).reduce((acc, n) => {
-    // Fallback to raw values here, because non-string fields
-    // will not have a snippet fallback. Raw values MUST be html escaped.
-    let value = result[n].snippet || htmlEscape(result[n].raw);
-    value = Array.isArray(value) ? value.join(", ") : value;
-    acc[n] = value;
-    return acc;
-  }, {});
-}
 export class ResultsContainer extends Component {
   static propTypes = {
     // Props
+    clickThroughTags: PropTypes.arrayOf(PropTypes.string),
     renderResult: PropTypes.func,
     titleField: PropTypes.string,
     urlField: PropTypes.string,
     view: PropTypes.func,
+    shouldTrackClickThrough: PropTypes.bool,
     // State
-    results: PropTypes.arrayOf(ResultType).isRequired,
-    // Actions
-    trackClickThrough: PropTypes.func
+    results: PropTypes.arrayOf(ResultType).isRequired
   };
 
-  handleClickLink = id => {
-    const { trackClickThrough } = this.props;
-    !!trackClickThrough && trackClickThrough(id);
+  static defaultProps = {
+    clickThroughTags: [],
+    shouldTrackClickThrough: true
   };
 
   render() {
-    const { renderResult, results, titleField, urlField, view } = this.props;
+    const {
+      clickThroughTags,
+      renderResult,
+      results,
+      shouldTrackClickThrough,
+      titleField,
+      urlField,
+      view
+    } = this.props;
 
     const View = view || Results;
     const ResultView = renderResult || Result;
@@ -69,15 +46,14 @@ export class ResultsContainer extends Component {
     return (
       <View>
         {results.map(result => (
-          <ResultView
-            fields={formatResultFields(result)}
+          <ResultContainer
             key={`result-${getRaw(result, "id")}`}
-            onClickLink={() => this.handleClickLink(getRaw(result, "id"))}
-            title={
-              getSnippet(result, titleField) ||
-              htmlEscape(getRaw(result, titleField))
-            }
-            url={getRaw(result, urlField)}
+            titleField={titleField}
+            urlField={urlField}
+            view={ResultView}
+            result={result}
+            shouldTrackClickThrough={shouldTrackClickThrough}
+            clickThroughTags={clickThroughTags}
           />
         ))}
       </View>

--- a/packages/react-search-ui/src/containers/SearchBox.js
+++ b/packages/react-search-ui/src/containers/SearchBox.js
@@ -12,10 +12,12 @@ export class SearchBoxContainer extends Component {
     autocompleteResults: PropTypes.oneOfType([
       PropTypes.bool,
       PropTypes.shape({
-        titleField: PropTypes.string.isRequired,
-        urlField: PropTypes.string.isRequired,
+        clickThroughTags: PropTypes.arrayOf(PropTypes.string),
         linkTarget: PropTypes.string,
-        sectionTitle: PropTypes.string
+        sectionTitle: PropTypes.string,
+        shouldTrackClickThrough: PropTypes.bool,
+        titleField: PropTypes.string.isRequired,
+        urlField: PropTypes.string.isRequired
       })
     ]),
     debounceLength: PropTypes.number,
@@ -27,7 +29,8 @@ export class SearchBoxContainer extends Component {
     autocompletedResults: PropTypes.arrayOf(Result).isRequired,
     searchTerm: PropTypes.string.isRequired,
     // Actions
-    setSearchTerm: PropTypes.func.isRequired
+    setSearchTerm: PropTypes.func.isRequired,
+    trackAutocompleteClickThrough: PropTypes.func.isRequired
   };
 
   state = {
@@ -72,6 +75,21 @@ export class SearchBoxContainer extends Component {
     setSearchTerm(value, options);
   };
 
+  handleNotifyAutocompleteSelected = selection => {
+    const { autocompleteResults, trackAutocompleteClickThrough } = this.props;
+    // Because suggestions don't count as clickthroughs, only
+    // results
+    if (
+      autocompleteResults &&
+      autocompleteResults.shouldTrackClickThrough !== false &&
+      !selection.suggestion
+    ) {
+      const { clickThroughTags = [] } = autocompleteResults;
+      const id = selection.id.raw;
+      trackAutocompleteClickThrough(id, clickThroughTags);
+    }
+  };
+
   render() {
     const { isFocused } = this.state;
     const {
@@ -91,6 +109,7 @@ export class SearchBoxContainer extends Component {
         autocompletedResults={autocompletedResults}
         autocompletedSuggestions={{}}
         isFocused={isFocused}
+        notifyAutocompleteSelected={this.handleNotifyAutocompleteSelected}
         onChange={value => this.handleChange(value)}
         onSelectAutocomplete={onSelectAutocomplete}
         onSubmit={this.handleSubmit}

--- a/packages/react-search-ui/src/containers/__tests__/Result.test.js
+++ b/packages/react-search-ui/src/containers/__tests__/Result.test.js
@@ -1,0 +1,83 @@
+import React from "react";
+import { shallow } from "enzyme";
+import { ResultContainer } from "../Result";
+
+const params = {
+  result: {
+    id: {
+      raw: "id",
+      snippet: "<em>id</em>"
+    },
+    title: {
+      raw: "title",
+      snippet: "<em>title</em>"
+    },
+    url: {
+      raw: "url",
+      snippet: "<em>url</em>"
+    }
+  },
+  trackClickThrough: jest.fn(),
+  titleField: "title",
+  urlField: "url"
+};
+
+beforeEach(() => {
+  params.trackClickThrough = jest.fn();
+});
+
+it("renders correctly", () => {
+  const wrapper = shallow(<ResultContainer {...params} />);
+  expect(wrapper).toMatchSnapshot();
+});
+
+describe("link clicks", () => {
+  it("will call back when a document link is clicked in the view", () => {
+    const wrapper = shallow(<ResultContainer {...params} />);
+
+    wrapper
+      .find("Result")
+      .at(0)
+      .prop("onClickLink")();
+
+    const [id] = params.trackClickThrough.mock.calls[0];
+    expect(id).toEqual("id");
+  });
+
+  it("will not call back when shouldTrackClickThrough is false", () => {
+    const wrapper = shallow(
+      <ResultContainer {...params} shouldTrackClickThrough={false} />
+    );
+
+    wrapper
+      .find("Result")
+      .at(0)
+      .prop("onClickLink")();
+
+    expect(params.trackClickThrough.mock.calls.length).toEqual(0);
+  });
+
+  it("will pass through tags", () => {
+    const wrapper = shallow(
+      <ResultContainer {...params} clickThroughTags={["whatever"]} />
+    );
+
+    wrapper
+      .find("Result")
+      .at(0)
+      .prop("onClickLink")();
+
+    const [id, tags] = params.trackClickThrough.mock.calls[0];
+    expect(id).toEqual("id");
+    expect(tags).toEqual(["whatever"]);
+  });
+});
+
+it("supports a render prop", () => {
+  // eslint-disable-next-line react/prop-types
+  const render = ({ children }) => {
+    return <div>{children}</div>;
+  };
+  const wrapper = shallow(<ResultContainer {...params} view={render} />);
+  expect(wrapper.find(render).dive()).toMatchSnapshot();
+});

--- a/packages/react-search-ui/src/containers/__tests__/Results.test.js
+++ b/packages/react-search-ui/src/containers/__tests__/Results.test.js
@@ -33,14 +33,9 @@ const params = {
       }
     }
   ],
-  trackClickThrough: jest.fn(),
   titleField: "title",
   urlField: "url"
 };
-
-beforeEach(() => {
-  params.trackClickThrough = jest.fn();
-});
 
 it("renders correctly", () => {
   const wrapper = shallow(<ResultsContainer {...params} />);
@@ -56,25 +51,61 @@ it("supports a render prop", () => {
   expect(wrapper.find(render).dive()).toMatchSnapshot();
 });
 
-it("supports an individual result render prop", () => {
+it("passes through props to individual Result items", () => {
   // eslint-disable-next-line react/prop-types
   const renderResult = ({ title }) => {
     return <li>{title}</li>;
   };
   const wrapper = shallow(
-    <ResultsContainer {...params} renderResult={renderResult} />
+    <ResultsContainer
+      {...params}
+      renderResult={renderResult}
+      shouldTrackClickThrough={true}
+      clickThroughTags={["whatever"]}
+    />
   );
-  expect(wrapper.find(renderResult).map(n => n.dive())).toMatchSnapshot();
-});
-
-it("will call back when a document link is clicked in the view", () => {
-  const wrapper = shallow(<ResultsContainer {...params} />);
-
-  wrapper
-    .find("Result")
-    .at(0)
-    .prop("onClickLink")();
-
-  const clickThrough = params.trackClickThrough.mock.calls[0][0];
-  expect(clickThrough).toEqual("id");
+  expect(wrapper.find("WithSearch").map(n => n.props())).toEqual([
+    {
+      result: {
+        id: {
+          raw: "id",
+          snippet: "<em>id</em>"
+        },
+        title: {
+          raw: "title",
+          snippet: "<em>title</em>"
+        },
+        url: {
+          raw: "url",
+          snippet: "<em>url</em>"
+        }
+      },
+      titleField: "title",
+      urlField: "url",
+      shouldTrackClickThrough: true,
+      clickThroughTags: ["whatever"],
+      view: renderResult
+    },
+    {
+      result: {
+        id: {
+          raw: "id",
+          snippet: "<em>id</em>"
+        },
+        title: {
+          raw: "title",
+          snippet: "<em>title</em>"
+        },
+        url: {
+          raw: "url",
+          snippet: "<em>url</em>"
+        }
+      },
+      titleField: "title",
+      urlField: "url",
+      shouldTrackClickThrough: true,
+      clickThroughTags: ["whatever"],
+      view: renderResult
+    }
+  ]);
 });

--- a/packages/react-search-ui/src/containers/__tests__/__snapshots__/Result.test.js.snap
+++ b/packages/react-search-ui/src/containers/__tests__/__snapshots__/Result.test.js.snap
@@ -1,0 +1,19 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders correctly 1`] = `
+<Result
+  fields={
+    Object {
+      "id": "<em>id</em>",
+      "title": "<em>title</em>",
+      "url": "<em>url</em>",
+    }
+  }
+  key="result-id"
+  onClickLink={[Function]}
+  title="<em>title</em>"
+  url="url"
+/>
+`;
+
+exports[`supports a render prop 1`] = `<div />`;

--- a/packages/react-search-ui/src/containers/__tests__/__snapshots__/Results.test.js.snap
+++ b/packages/react-search-ui/src/containers/__tests__/__snapshots__/Results.test.js.snap
@@ -2,73 +2,106 @@
 
 exports[`renders correctly 1`] = `
 <Results>
-  <Result
-    fields={
+  <WithSearch
+    clickThroughTags={Array []}
+    key="result-id"
+    result={
       Object {
-        "id": "<em>id</em>",
-        "title": "<em>title</em>",
-        "url": "<em>url</em>",
+        "id": Object {
+          "raw": "id",
+          "snippet": "<em>id</em>",
+        },
+        "title": Object {
+          "raw": "title",
+          "snippet": "<em>title</em>",
+        },
+        "url": Object {
+          "raw": "url",
+          "snippet": "<em>url</em>",
+        },
       }
     }
-    key="result-id"
-    onClickLink={[Function]}
-    title="<em>title</em>"
-    url="url"
+    shouldTrackClickThrough={true}
+    titleField="title"
+    urlField="url"
+    view={[Function]}
   />
-  <Result
-    fields={
+  <WithSearch
+    clickThroughTags={Array []}
+    key="result-id"
+    result={
       Object {
-        "id": "<em>id</em>",
-        "title": "<em>title</em>",
-        "url": "<em>url</em>",
+        "id": Object {
+          "raw": "id",
+          "snippet": "<em>id</em>",
+        },
+        "title": Object {
+          "raw": "title",
+          "snippet": "<em>title</em>",
+        },
+        "url": Object {
+          "raw": "url",
+          "snippet": "<em>url</em>",
+        },
       }
     }
-    key="result-id"
-    onClickLink={[Function]}
-    title="<em>title</em>"
-    url="url"
+    shouldTrackClickThrough={true}
+    titleField="title"
+    urlField="url"
+    view={[Function]}
   />
 </Results>
 `;
 
 exports[`supports a render prop 1`] = `
 <div>
-  <Result
-    fields={
+  <WithSearch
+    clickThroughTags={Array []}
+    key="result-id"
+    result={
       Object {
-        "id": "<em>id</em>",
-        "title": "<em>title</em>",
-        "url": "<em>url</em>",
+        "id": Object {
+          "raw": "id",
+          "snippet": "<em>id</em>",
+        },
+        "title": Object {
+          "raw": "title",
+          "snippet": "<em>title</em>",
+        },
+        "url": Object {
+          "raw": "url",
+          "snippet": "<em>url</em>",
+        },
       }
     }
-    key="result-id"
-    onClickLink={[Function]}
-    title="<em>title</em>"
-    url="url"
+    shouldTrackClickThrough={true}
+    titleField="title"
+    urlField="url"
+    view={[Function]}
   />
-  <Result
-    fields={
+  <WithSearch
+    clickThroughTags={Array []}
+    key="result-id"
+    result={
       Object {
-        "id": "<em>id</em>",
-        "title": "<em>title</em>",
-        "url": "<em>url</em>",
+        "id": Object {
+          "raw": "id",
+          "snippet": "<em>id</em>",
+        },
+        "title": Object {
+          "raw": "title",
+          "snippet": "<em>title</em>",
+        },
+        "url": Object {
+          "raw": "url",
+          "snippet": "<em>url</em>",
+        },
       }
     }
-    key="result-id"
-    onClickLink={[Function]}
-    title="<em>title</em>"
-    url="url"
+    shouldTrackClickThrough={true}
+    titleField="title"
+    urlField="url"
+    view={[Function]}
   />
 </div>
-`;
-
-exports[`supports an individual result render prop 1`] = `
-Array [
-  <li>
-    &lt;em&gt;title&lt;/em&gt;
-  </li>,
-  <li>
-    &lt;em&gt;title&lt;/em&gt;
-  </li>,
-]
 `;

--- a/packages/react-search-ui/src/containers/__tests__/__snapshots__/SearchBox.test.js.snap
+++ b/packages/react-search-ui/src/containers/__tests__/__snapshots__/SearchBox.test.js.snap
@@ -11,6 +11,7 @@ exports[`renders correctly 1`] = `
     }
   }
   isFocused={false}
+  notifyAutocompleteSelected={[Function]}
   onChange={[Function]}
   onSubmit={[Function]}
   useAutocomplete={false}

--- a/packages/react-search-ui/src/containers/index.js
+++ b/packages/react-search-ui/src/containers/index.js
@@ -2,6 +2,7 @@ export { default as ErrorBoundary } from "./ErrorBoundary";
 export { default as Facet } from "./Facet";
 export { default as Paging } from "./Paging";
 export { default as PagingInfo } from "./PagingInfo";
+export { default as Result } from "./Result";
 export { default as Results } from "./Results";
 export { default as ResultsPerPage } from "./ResultsPerPage";
 export { default as SearchBox } from "./SearchBox";

--- a/packages/search-ui-app-search-connector/src/AppSearchAPIConnector.js
+++ b/packages/search-ui-app-search-connector/src/AppSearchAPIConnector.js
@@ -35,7 +35,13 @@ export default class AppSearchAPIConnector {
     this.additionalOptions = additionalOptions;
   }
 
-  click({ query, documentId, requestId, tags }) {
+  click({ query, documentId, requestId, tags = [] }) {
+    tags = tags.concat("results");
+    return this.client.click({ query, documentId, requestId, tags });
+  }
+
+  autocompleteClick({ query, documentId, requestId, tags = [] }) {
+    tags = tags.concat("autocomplete");
     return this.client.click({ query, documentId, requestId, tags });
   }
 

--- a/packages/search-ui-app-search-connector/src/__tests__/AppSearchAPIConnector.test.js
+++ b/packages/search-ui-app-search-connector/src/__tests__/AppSearchAPIConnector.test.js
@@ -45,6 +45,10 @@ function getLastSearchCall() {
   return mockClient.search.mock.calls[0];
 }
 
+function getLastClickCall() {
+  return mockClient.click.mock.calls[0];
+}
+
 describe("AppSearchAPIConnector", () => {
   it("can be initialized", () => {
     const connector = new AppSearchAPIConnector(params);
@@ -55,6 +59,74 @@ describe("AppSearchAPIConnector", () => {
     expect(() => {
       new AppSearchAPIConnector({});
     }).toThrow();
+  });
+
+  describe("click", () => {
+    function subject() {
+      const connector = new AppSearchAPIConnector({
+        ...params
+      });
+
+      return connector.click({
+        query: "test",
+        documentId: "11111",
+        requestId: "12345",
+        tags: ["test"]
+      });
+    }
+
+    it("calls the App Search click endpoint", () => {
+      subject();
+      expect(getLastClickCall()).toBeDefined();
+    });
+
+    it("passes query, documentId, and requestId to the click endpoint", () => {
+      subject();
+      const [{ query, documentId, requestId }] = getLastClickCall();
+      expect(query).toEqual("test");
+      expect(documentId).toEqual("11111");
+      expect(requestId).toEqual("12345");
+    });
+
+    it("appends tags to a base 'results' tag", () => {
+      subject();
+      const [{ tags }] = getLastClickCall();
+      expect(tags).toEqual(["test", "results"]);
+    });
+  });
+
+  describe("autocompleteClick", () => {
+    function subject() {
+      const connector = new AppSearchAPIConnector({
+        ...params
+      });
+
+      return connector.autocompleteClick({
+        query: "test",
+        documentId: "11111",
+        requestId: "12345",
+        tags: ["test"]
+      });
+    }
+
+    it("calls the App Search click endpoint", () => {
+      subject();
+      expect(getLastClickCall()).toBeDefined();
+    });
+
+    it("passes query, documentId, and requestId to the click endpoint", () => {
+      subject();
+      const [{ query, documentId, requestId }] = getLastClickCall();
+      expect(query).toEqual("test");
+      expect(documentId).toEqual("11111");
+      expect(requestId).toEqual("12345");
+    });
+
+    it("appends tags to a base 'autocomplete' tag", () => {
+      subject();
+      const [{ tags }] = getLastClickCall();
+      expect(tags).toEqual(["test", "autocomplete"]);
+    });
   });
 
   describe("search", () => {

--- a/packages/search-ui/src/__tests__/SearchDriver.test.js
+++ b/packages/search-ui/src/__tests__/SearchDriver.test.js
@@ -269,7 +269,7 @@ describe("#getActions", () => {
   it("returns the current state", () => {
     const driver = new SearchDriver(params);
     const actions = driver.getActions();
-    expect(Object.keys(actions).length).toBe(10);
+    expect(Object.keys(actions).length).toBe(11);
     expect(actions.addFilter).toBeInstanceOf(Function);
     expect(actions.clearFilters).toBeInstanceOf(Function);
     expect(actions.removeFilter).toBeInstanceOf(Function);
@@ -280,5 +280,6 @@ describe("#getActions", () => {
     expect(actions.setSort).toBeInstanceOf(Function);
     expect(actions.setCurrent).toBeInstanceOf(Function);
     expect(actions.trackClickThrough).toBeInstanceOf(Function);
+    expect(actions.trackAutocompleteClickThrough).toBeInstanceOf(Function);
   });
 });

--- a/packages/search-ui/src/__tests__/actions/trackAutocompleteClickThrough.test.js
+++ b/packages/search-ui/src/__tests__/actions/trackAutocompleteClickThrough.test.js
@@ -1,0 +1,29 @@
+import { getAutocompleteClickCalls, setupDriver } from "../../test/helpers";
+
+describe("#trackAutocompleteClickThrough", () => {
+  function subject({ initialState } = {}, documentId, tags) {
+    const { driver, mockApiConnector } = setupDriver({ initialState });
+    driver.trackAutocompleteClickThrough(documentId, tags);
+    return { driver, mockApiConnector };
+  }
+
+  it("Calls click on connector", () => {
+    const { mockApiConnector } = subject();
+    expect(getAutocompleteClickCalls(mockApiConnector)).toHaveLength(1);
+  });
+
+  it("Calls Connector 'autocompleteClick' with correct parameters", () => {
+    const { mockApiConnector } = subject(
+      { initialState: { searchTerm: "search terms" } },
+      1,
+      ["test"]
+    );
+    const [{ query, documentId, requestId, tags }] = getAutocompleteClickCalls(
+      mockApiConnector
+    )[0];
+    expect(documentId).toEqual(1);
+    expect(query).toEqual("search terms");
+    expect(tags).toEqual(["test"]);
+    expect(requestId).toEqual("12345");
+  });
+});

--- a/packages/search-ui/src/__tests__/actions/trackClickThrough.test.js
+++ b/packages/search-ui/src/__tests__/actions/trackClickThrough.test.js
@@ -1,0 +1,29 @@
+import { getClickCalls, setupDriver } from "../../test/helpers";
+
+describe("#trackClickThrough", () => {
+  function subject({ initialState } = {}, documentId, tags) {
+    const { driver, mockApiConnector } = setupDriver({ initialState });
+    driver.trackClickThrough(documentId, tags);
+    return { driver, mockApiConnector };
+  }
+
+  it("Calls click on connector", () => {
+    const { mockApiConnector } = subject();
+    expect(getClickCalls(mockApiConnector)).toHaveLength(1);
+  });
+
+  it("Calls Connector 'click' with correct parameters", () => {
+    const { mockApiConnector } = subject(
+      { initialState: { searchTerm: "search terms" } },
+      1,
+      ["test"]
+    );
+    const [{ query, documentId, requestId, tags }] = getClickCalls(
+      mockApiConnector
+    )[0];
+    expect(documentId).toEqual(1);
+    expect(query).toEqual("search terms");
+    expect(tags).toEqual(["test"]);
+    expect(requestId).toEqual("12345");
+  });
+});

--- a/packages/search-ui/src/actions/index.js
+++ b/packages/search-ui/src/actions/index.js
@@ -1,4 +1,7 @@
 export { default as addFilter } from "./addFilter";
+export {
+  default as trackAutocompleteClickThrough
+} from "./trackAutocompleteClickThrough";
 export { default as clearFilters } from "./clearFilters";
 export { default as removeFilter } from "./removeFilter";
 export { default as reset } from "./reset";

--- a/packages/search-ui/src/actions/trackAutocompleteClickThrough.js
+++ b/packages/search-ui/src/actions/trackAutocompleteClickThrough.js
@@ -1,16 +1,16 @@
 /**
  * Report a click through event. A click through event is when a user
- * clicks on a result link.
+ * clicks on a result within an autocomplete Dropdown.
  *
  * @param documentId String The document ID associated with result that was
  * clicked
  * @param tag Array[String] Optional Tags which can be used to categorize
  * this click event
  */
-export default function trackClickThrough(documentId, tags = []) {
+export default function trackAutocompleteClickThrough(documentId, tags = []) {
   const { requestId, searchTerm } = this.state;
 
-  this.apiConnector.click({
+  this.apiConnector.autocompleteClick({
     query: searchTerm,
     documentId,
     requestId,

--- a/packages/search-ui/src/test/helpers.js
+++ b/packages/search-ui/src/test/helpers.js
@@ -14,7 +14,8 @@ export function getMockApiConnector() {
       .fn()
       .mockReturnValue({ then: cb => cb(searchResponse) }),
     search: jest.fn().mockReturnValue({ then: cb => cb(searchResponse) }),
-    click: jest.fn().mockReturnValue({ then: () => {} })
+    click: jest.fn().mockReturnValue({ then: () => {} }),
+    autocompleteClick: jest.fn().mockReturnValue({ then: () => {} })
   };
 }
 
@@ -28,6 +29,9 @@ export function setupDriver({
     .fn()
     .mockReturnValue({ then: cb => cb(searchResponse) });
   mockApiConnector.click = jest.fn().mockReturnValue({ then: () => {} });
+  mockApiConnector.autocompleteClick = jest
+    .fn()
+    .mockReturnValue({ then: () => {} });
 
   trackUrlState =
     trackUrlState === false || trackUrlState === true ? trackUrlState : true;
@@ -86,4 +90,12 @@ export function waitABit(length) {
 
 export function getSearchCalls(mockApiConnector) {
   return mockApiConnector.search.mock.calls;
+}
+
+export function getClickCalls(mockApiConnector) {
+  return mockApiConnector.click.mock.calls;
+}
+
+export function getAutocompleteClickCalls(mockApiConnector) {
+  return mockApiConnector.autocompleteClick.mock.calls;
 }


### PR DESCRIPTION
This PR adds support for configuring clickthrough tracking behavior on Autocomplete.

Design is documented here: https://github.com/elastic/search-ui/issues/113

Changes:

There are now two additional parameters you can pass to the `autocompleteResults` configuration: `shouldTrackClickThrough` and `clickThroughTags`.

```
<SearchBox
  autocompleteResults={{
    shouldTrackClickThrough: true,
    clickThroughTags={['someTag']}
  }}
```

- By default, a clickthrough event WILL be logged any time a user selects a "Result" item from an autocomplete. Note that this will NOT be logged when a "suggestion" is selected, which is not considered a clickthrough event.
- `shouldTrackClickThrough` is optional but can be set to be false to prevent that from occurring by default.
- `clickThroughTags` is optional, it allows you to append analytics tags to the clickthrough API call.

In addition to this change, I updated the `Results` and `Result` components to have a similar API:

```
<Results
    titleField="title"
    urlField="nps_link"
    shouldTrackClickThrough={true}
    clickThroughTags={['whatever']}
/>
```

From a View perspective, in the autocomplete, the view implementor will need to call the provided `notifyAutocompleteSelected` in order to have their clickthrough tracked.

From a Connector perspective, there are two different functions that need to be implemented for tracking these things:

```
click - Track a clickthrough on a result
autocompleteClick - Track a clickthrough on an autocomplete
```

In the Site Search connector, there are two different API endpoints that can be used to track these things separate (will be implemented in a separate PR).

In the App Search connector, there is only a SINGLE click endpoint, so we need some way to distinguish between these two types of clickthroughs. I am simply sending different tags on the click call, depending on which type of event it is... `['results']` for a result clickthrough, and `['autocomplete']` for an autocomplete clickthrough.

Other changes:
- To make the change to Results I describe above, I had to Refactor the `Results` container into separate `Results` and `Result` containers, which is a more flexible experience for users anyway.
- Backfilled some tests

To test this, run the sandbox app and play around with the autocomplete: https://github.com/elastic/search-ui/tree/master/examples/sandbox

You'll then be able to play with the component config in `App.js` and watch the outgoing API calls:

![latest](https://user-images.githubusercontent.com/1427475/55239664-858a5a00-520d-11e9-9d51-7d84087f0430.gif)
