### PR TITLE
Added autocompleteMinimumCharacters to SearchBox

### DIFF
--- a/examples/sandbox/src/App.js
+++ b/examples/sandbox/src/App.js
@@ -90,6 +90,7 @@ export default function App() {
             <Layout
               header={
                 <SearchBox
+                  autocompleteMinimumCharacters={3}
                   autocompleteResults={{
                     linkTarget: "_blank",
                     sectionTitle: "Results",

--- a/packages/react-search-ui/src/containers/SearchBox.js
+++ b/packages/react-search-ui/src/containers/SearchBox.js
@@ -8,7 +8,7 @@ import { Result } from "../types";
 export class SearchBoxContainer extends Component {
   static propTypes = {
     // Props
-    autocompleteView: PropTypes.func,
+    autocompleteMinimumCharacters: PropTypes.number,
     autocompleteResults: PropTypes.oneOfType([
       PropTypes.bool,
       PropTypes.shape({
@@ -20,6 +20,7 @@ export class SearchBoxContainer extends Component {
         urlField: PropTypes.string.isRequired
       })
     ]),
+    autocompleteView: PropTypes.func,
     debounceLength: PropTypes.number,
     inputProps: PropTypes.object,
     onSelectAutocomplete: PropTypes.func,
@@ -58,6 +59,7 @@ export class SearchBoxContainer extends Component {
 
   handleChange = value => {
     const {
+      autocompleteMinimumCharacters,
       autocompleteResults,
       searchAsYouType,
       setSearchTerm,
@@ -65,6 +67,7 @@ export class SearchBoxContainer extends Component {
     } = this.props;
 
     const options = {
+      autocompleteMinimumCharacters,
       ...((autocompleteResults || searchAsYouType) && {
         debounce: debounceLength || 200
       }),
@@ -93,6 +96,7 @@ export class SearchBoxContainer extends Component {
   render() {
     const { isFocused } = this.state;
     const {
+      autocompleteMinimumCharacters = 0,
       autocompleteResults,
       autocompletedResults,
       inputProps,
@@ -102,6 +106,9 @@ export class SearchBoxContainer extends Component {
     } = this.props;
 
     const View = view || SearchBox;
+    const useAutocomplete =
+      !!autocompleteResults &&
+      searchTerm.length >= autocompleteMinimumCharacters;
 
     return (
       <View
@@ -113,7 +120,7 @@ export class SearchBoxContainer extends Component {
         onChange={value => this.handleChange(value)}
         onSelectAutocomplete={onSelectAutocomplete}
         onSubmit={this.handleSubmit}
-        useAutocomplete={!!autocompleteResults}
+        useAutocomplete={useAutocomplete}
         value={searchTerm}
         inputProps={{
           onFocus: this.handleFocus,

--- a/packages/react-search-ui/src/containers/__tests__/SearchBox.test.js
+++ b/packages/react-search-ui/src/containers/__tests__/SearchBox.test.js
@@ -85,6 +85,23 @@ it("will call back to setSearchTerm with refresh: false when input is changed", 
   ]);
 });
 
+it("will call back to setSearchTerm with autocompleteMinimumCharacters setting", () => {
+  const wrapper = shallow(
+    <SearchBoxContainer {...params} autocompleteMinimumCharacters={3} />
+  );
+  wrapper.find("SearchBox").prop("onChange")("new term");
+
+  const call = params.setSearchTerm.mock.calls[0];
+  expect(call).toEqual([
+    "new term",
+    {
+      refresh: false,
+      autocompleteResults: false,
+      autocompleteMinimumCharacters: 3
+    }
+  ]);
+});
+
 it("will call back to setSearchTerm with refresh: true when input is changed and searchAsYouType is true", () => {
   const wrapper = shallow(
     <SearchBoxContainer {...params} searchAsYouType={true} />

--- a/packages/search-ui/src/__tests__/actions/setSearchTerm.test.js
+++ b/packages/search-ui/src/__tests__/actions/setSearchTerm.test.js
@@ -1,4 +1,9 @@
-import { getSearchCalls, setupDriver, waitABit } from "../../test/helpers";
+import {
+  getAutocompleteResultsCalls,
+  getSearchCalls,
+  setupDriver,
+  waitABit
+} from "../../test/helpers";
 import {
   itResetsCurrent,
   itResetsFilters,
@@ -106,26 +111,71 @@ describe("#setSearchTerm", () => {
   describe("when autocompleteResults is true", () => {
     it("updates autocompletedResults", () => {
       expect(
-        subject("term", { autocompleteResults: true }).state
+        subject("term", { autocompleteResults: true, refresh: false }).state
           .autocompletedResults
       ).toEqual([{}, {}]);
     });
 
     it("Will not debounce requests if there is no debounce specified", async () => {
       const { driver, mockApiConnector } = setupDriver();
-      driver.setSearchTerm("term", { autocompleteResults: true });
-      driver.setSearchTerm("term", { autocompleteResults: true });
-      driver.setSearchTerm("term", { autocompleteResults: true });
-      expect(getSearchCalls(mockApiConnector)).toHaveLength(3);
+      driver.setSearchTerm("term", {
+        autocompleteResults: true,
+        refresh: false
+      });
+      driver.setSearchTerm("term", {
+        autocompleteResults: true,
+        refresh: false
+      });
+      driver.setSearchTerm("term", {
+        autocompleteResults: true,
+        refresh: false
+      });
+      expect(getAutocompleteResultsCalls(mockApiConnector)).toHaveLength(3);
     });
 
     it("Will debounce requests", async () => {
       const { driver, mockApiConnector } = setupDriver();
-      driver.setSearchTerm("term", { autocompleteResults: true, debounce: 10 });
-      driver.setSearchTerm("term", { autocompleteResults: true, debounce: 10 });
-      driver.setSearchTerm("term", { autocompleteResults: true, debounce: 10 });
+      driver.setSearchTerm("term", {
+        autocompleteResults: true,
+        debounce: 10,
+        refresh: false
+      });
+      driver.setSearchTerm("term", {
+        autocompleteResults: true,
+        debounce: 10,
+        refresh: false
+      });
+      driver.setSearchTerm("term", {
+        autocompleteResults: true,
+        debounce: 10,
+        refresh: false
+      });
       await waitABit(100);
-      expect(getSearchCalls(mockApiConnector)).toHaveLength(1);
+      expect(getAutocompleteResultsCalls(mockApiConnector)).toHaveLength(1);
+    });
+
+    describe("and autocompleteMinimumCharacters is set and less than requirement", () => {
+      it("it will not trigger", () => {
+        const { driver, mockApiConnector } = setupDriver();
+        driver.setSearchTerm("term", {
+          autocompleteMinimumCharacters: 5,
+          autocompleteResults: true,
+          refresh: false
+        });
+        expect(getAutocompleteResultsCalls(mockApiConnector)).toHaveLength(0);
+      });
+    });
+
+    describe("and autocompleteMinimumCharacters is set and greater than requirement", () => {
+      it("it will not trigger", () => {
+        const { driver, mockApiConnector } = setupDriver();
+        driver.setSearchTerm("term", {
+          autocompleteMinimumCharacters: 2,
+          autocompleteResults: true,
+          refresh: false
+        });
+        expect(getAutocompleteResultsCalls(mockApiConnector)).toHaveLength(1);
+      });
     });
   });
 

--- a/packages/search-ui/src/actions/setSearchTerm.js
+++ b/packages/search-ui/src/actions/setSearchTerm.js
@@ -5,13 +5,21 @@
  *
  * @param searchTerm String
  * @param options Object Additional objects
- * @param options.autocompleteResults Fetch autocomplete results?
+ * @param autocompleteMinimumCharacters Number Only trigger autocomplete if
+ * searchTerm has at least this number of characters
+ * @param options.autocompleteResults Boolean Fetch autocomplete
+ * results?
  * @param options.refresh Boolean Refresh search results?
  * @param options.debounce Length to debounce API calls
  */
 export default function setSearchTerm(
   searchTerm,
-  { autocompleteResults = false, refresh = true, debounce = 0 } = {}
+  {
+    autocompleteMinimumCharacters = 0,
+    autocompleteResults = false,
+    refresh = true,
+    debounce = 0
+  } = {}
 ) {
   this._setState({ searchTerm });
 
@@ -27,7 +35,10 @@ export default function setSearchTerm(
     );
   }
 
-  if (autocompleteResults) {
+  if (
+    autocompleteResults &&
+    searchTerm.length > autocompleteMinimumCharacters
+  ) {
     this.debounceManager.runWithDebounce(
       debounce,
       this._updateAutocompleteResults,

--- a/packages/search-ui/src/test/helpers.js
+++ b/packages/search-ui/src/test/helpers.js
@@ -25,13 +25,6 @@ export function setupDriver({
   trackUrlState
 } = {}) {
   const mockApiConnector = getMockApiConnector();
-  mockApiConnector.search = jest
-    .fn()
-    .mockReturnValue({ then: cb => cb(searchResponse) });
-  mockApiConnector.click = jest.fn().mockReturnValue({ then: () => {} });
-  mockApiConnector.autocompleteClick = jest
-    .fn()
-    .mockReturnValue({ then: () => {} });
 
   trackUrlState =
     trackUrlState === false || trackUrlState === true ? trackUrlState : true;
@@ -90,6 +83,10 @@ export function waitABit(length) {
 
 export function getSearchCalls(mockApiConnector) {
   return mockApiConnector.search.mock.calls;
+}
+
+export function getAutocompleteResultsCalls(mockApiConnector) {
+  return mockApiConnector.autocompleteResults.mock.calls;
 }
 
 export function getClickCalls(mockApiConnector) {


### PR DESCRIPTION
This PR adds support for `autocompleteMinimumCharacters` on Autocomplete.

Design is documented here: https://github.com/elastic/search-ui/issues/113

```
                <SearchBox
                  autocompleteMinimumCharacters={3}
                  autocompleteResults={{
                    titleField: "title",
                    urlField: "nps_link"
                  }}
                />
```

This prevent the autocomplete box from making a query or showing until at least the minimum amount of characters have been entered.

![latest](https://user-images.githubusercontent.com/1427475/55260917-fc404b00-523f-11e9-8b1c-4c589dc668ab.gif)
