### PR TITLE
Fix view rendering logic

### DIFF
--- a/packages/react-search-ui/src/containers/ErrorBoundary.js
+++ b/packages/react-search-ui/src/containers/ErrorBoundary.js
@@ -17,7 +17,7 @@ export class ErrorBoundaryContainer extends Component {
 
     const View = view || ErrorBoundary;
 
-    return <View {...rest} />;
+    return View(rest);
   }
 }
 

--- a/packages/react-search-ui/src/containers/Paging.js
+++ b/packages/react-search-ui/src/containers/Paging.js
@@ -1,5 +1,4 @@
 import PropTypes from "prop-types";
-import React from "react";
 
 import { withSearch } from "..";
 import { Paging } from "@elastic/react-search-ui-views";
@@ -15,16 +14,12 @@ export function PagingContainer({
 
   const View = view || Paging;
 
-  return (
-    <div>
-      <View
-        current={current}
-        resultsPerPage={resultsPerPage}
-        totalPages={totalPages}
-        onChange={setCurrent}
-      />
-    </div>
-  );
+  return View({
+    current,
+    resultsPerPage,
+    totalPages,
+    onChange: setCurrent
+  });
 }
 
 PagingContainer.propTypes = {

--- a/packages/react-search-ui/src/containers/PagingInfo.js
+++ b/packages/react-search-ui/src/containers/PagingInfo.js
@@ -34,14 +34,12 @@ export class PagingInfoContainer extends Component {
 
     const View = view || PagingInfo;
 
-    return (
-      <View
-        end={end}
-        searchTerm={resultSearchTerm}
-        start={start}
-        totalResults={totalResults}
-      />
-    );
+    return View({
+      end: end,
+      searchTerm: resultSearchTerm,
+      start: start,
+      totalResults: totalResults
+    });
   }
 }
 

--- a/packages/react-search-ui/src/containers/Result.js
+++ b/packages/react-search-ui/src/containers/Result.js
@@ -76,18 +76,15 @@ export class ResultContainer extends Component {
     const { result, titleField, urlField, view } = this.props;
     const View = view || Result;
 
-    return (
-      <View
-        fields={formatResultFields(result)}
-        key={`result-${getRaw(result, "id")}`}
-        onClickLink={() => this.handleClickLink(getRaw(result, "id"))}
-        title={
-          getSnippet(result, titleField) ||
-          htmlEscape(getRaw(result, titleField))
-        }
-        url={getRaw(result, urlField)}
-      />
-    );
+    return View({
+      fields: formatResultFields(result),
+      key: `result-${getRaw(result, "id")}`,
+      onClickLink: () => this.handleClickLink(getRaw(result, "id")),
+      title:
+        getSnippet(result, titleField) ||
+        htmlEscape(getRaw(result, titleField)),
+      url: getRaw(result, urlField)
+    });
   }
 }
 

--- a/packages/react-search-ui/src/containers/Results.js
+++ b/packages/react-search-ui/src/containers/Results.js
@@ -43,21 +43,19 @@ export class ResultsContainer extends Component {
     const View = view || Results;
     const ResultView = renderResult || Result;
 
-    return (
-      <View>
-        {results.map(result => (
-          <ResultContainer
-            key={`result-${getRaw(result, "id")}`}
-            titleField={titleField}
-            urlField={urlField}
-            view={ResultView}
-            result={result}
-            shouldTrackClickThrough={shouldTrackClickThrough}
-            clickThroughTags={clickThroughTags}
-          />
-        ))}
-      </View>
-    );
+    return View({
+      children: results.map(result => (
+        <ResultContainer
+          key={`result-${getRaw(result, "id")}`}
+          titleField={titleField}
+          urlField={urlField}
+          view={ResultView}
+          result={result}
+          shouldTrackClickThrough={shouldTrackClickThrough}
+          clickThroughTags={clickThroughTags}
+        />
+      ))
+    });
   }
 }
 

--- a/packages/react-search-ui/src/containers/ResultsPerPage.js
+++ b/packages/react-search-ui/src/containers/ResultsPerPage.js
@@ -28,15 +28,13 @@ export class ResultsPerPageContainer extends Component {
 
     const View = view || ResultsPerPage;
 
-    return (
-      <View
-        onChange={value => {
-          setResultsPerPage(value);
-        }}
-        options={[20, 40, 60]}
-        value={resultsPerPage}
-      />
-    );
+    return View({
+      onChange: value => {
+        setResultsPerPage(value);
+      },
+      options: [20, 40, 60],
+      value: resultsPerPage
+    });
   }
 }
 

--- a/packages/react-search-ui/src/containers/SearchBox.js
+++ b/packages/react-search-ui/src/containers/SearchBox.js
@@ -110,25 +110,23 @@ export class SearchBoxContainer extends Component {
       !!autocompleteResults &&
       searchTerm.length >= autocompleteMinimumCharacters;
 
-    return (
-      <View
-        autocompleteResults={autocompleteResults}
-        autocompletedResults={autocompletedResults}
-        autocompletedSuggestions={{}}
-        isFocused={isFocused}
-        notifyAutocompleteSelected={this.handleNotifyAutocompleteSelected}
-        onChange={value => this.handleChange(value)}
-        onSelectAutocomplete={onSelectAutocomplete}
-        onSubmit={this.handleSubmit}
-        useAutocomplete={useAutocomplete}
-        value={searchTerm}
-        inputProps={{
-          onFocus: this.handleFocus,
-          onBlur: this.handleBlur,
-          ...inputProps
-        }}
-      />
-    );
+    return View({
+      autocompleteResults: autocompleteResults,
+      autocompletedResults: autocompletedResults,
+      autocompletedSuggestions: {},
+      isFocused: isFocused,
+      notifyAutocompleteSelected: this.handleNotifyAutocompleteSelected,
+      onChange: value => this.handleChange(value),
+      onSelectAutocomplete: onSelectAutocomplete,
+      onSubmit: this.handleSubmit,
+      useAutocomplete: useAutocomplete,
+      value: searchTerm,
+      inputProps: {
+        onFocus: this.handleFocus,
+        onBlur: this.handleBlur,
+        ...inputProps
+      }
+    });
   }
 }
 

--- a/packages/react-search-ui/src/containers/Sorting.js
+++ b/packages/react-search-ui/src/containers/Sorting.js
@@ -51,16 +51,14 @@ export class SortingContainer extends Component {
 
     const View = view || Sorting;
 
-    return (
-      <View
-        onChange={o => {
-          const sortOption = findSortOption(sortOptions, o);
-          setSort(sortOption.value, sortOption.direction);
-        }}
-        options={sortOptions.map(formatSelectOption)}
-        value={formatValue(sortField, sortDirection)}
-      />
-    );
+    return View({
+      onChange: o => {
+        const sortOption = findSortOption(sortOptions, o);
+        setSort(sortOption.value, sortOption.direction);
+      },
+      options: sortOptions.map(formatSelectOption),
+      value: formatValue(sortField, sortDirection)
+    });
   }
 }
 

--- a/packages/react-search-ui/src/containers/__tests__/ErrorBoundary.test.js
+++ b/packages/react-search-ui/src/containers/__tests__/ErrorBoundary.test.js
@@ -7,16 +7,11 @@ const params = {
   error: "I am an error"
 };
 
-it("renders correctly", () => {
-  const wrapper = shallow(<ErrorBoundaryContainer {...params} />);
-  expect(wrapper).toMatchSnapshot();
-});
-
 it("supports a render prop", () => {
   // eslint-disable-next-line react/prop-types
   const render = ({ error }) => {
     return <div>{error}</div>;
   };
   const wrapper = shallow(<ErrorBoundaryContainer {...params} view={render} />);
-  expect(wrapper.find(render).dive()).toMatchSnapshot();
+  expect(wrapper).toMatchSnapshot();
 });

--- a/packages/react-search-ui/src/containers/__tests__/Paging.test.js
+++ b/packages/react-search-ui/src/containers/__tests__/Paging.test.js
@@ -13,18 +13,13 @@ beforeEach(() => {
   params.setCurrent = jest.fn();
 });
 
-it("renders correctly", () => {
-  const wrapper = shallow(<PagingContainer {...params} />);
-  expect(wrapper).toMatchSnapshot();
-});
-
 it("supports a render prop", () => {
   // eslint-disable-next-line react/prop-types
   const render = ({ current }) => {
     return <div>{current}</div>;
   };
   const wrapper = shallow(<PagingContainer {...params} view={render} />);
-  expect(wrapper.find(render).dive()).toMatchSnapshot();
+  expect(wrapper).toMatchSnapshot();
 });
 
 it("renders empty when there are no results", () => {
@@ -40,9 +35,12 @@ it("renders empty when there are no results", () => {
 });
 
 it("will call back when a the page is changed", () => {
-  const wrapper = shallow(<PagingContainer {...params} />);
+  let viewProps;
 
-  wrapper.find("Paging").prop("onChange")(2);
+  shallow(<PagingContainer {...params} view={props => (viewProps = props)} />);
+
+  const { onChange } = viewProps;
+  onChange(2);
 
   const current = params.setCurrent.mock.calls[0][0];
   expect(current).toEqual(2);

--- a/packages/react-search-ui/src/containers/__tests__/PagingInfo.test.js
+++ b/packages/react-search-ui/src/containers/__tests__/PagingInfo.test.js
@@ -10,11 +10,6 @@ const params = {
   totalResults: 100
 };
 
-it("renders correctly", () => {
-  const wrapper = shallow(<PagingInfoContainer {...params} />);
-  expect(wrapper).toMatchSnapshot();
-});
-
 it("supports a render prop", () => {
   // eslint-disable-next-line react/prop-types
   const render = ({ start, end }) => {
@@ -26,7 +21,7 @@ it("supports a render prop", () => {
     );
   };
   const wrapper = shallow(<PagingInfoContainer {...params} view={render} />);
-  expect(wrapper.find(render).dive()).toMatchSnapshot();
+  expect(wrapper).toMatchSnapshot();
 });
 
 it("renders empty when it doesn't have enough data", () => {

--- a/packages/react-search-ui/src/containers/__tests__/Result.test.js
+++ b/packages/react-search-ui/src/containers/__tests__/Result.test.js
@@ -26,46 +26,51 @@ beforeEach(() => {
   params.trackClickThrough = jest.fn();
 });
 
-it("renders correctly", () => {
-  const wrapper = shallow(<ResultContainer {...params} />);
-  expect(wrapper).toMatchSnapshot();
-});
-
 describe("link clicks", () => {
   it("will call back when a document link is clicked in the view", () => {
-    const wrapper = shallow(<ResultContainer {...params} />);
+    let viewProps;
 
-    wrapper
-      .find("Result")
-      .at(0)
-      .prop("onClickLink")();
+    shallow(
+      <ResultContainer {...params} view={props => (viewProps = props)} />
+    );
+
+    const { onClickLink } = viewProps;
+    onClickLink();
 
     const [id] = params.trackClickThrough.mock.calls[0];
     expect(id).toEqual("id");
   });
 
   it("will not call back when shouldTrackClickThrough is false", () => {
-    const wrapper = shallow(
-      <ResultContainer {...params} shouldTrackClickThrough={false} />
+    let viewProps;
+
+    shallow(
+      <ResultContainer
+        {...params}
+        shouldTrackClickThrough={false}
+        view={props => (viewProps = props)}
+      />
     );
 
-    wrapper
-      .find("Result")
-      .at(0)
-      .prop("onClickLink")();
+    const { onClickLink } = viewProps;
+    onClickLink();
 
     expect(params.trackClickThrough.mock.calls.length).toEqual(0);
   });
 
   it("will pass through tags", () => {
-    const wrapper = shallow(
-      <ResultContainer {...params} clickThroughTags={["whatever"]} />
+    let viewProps;
+
+    shallow(
+      <ResultContainer
+        {...params}
+        clickThroughTags={["whatever"]}
+        view={props => (viewProps = props)}
+      />
     );
 
-    wrapper
-      .find("Result")
-      .at(0)
-      .prop("onClickLink")();
+    const { onClickLink } = viewProps;
+    onClickLink();
 
     const [id, tags] = params.trackClickThrough.mock.calls[0];
     expect(id).toEqual("id");
@@ -79,5 +84,5 @@ it("supports a render prop", () => {
     return <div>{children}</div>;
   };
   const wrapper = shallow(<ResultContainer {...params} view={render} />);
-  expect(wrapper.find(render).dive()).toMatchSnapshot();
+  expect(wrapper).toMatchSnapshot();
 });

--- a/packages/react-search-ui/src/containers/__tests__/Results.test.js
+++ b/packages/react-search-ui/src/containers/__tests__/Results.test.js
@@ -37,18 +37,13 @@ const params = {
   urlField: "url"
 };
 
-it("renders correctly", () => {
-  const wrapper = shallow(<ResultsContainer {...params} />);
-  expect(wrapper).toMatchSnapshot();
-});
-
 it("supports a render prop", () => {
   // eslint-disable-next-line react/prop-types
   const render = ({ children }) => {
     return <div>{children}</div>;
   };
   const wrapper = shallow(<ResultsContainer {...params} view={render} />);
-  expect(wrapper.find(render).dive()).toMatchSnapshot();
+  expect(wrapper).toMatchSnapshot();
 });
 
 it("passes through props to individual Result items", () => {

--- a/packages/react-search-ui/src/containers/__tests__/ResultsPerPage.test.js
+++ b/packages/react-search-ui/src/containers/__tests__/ResultsPerPage.test.js
@@ -13,11 +13,6 @@ beforeEach(() => {
   params.setResultsPerPage = jest.fn();
 });
 
-it("renders correctly", () => {
-  const wrapper = shallow(<ResultsPerPageContainer {...params} />);
-  expect(wrapper).toMatchSnapshot();
-});
-
 it("supports a render prop", () => {
   // eslint-disable-next-line react/prop-types
   const render = ({ value }) => {
@@ -26,7 +21,7 @@ it("supports a render prop", () => {
   const wrapper = shallow(
     <ResultsPerPageContainer {...params} view={render} />
   );
-  expect(wrapper.find(render).dive()).toMatchSnapshot();
+  expect(wrapper).toMatchSnapshot();
 });
 
 it("renders empty when it doesn't have enough data", () => {
@@ -43,9 +38,14 @@ it("renders empty when it doesn't have enough data", () => {
 });
 
 it("will call back when a selection is made in the view", () => {
-  const wrapper = shallow(<ResultsPerPageContainer {...params} />);
+  let viewProps;
 
-  wrapper.find("ResultsPerPage").prop("onChange")(40);
+  shallow(
+    <ResultsPerPageContainer {...params} view={props => (viewProps = props)} />
+  );
+
+  const { onChange } = viewProps;
+  onChange(40);
 
   const resultsPerPage = params.setResultsPerPage.mock.calls[0][0];
   expect(resultsPerPage).toEqual(40);

--- a/packages/react-search-ui/src/containers/__tests__/SearchBox.test.js
+++ b/packages/react-search-ui/src/containers/__tests__/SearchBox.test.js
@@ -15,68 +15,69 @@ beforeEach(() => {
   params.trackAutocompleteClickThrough = jest.fn();
 });
 
-it("renders correctly", () => {
-  const wrapper = shallow(<SearchBoxContainer {...params} />);
-  expect(wrapper).toMatchSnapshot();
-});
-
 it("supports a render prop", () => {
   // eslint-disable-next-line react/prop-types
   const render = ({ value }) => {
     return <div>{value}</div>;
   };
   const wrapper = shallow(<SearchBoxContainer {...params} view={render} />);
-  expect(wrapper.find(render).dive()).toMatchSnapshot();
+  expect(wrapper).toMatchSnapshot();
 });
 
 it("will keep focus prop in sync with view component", () => {
-  const wrapper = shallow(<SearchBoxContainer {...params} />);
+  let viewProps;
 
-  expect(wrapper.find("SearchBox").prop("isFocused")).toBe(false);
+  shallow(
+    <SearchBoxContainer {...params} view={props => (viewProps = props)} />
+  );
 
-  wrapper
-    .find("SearchBox")
-    .prop("inputProps")
-    ["onFocus"]();
+  expect(viewProps.isFocused).toBe(false);
+  viewProps.inputProps.onFocus();
 
-  expect(wrapper.find("SearchBox").prop("isFocused")).toBe(true);
+  expect(viewProps.isFocused).toBe(true);
 
-  wrapper
-    .find("SearchBox")
-    .prop("inputProps")
-    ["onBlur"]();
+  viewProps.inputProps.onBlur();
 
-  expect(wrapper.find("SearchBox").prop("isFocused")).toBe(false);
+  expect(viewProps.isFocused).toBe(false);
 });
 
 describe("useAutocomplete", () => {
   it("will be true  if autocompleteResults configuration has been provided", () => {
-    const wrapper = shallow(
+    let viewProps;
+
+    shallow(
       <SearchBoxContainer
         {...params}
         autocompleteResults={{
           titleField: "title",
           urlField: "nps_link"
         }}
+        view={props => (viewProps = props)}
       />
     );
-    wrapper.find("SearchBox").prop("onChange")("new term");
-    expect(wrapper.find("SearchBox").prop("useAutocomplete")).toBe(true);
+    viewProps.onChange("new term");
+    expect(viewProps.useAutocomplete).toBe(true);
   });
 
   it("will be false if no autocomplete config has been provided", () => {
-    const wrapper = shallow(<SearchBoxContainer {...params} />);
-    wrapper.find("SearchBox").prop("onChange")("new term");
-    expect(wrapper.find("SearchBox").prop("useAutocomplete")).toBe(false);
+    let viewProps;
+    shallow(
+      <SearchBoxContainer {...params} view={props => (viewProps = props)} />
+    );
+    viewProps.onChange("new term");
+    expect(viewProps.useAutocomplete).toBe(false);
   });
 });
 
 it("will call back to setSearchTerm with refresh: false when input is changed", () => {
-  const wrapper = shallow(<SearchBoxContainer {...params} />);
+  let viewProps;
+  shallow(
+    <SearchBoxContainer {...params} view={props => (viewProps = props)} />
+  );
 
-  expect(wrapper.find("SearchBox").prop("value")).toBe("test");
+  expect(viewProps.value).toBe("test");
 
-  wrapper.find("SearchBox").prop("onChange")("new term");
+  viewProps.onChange("new term");
 
   const call = params.setSearchTerm.mock.calls[0];
   expect(call).toEqual([
@@ -86,10 +87,15 @@ it("will call back to setSearchTerm with refresh: false when input is changed", 
 });
 
 it("will call back to setSearchTerm with autocompleteMinimumCharacters setting", () => {
-  const wrapper = shallow(
-    <SearchBoxContainer {...params} autocompleteMinimumCharacters={3} />
+  let viewProps;
+  shallow(
+    <SearchBoxContainer
+      {...params}
+      autocompleteMinimumCharacters={3}
+      view={props => (viewProps = props)}
+    />
   );
-  wrapper.find("SearchBox").prop("onChange")("new term");
+  viewProps.onChange("new term");
 
   const call = params.setSearchTerm.mock.calls[0];
   expect(call).toEqual([
@@ -103,13 +109,18 @@ it("will call back to setSearchTerm with autocompleteMinimumCharacters setting",
 });
 
 it("will call back to setSearchTerm with refresh: true when input is changed and searchAsYouType is true", () => {
-  const wrapper = shallow(
-    <SearchBoxContainer {...params} searchAsYouType={true} />
+  let viewProps;
+  shallow(
+    <SearchBoxContainer
+      {...params}
+      searchAsYouType={true}
+      view={props => (viewProps = props)}
+    />
   );
 
-  expect(wrapper.find("SearchBox").prop("value")).toBe("test");
+  expect(viewProps.value).toBe("test");
 
-  wrapper.find("SearchBox").prop("onChange")("new term");
+  viewProps.onChange("new term");
 
   const call = params.setSearchTerm.mock.calls[0];
   expect(call).toEqual([
@@ -119,17 +130,19 @@ it("will call back to setSearchTerm with refresh: true when input is changed and
 });
 
 it("will call back to setSearchTerm with a specific debounce when input is changed and searchAsYouType is true and a debounce is provided", () => {
-  const wrapper = shallow(
+  let viewProps;
+  shallow(
     <SearchBoxContainer
       {...params}
       searchAsYouType={true}
       debounceLength={500}
+      view={props => (viewProps = props)}
     />
   );
 
-  expect(wrapper.find("SearchBox").prop("value")).toBe("test");
+  expect(viewProps.value).toBe("test");
 
-  wrapper.find("SearchBox").prop("onChange")("new term");
+  viewProps.onChange("new term");
 
   const call = params.setSearchTerm.mock.calls[0];
   expect(call).toEqual([
@@ -139,7 +152,8 @@ it("will call back to setSearchTerm with a specific debounce when input is chang
 });
 
 it("will call back to setSearchTerm with a specific debounce when input is changed and autocompleteResults is true and a debounce is provided", () => {
-  const wrapper = shallow(
+  let viewProps;
+  shallow(
     <SearchBoxContainer
       {...params}
       autocompleteResults={{
@@ -147,12 +161,13 @@ it("will call back to setSearchTerm with a specific debounce when input is chang
         urlField: "nps_link"
       }}
       debounceLength={500}
+      view={props => (viewProps = props)}
     />
   );
 
-  expect(wrapper.find("SearchBox").prop("value")).toBe("test");
+  expect(viewProps.value).toBe("test");
 
-  wrapper.find("SearchBox").prop("onChange")("new term");
+  viewProps.onChange("new term");
 
   const call = params.setSearchTerm.mock.calls[0];
   expect(call).toEqual([
@@ -162,11 +177,17 @@ it("will call back to setSearchTerm with a specific debounce when input is chang
 });
 
 it("will call back setSearchTerm with refresh: true when form is submitted", () => {
-  const wrapper = shallow(
-    <SearchBoxContainer {...params} searchTerm="a term" />
+  let viewProps;
+
+  shallow(
+    <SearchBoxContainer
+      {...params}
+      searchTerm="a term"
+      view={props => (viewProps = props)}
+    />
   );
 
-  wrapper.find("SearchBox").prop("onSubmit")({
+  viewProps.onSubmit({
     preventDefault: () => {}
   });
 
@@ -176,10 +197,15 @@ it("will call back setSearchTerm with refresh: true when form is submitted", () 
 
 describe("autocomplete clickthroughs", () => {
   it("will call back to trackAutocompleteClickThrough when an autocomplete item is selected in the view", () => {
-    const wrapper = shallow(
-      <SearchBoxContainer {...params} autocompleteResults={true} />
+    let viewProps;
+    shallow(
+      <SearchBoxContainer
+        {...params}
+        autocompleteResults={true}
+        view={props => (viewProps = props)}
+      />
     );
-    const { notifyAutocompleteSelected } = wrapper.props();
+    const { notifyAutocompleteSelected } = viewProps;
     notifyAutocompleteSelected({
       id: { raw: "123" }
     });
@@ -187,7 +213,8 @@ describe("autocomplete clickthroughs", () => {
   });
 
   it("will not call back when shouldTrackClickThrough is false", () => {
-    const wrapper = shallow(
+    let viewProps;
+    shallow(
       <SearchBoxContainer
         {...params}
         autocompleteResults={{
@@ -195,9 +222,10 @@ describe("autocomplete clickthroughs", () => {
           titleField: "title",
           urlField: "nps_link"
         }}
+        view={props => (viewProps = props)}
       />
     );
-    const { notifyAutocompleteSelected } = wrapper.props();
+    const { notifyAutocompleteSelected } = viewProps;
     notifyAutocompleteSelected({
       id: { raw: "123" }
     });
@@ -205,10 +233,15 @@ describe("autocomplete clickthroughs", () => {
   });
 
   it("will not call back when the selected item is a suggestion", () => {
-    const wrapper = shallow(
-      <SearchBoxContainer {...params} autocompleteResults={true} />
+    let viewProps;
+    shallow(
+      <SearchBoxContainer
+        {...params}
+        autocompleteResults={true}
+        view={props => (viewProps = props)}
+      />
     );
-    const { notifyAutocompleteSelected } = wrapper.props();
+    const { notifyAutocompleteSelected } = viewProps;
     notifyAutocompleteSelected({
       suggestion: "bike"
     });
@@ -216,6 +249,7 @@ describe("autocomplete clickthroughs", () => {
   });
 
   it("will pass through tags", () => {
+    let viewProps;
     const wrapper = shallow(
       <SearchBoxContainer
         {...params}
@@ -224,9 +258,10 @@ describe("autocomplete clickthroughs", () => {
           titleField: "title",
           urlField: "nps_link"
         }}
+        view={props => (viewProps = props)}
       />
     );
-    const { notifyAutocompleteSelected } = wrapper.props();
+    const { notifyAutocompleteSelected } = viewProps;
     notifyAutocompleteSelected({
       id: { raw: "123" }
     });

--- a/packages/react-search-ui/src/containers/__tests__/Sorting.test.js
+++ b/packages/react-search-ui/src/containers/__tests__/Sorting.test.js
@@ -27,18 +27,13 @@ beforeEach(() => {
   params.setSort = jest.fn();
 });
 
-it("renders correctly", () => {
-  const wrapper = shallow(<SortingContainer {...params} />);
-  expect(wrapper).toMatchSnapshot();
-});
-
 it("supports a render prop", () => {
   // eslint-disable-next-line react/prop-types
   const render = ({ value }) => {
     return <div>{value}</div>;
   };
   const wrapper = shallow(<SortingContainer {...params} view={render} />);
-  expect(wrapper.find(render).dive()).toMatchSnapshot();
+  expect(wrapper).toMatchSnapshot();
 });
 
 it("renders empty when it doesn't have enough data", () => {
@@ -55,9 +50,12 @@ it("renders empty when it doesn't have enough data", () => {
 });
 
 it("will call back when sort is changed in view", () => {
-  const wrapper = shallow(<SortingContainer {...params} />);
+  let viewProps;
 
-  wrapper.find("Sorting").prop("onChange")("field|||desc");
+  shallow(<SortingContainer {...params} view={props => (viewProps = props)} />);
+
+  const { onChange } = viewProps;
+  onChange("field|||desc");
 
   const [sortField, sortDirection] = params.setSort.mock.calls[0];
   expect(sortField).toEqual("field");

--- a/packages/react-search-ui/src/containers/__tests__/__snapshots__/ErrorBoundary.test.js.snap
+++ b/packages/react-search-ui/src/containers/__tests__/__snapshots__/ErrorBoundary.test.js.snap
@@ -1,15 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`renders correctly 1`] = `
-<ErrorBoundary
-  error="I am an error"
->
-  <div>
-    Child
-  </div>
-</ErrorBoundary>
-`;
-
 exports[`supports a render prop 1`] = `
 <div>
   I am an error

--- a/packages/react-search-ui/src/containers/__tests__/__snapshots__/Paging.test.js.snap
+++ b/packages/react-search-ui/src/containers/__tests__/__snapshots__/Paging.test.js.snap
@@ -1,16 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`renders correctly 1`] = `
-<div>
-  <Paging
-    current={1}
-    onChange={[MockFunction]}
-    resultsPerPage={20}
-    totalPages={5}
-  />
-</div>
-`;
-
 exports[`renders empty when there are no results 1`] = `""`;
 
 exports[`supports a render prop 1`] = `

--- a/packages/react-search-ui/src/containers/__tests__/__snapshots__/PagingInfo.test.js.snap
+++ b/packages/react-search-ui/src/containers/__tests__/__snapshots__/PagingInfo.test.js.snap
@@ -1,14 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`renders correctly 1`] = `
-<PagingInfo
-  end={20}
-  searchTerm="test"
-  start={1}
-  totalResults={100}
-/>
-`;
-
 exports[`renders empty when it doesn't have enough data 1`] = `""`;
 
 exports[`supports a render prop 1`] = `

--- a/packages/react-search-ui/src/containers/__tests__/__snapshots__/Result.test.js.snap
+++ b/packages/react-search-ui/src/containers/__tests__/__snapshots__/Result.test.js.snap
@@ -1,19 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`renders correctly 1`] = `
-<Result
-  fields={
-    Object {
-      "id": "<em>id</em>",
-      "title": "<em>title</em>",
-      "url": "<em>url</em>",
-    }
-  }
-  key="result-id"
-  onClickLink={[Function]}
-  title="<em>title</em>"
-  url="url"
-/>
-`;
-
 exports[`supports a render prop 1`] = `<div />`;

--- a/packages/react-search-ui/src/containers/__tests__/__snapshots__/Results.test.js.snap
+++ b/packages/react-search-ui/src/containers/__tests__/__snapshots__/Results.test.js.snap
@@ -1,58 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`renders correctly 1`] = `
-<Results>
-  <WithSearch
-    clickThroughTags={Array []}
-    key="result-id"
-    result={
-      Object {
-        "id": Object {
-          "raw": "id",
-          "snippet": "<em>id</em>",
-        },
-        "title": Object {
-          "raw": "title",
-          "snippet": "<em>title</em>",
-        },
-        "url": Object {
-          "raw": "url",
-          "snippet": "<em>url</em>",
-        },
-      }
-    }
-    shouldTrackClickThrough={true}
-    titleField="title"
-    urlField="url"
-    view={[Function]}
-  />
-  <WithSearch
-    clickThroughTags={Array []}
-    key="result-id"
-    result={
-      Object {
-        "id": Object {
-          "raw": "id",
-          "snippet": "<em>id</em>",
-        },
-        "title": Object {
-          "raw": "title",
-          "snippet": "<em>title</em>",
-        },
-        "url": Object {
-          "raw": "url",
-          "snippet": "<em>url</em>",
-        },
-      }
-    }
-    shouldTrackClickThrough={true}
-    titleField="title"
-    urlField="url"
-    view={[Function]}
-  />
-</Results>
-`;
-
 exports[`supports a render prop 1`] = `
 <div>
   <WithSearch

--- a/packages/react-search-ui/src/containers/__tests__/__snapshots__/ResultsPerPage.test.js.snap
+++ b/packages/react-search-ui/src/containers/__tests__/__snapshots__/ResultsPerPage.test.js.snap
@@ -1,19 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`renders correctly 1`] = `
-<ResultsPerPage
-  onChange={[Function]}
-  options={
-    Array [
-      20,
-      40,
-      60,
-    ]
-  }
-  value={20}
-/>
-`;
-
 exports[`renders empty when it doesn't have enough data 1`] = `""`;
 
 exports[`supports a render prop 1`] = `

--- a/packages/react-search-ui/src/containers/__tests__/__snapshots__/SearchBox.test.js.snap
+++ b/packages/react-search-ui/src/containers/__tests__/__snapshots__/SearchBox.test.js.snap
@@ -1,24 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`renders correctly 1`] = `
-<SearchBox
-  autocompletedResults={Array []}
-  autocompletedSuggestions={Object {}}
-  inputProps={
-    Object {
-      "onBlur": [Function],
-      "onFocus": [Function],
-    }
-  }
-  isFocused={false}
-  notifyAutocompleteSelected={[Function]}
-  onChange={[Function]}
-  onSubmit={[Function]}
-  useAutocomplete={false}
-  value="test"
-/>
-`;
-
 exports[`supports a render prop 1`] = `
 <div>
   test

--- a/packages/react-search-ui/src/containers/__tests__/__snapshots__/Sorting.test.js.snap
+++ b/packages/react-search-ui/src/containers/__tests__/__snapshots__/Sorting.test.js.snap
@@ -1,24 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`renders correctly 1`] = `
-<Sorting
-  onChange={[Function]}
-  options={
-    Array [
-      Object {
-        "label": "name",
-        "value": "field|||asc",
-      },
-      Object {
-        "label": "name",
-        "value": "field|||desc",
-      },
-    ]
-  }
-  value="field|||asc"
-/>
-`;
-
 exports[`renders empty when it doesn't have enough data 1`] = `""`;
 
 exports[`supports a render prop 1`] = `


### PR DESCRIPTION
View rendering logic was mounting views in such a way that
on every state change, the entire view was being unmounted and
remounted. This was very inefficient and caused issues with passing
custom props into views.

This was also causing issues on https://swiftype.com/ search. 
Particularly on mobile devices.

Fixes #160 

This fix was actually fairly simple, view just needed to be rendered
like this:

```js
View({
  current,
  resultsPerPage,
  totalPages,
  onChange: setCurrent
});
```

Instead of:

```jsx
<View
   current={current}
   resultsPerPage={resultsPerPage}
   totalPages={totalPages}
   onChange={setCurrent}
 />
```

Most of the files changed in this PR are just adjusting
specs to work with this new approach.

To test this, run the sandbox app and play around with the autocomplete: https://github.com/elastic/search-ui/tree/master/examples/sandbox.

Create and use a custom view in `App.js` like follows, and make sure the "mounting" log message is not printed with every key stroke that is made in the search box.

```
class Mounter extends React.Component {
  componentDidMount() {
    console.log(`Mounting`);
  }

  render() {
    return <div>Mounter</div>;
  }
}
```

```
<PagingInfo view={() => <Mounter />} />
```

![latest](https://user-images.githubusercontent.com/1427475/55633739-f8a24c00-578a-11e9-9091-7573899b74d7.gif)
