### PR TITLE
Added autocomplete support for Site Search

### DIFF
--- a/packages/search-ui-site-search-connector/src/SiteSearchAPIConnector.js
+++ b/packages/search-ui-site-search-connector/src/SiteSearchAPIConnector.js
@@ -40,10 +40,38 @@ export default class SiteSearchAPIConnector {
     });
   }
 
+  autocompleteClick({ query, documentId, tags }) {
+    if (tags) {
+      console.warn(
+        "search-ui-site-search-connector: Site Search does not support tags on autocompleteClick"
+      );
+    }
+    this._get("analytics/pas", {
+      t: new Date().getTime(),
+      q: query,
+      doc_id: documentId
+    });
+  }
+
   search(state, queryConfig) {
     const options = adaptRequest(state, queryConfig, this.documentType);
 
     return this.request("POST", "engines/search.json", {
+      ...options,
+      ...this.additionalOptions(options)
+    }).then(json => {
+      return adaptResponse(json, this.documentType);
+    });
+  }
+
+  async autocompleteResults({ searchTerm }, queryConfig) {
+    const options = adaptRequest(
+      { searchTerm },
+      queryConfig,
+      this.documentType
+    );
+
+    return this.request("POST", "engines/suggest.json", {
       ...options,
       ...this.additionalOptions(options)
     }).then(json => {

--- a/packages/search-ui-site-search-connector/src/__tests__/__snapshots__/SiteSearchAPIConnector.test.js.snap
+++ b/packages/search-ui-site-search-connector/src/__tests__/__snapshots__/SiteSearchAPIConnector.test.js.snap
@@ -1,5 +1,81 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`#autocompleteResults will correctly format an API response 1`] = `
+Object {
+  "facets": Object {
+    "states": Array [
+      Object {
+        "data": Array [
+          Object {
+            "count": 2,
+            "value": "Maine",
+          },
+        ],
+        "field": "states",
+        "type": "value",
+      },
+    ],
+  },
+  "requestId": "",
+  "results": Array [
+    Object {
+      "acres": Object {
+        "raw": 49057.36,
+      },
+      "external_id": Object {
+        "raw": "9000",
+      },
+      "id": Object {
+        "raw": "5beb474f8db2315427beecc7",
+      },
+      "nps_link": Object {
+        "raw": "https://www.nps.gov/acad/index.htm",
+      },
+      "states": Object {
+        "raw": Array [
+          "Maine",
+        ],
+      },
+      "title": Object {
+        "raw": "Acadia",
+        "snippet": "<em>Acadia</em>",
+      },
+      "updated_at": Object {
+        "raw": "2018-11-13T21:51:11+00:00",
+      },
+    },
+    Object {
+      "acres": Object {
+        "raw": 49057.36,
+      },
+      "external_id": Object {
+        "raw": "0",
+      },
+      "id": Object {
+        "raw": "5beb47b8a1f2532eb09be102",
+      },
+      "nps_link": Object {
+        "raw": "https://www.nps.gov/acad/index.htm",
+      },
+      "states": Object {
+        "raw": Array [
+          "Maine",
+        ],
+      },
+      "title": Object {
+        "raw": "Acadia",
+        "snippet": "<em>Acadia</em>",
+      },
+      "updated_at": Object {
+        "raw": "2018-11-13T21:52:56+00:00",
+      },
+    },
+  ],
+  "totalPages": 1,
+  "totalResults": 2,
+}
+`;
+
 exports[`#search will correctly format an API response 1`] = `
 Object {
   "facets": Object {

--- a/packages/search-ui-site-search-connector/src/responseAdapters.js
+++ b/packages/search-ui-site-search-connector/src/responseAdapters.js
@@ -4,6 +4,8 @@ const addEachKeyValueToObject = (acc, [key, value]) => ({
 });
 
 export function getFacets(docInfo) {
+  if (!docInfo.facets) return {};
+
   return Object.entries(docInfo.facets)
     .map(([facetName, facetValue]) => {
       return [


### PR DESCRIPTION
This PR adds autocomplete support to the Site Search connector.

Design is documented here: https://github.com/elastic/search-ui/issues/113.

To test this, run the sandbox app and play around with the autocomplete: https://github.com/elastic/search-ui/tree/master/examples/sandbox.

You'll need to switch to use the Site Search connector. You can use the following credentials in `App.js`.

```js
import SiteSearchAPIConnector from "@elastic/search-ui-site-search-connector";
```

```js
const connector = new SiteSearchAPIConnector({
  engineKey: "Z43R5U3HiDsDgpKawZkA",
  documentType: "national-parks",
  additionalOptions: () => ({})
});
```