### PR TITLE
Allow query configuration of  sort, filters, etc. for Autocomplete queries

### DIFF
--- a/examples/sandbox/src/App.js
+++ b/examples/sandbox/src/App.js
@@ -62,8 +62,13 @@ export default function App() {
             }
           }
         },
+        initialState: {
+          sortField: "title",
+          sortDirection: "asc"
+        },
         autocompleteQuery: {
           results: {
+            resultsPerPage: 5,
             search_fields: {
               title: {},
               description: {}

--- a/packages/search-ui-app-search-connector/src/AppSearchAPIConnector.js
+++ b/packages/search-ui-app-search-connector/src/AppSearchAPIConnector.js
@@ -58,8 +58,26 @@ export default class AppSearchAPIConnector {
   }
 
   async autocompleteResults({ searchTerm }, queryConfig) {
-    const { query, ...optionsFromState } = adaptRequest({ searchTerm });
-    const withQueryConfigOptions = { ...queryConfig, ...optionsFromState };
+    const {
+      filters,
+      resultsPerPage,
+      sortDirection,
+      sortField,
+      ...restOfQueryConfig
+    } = queryConfig;
+
+    const { query, ...optionsFromState } = adaptRequest({
+      searchTerm,
+      filters,
+      resultsPerPage,
+      sortDirection,
+      sortField
+    });
+
+    const withQueryConfigOptions = {
+      ...restOfQueryConfig,
+      ...optionsFromState
+    };
     const options = {
       ...withQueryConfigOptions,
       ...this.additionalOptions(withQueryConfigOptions)

--- a/packages/search-ui-app-search-connector/src/AppSearchAPIConnector.js
+++ b/packages/search-ui-app-search-connector/src/AppSearchAPIConnector.js
@@ -46,8 +46,28 @@ export default class AppSearchAPIConnector {
   }
 
   async search(state, queryConfig) {
-    const { query, ...optionsFromState } = adaptRequest(state);
-    const withQueryConfigOptions = { ...queryConfig, ...optionsFromState };
+    const {
+      current,
+      filters,
+      resultsPerPage,
+      sortDirection,
+      sortField,
+      ...restOfQueryConfig
+    } = queryConfig;
+
+    const { query, ...optionsFromState } = adaptRequest({
+      ...state,
+      ...(current !== undefined && { current }),
+      ...(filters !== undefined && { filters }),
+      ...(resultsPerPage !== undefined && { resultsPerPage }),
+      ...(sortDirection !== undefined && { sortDirection }),
+      ...(sortField !== undefined && { sortField })
+    });
+
+    const withQueryConfigOptions = {
+      ...restOfQueryConfig,
+      ...optionsFromState
+    };
     const options = {
       ...withQueryConfigOptions,
       ...this.additionalOptions(withQueryConfigOptions)
@@ -59,6 +79,7 @@ export default class AppSearchAPIConnector {
 
   async autocompleteResults({ searchTerm }, queryConfig) {
     const {
+      current,
       filters,
       resultsPerPage,
       sortDirection,
@@ -67,6 +88,7 @@ export default class AppSearchAPIConnector {
     } = queryConfig;
 
     const { query, ...optionsFromState } = adaptRequest({
+      current,
       searchTerm,
       filters,
       resultsPerPage,

--- a/packages/search-ui-site-search-connector/src/requestAdapter.js
+++ b/packages/search-ui-site-search-connector/src/requestAdapter.js
@@ -21,11 +21,23 @@ export default function adaptRequest(request, queryConfig, documentType) {
   }
 
   const updatedFacets = adaptFacetConfig(queryConfig.facets);
-  const updatedFilters = adaptFilterConfig(request.filters);
-  const page = request.current;
-  const per_page = request.resultsPerPage;
-  const sortDirection = request.sortDirection;
-  const sortField = request.sortField;
+  const updatedFilters = adaptFilterConfig(
+    queryConfig.filters !== undefined ? queryConfig.filters : request.filters
+  );
+  const page =
+    queryConfig.current !== undefined ? queryConfig.current : request.current;
+  const per_page =
+    queryConfig.resultsPerPage !== undefined
+      ? queryConfig.resultsPerPage
+      : request.resultsPerPage;
+  const sortDirection =
+    queryConfig.sortDirection !== undefined
+      ? queryConfig.sortDirection
+      : request.sortDirection;
+  const sortField =
+    queryConfig.sortField !== undefined
+      ? queryConfig.sortField
+      : request.sortField;
   const [fetchFields, highlightFields] = adaptResultFieldsConfig(
     queryConfig.result_fields
   );


### PR DESCRIPTION
This change allows [Request State](https://github.com/elastic/search-ui/tree/master/packages/react-search-ui#state) parameters to be provided in query configuration. 

Design is documented here: https://github.com/elastic/search-ui/issues/113.

Request State is things like "filters", "resultsPerPage", "sort", etc. Parameters that get fed into a search query but are managed as part of state. I.e., if a user selects a "sort" from a page, it gets passed to the query.

ex.
```jsx
<SearchProvider
      config={{
        autocompleteQuery: {
          results: {
            search_fields: {
              title: {},
              description: {}
            },
            result_fields: {
              title: {
                snippet: {
                  size: 100,
                  fallback: true
                }
              }
            },
            current: 2,
            resultsPerPage: 5,
            filters: [
              {
                field: "world_heritage_site",
                values: ["true"],
                type: "all"
              }
            ],
            sortDirection: "desc",
            sortField: "name"
          }
        }
      }}
    >
</SearchProvider>
```

Perviously, query configuration only accepted query parameters that are not managed in state. Things that are static for every request ... "result_fields", "search_fields", "facets.

This is important for autocomplete, since __Request State parameters are NOT applied to autocomplete queries__. Meaning, if a user makes a filter selection in the UI, it is NOT applied to autocomplete. So if a user needs an autocomplete to be filtered, sorted, etc, they need to pass these parameters to query config.

This is also now an option for regular query configuration as well. So they can choose to apply a static sort for example, that is not fed from state, rather than having a sort that is tied to the user selection from state.

To test this, run the sandbox app: https://github.com/elastic/search-ui/tree/master/examples/sandbox.

Update `autocompleteQuery.results` configuration in `App.js` to include:

```
resultsPerPage: 5
```

The number of results displayed on the page in the autocomplete should now be 5.

