### PR TITLE
Moved SearchDriver init to CDM in SearchProvider

### DIFF
--- a/examples/sandbox/package.json
+++ b/examples/sandbox/package.json
@@ -1,13 +1,13 @@
 {
   "name": "sandbox",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "private": true,
   "dependencies": {
-    "@elastic/react-search-ui": "^0.5.1",
-    "@elastic/react-search-ui-views": "^0.5.1",
-    "@elastic/search-ui": "^0.5.1",
-    "@elastic/search-ui-app-search-connector": "^0.5.1",
-    "@elastic/search-ui-site-search-connector": "^0.5.1",
+    "@elastic/react-search-ui": "^0.5.2",
+    "@elastic/react-search-ui-views": "^0.5.2",
+    "@elastic/search-ui": "^0.5.2",
+    "@elastic/search-ui-app-search-connector": "^0.5.2",
+    "@elastic/search-ui-site-search-connector": "^0.5.2",
     "react": "^16.8.1",
     "react-dom": "^16.8.1",
     "react-scripts": "2.1.5"

--- a/lerna.json
+++ b/lerna.json
@@ -3,7 +3,7 @@
     "examples/*",
     "packages/*"
   ],
-  "version": "0.5.1",
+  "version": "0.5.2",
   "command": {
     "publish": {
       "ignoreChanges": [

--- a/packages/react-search-ui-views/CHANGELOG.md
+++ b/packages/react-search-ui-views/CHANGELOG.md
@@ -35,3 +35,7 @@ Breaking Changes:
 ## 0.5.1 (March 7, 2019)
 
 Fixed this error: "ReferenceError: regeneratorRuntime is not defined"
+
+## 0.5.2 (April 1, 2019)
+
+Moved SearchDriver creation to componentDidMount

--- a/packages/react-search-ui-views/package.json
+++ b/packages/react-search-ui-views/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elastic/react-search-ui-views",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "A collection of React UI components for building search experiences",
   "license": "Apache-2.0",
   "main": "lib",

--- a/packages/react-search-ui/package.json
+++ b/packages/react-search-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elastic/react-search-ui",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "A React library for building search experiences",
   "license": "Apache-2.0",
   "main": "lib",
@@ -32,8 +32,8 @@
   },
   "dependencies": {
     "@babel/polyfill": "^7.2.5",
-    "@elastic/react-search-ui-views": "^0.5.1",
-    "@elastic/search-ui": "^0.5.1",
+    "@elastic/react-search-ui-views": "^0.5.2",
+    "@elastic/search-ui": "^0.5.2",
     "debounce-fn": "^1.0.0"
   },
   "peerDependencies": {

--- a/packages/react-search-ui/src/SearchProvider.js
+++ b/packages/react-search-ui/src/SearchProvider.js
@@ -37,15 +37,16 @@ class SearchProvider extends Component {
     })
   };
 
-  constructor(props) {
-    super(props);
-    this.driver = new SearchDriver(props.config);
-    this.state = this.driver.getState();
+  componentDidMount() {
+    const { config } = this.props;
+    this.driver = new SearchDriver(config);
+    this.setState(this.driver.getState());
     this.driver.subscribeToStateChanges(state => this.setState(state));
   }
 
   render() {
     const { children } = this.props;
+    if (!this.driver) return null;
 
     const providerValue = {
       ...this.state,

--- a/packages/search-ui-app-search-connector/package.json
+++ b/packages/search-ui-app-search-connector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elastic/search-ui-app-search-connector",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "A Search UI connector for Elastic's App Search Service",
   "license": "Apache-2.0",
   "main": "lib",

--- a/packages/search-ui-elasticsearch-connector/package.json
+++ b/packages/search-ui-elasticsearch-connector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elastic/search-ui-elasticsearch-connector",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "A Search UI connector for elasticsearch",
   "license": "Apache-2.0",
   "main": "lib",

--- a/packages/search-ui-site-search-connector/package.json
+++ b/packages/search-ui-site-search-connector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elastic/search-ui-site-search-connector",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "A Search UI connector for Elastic's Site Search Service",
   "license": "Apache-2.0",
   "main": "lib",

--- a/packages/search-ui/package.json
+++ b/packages/search-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elastic/search-ui",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "A Headless Search UI library",
   "license": "Apache-2.0",
   "main": "lib",


### PR DESCRIPTION
Moved SearchDriver initialization to ComponentDidMount in SearchProvider
to make sure that Server Side Rendering does not attempt to render
Search UI. Search UI is dependent on a browser environment to support
history and routing. Until we can find a better way to support
SSR, I have moved it to CDM to at least avoid errors.