### PR TITLE
Autocomplete suggestions support

### DIFF
--- a/examples/sandbox/src/App.js
+++ b/examples/sandbox/src/App.js
@@ -84,6 +84,13 @@ export default function App() {
                 raw: {}
               }
             }
+          },
+          suggestions: {
+            types: {
+              documents: {
+                fields: ["title"]
+              }
+            }
           }
         },
         apiConnector: connector
@@ -103,6 +110,11 @@ export default function App() {
                     urlField: "nps_link",
                     shouldTrackClickThrough: true,
                     clickThroughTags: ["test"]
+                  }}
+                  autocompleteSuggestions={{
+                    documents: {
+                      sectionTitle: "Suggested Queries"
+                    }
                   }}
                 />
               }

--- a/packages/react-search-ui-views/src/Autocomplete.js
+++ b/packages/react-search-ui-views/src/Autocomplete.js
@@ -30,86 +30,99 @@ function Autocomplete({
       })}
     >
       <div>
-        {autocompleteResults.sectionTitle && (
-          <div className="sui-search-box__section-title">
-            {autocompleteResults.sectionTitle}
-          </div>
-        )}
-        <ul>
-          {autocompletedResults.map(result => {
-            index++;
-            const titleSnippet = getSnippet(
-              result,
-              autocompleteResults.titleField
-            );
-            const titleRaw = getRaw(result, autocompleteResults.titleField);
-            return (
-              // eslint-disable-next-line react/jsx-key
-              <li
-                {...getItemProps({
-                  key: result.id.raw,
-                  index: index - 1,
-                  item: result
-                })}
-              >
-                {titleSnippet ? (
-                  <span
-                    dangerouslySetInnerHTML={{
-                      __html: titleSnippet
-                    }}
-                  />
-                ) : (
-                  <span>{titleRaw}</span>
-                )}
-              </li>
-            );
-          })}
-        </ul>
-        {Object.entries(autocompletedSuggestions).map(
-          ([suggestionType, suggestions]) => {
-            return (
-              <React.Fragment key={suggestionType}>
-                {autocompleteSuggestions[suggestionType] &&
-                  autocompleteSuggestions[suggestionType].sectionTitle && (
-                    <div className="sui-search-box__section-title">
-                      {autocompleteSuggestions[suggestionType].sectionTitle}
-                    </div>
+        {!!autocompleteResults &&
+          !!autocompletedResults &&
+          autocompletedResults.length > 0 &&
+          autocompleteResults.sectionTitle && (
+            <div className="sui-search-box__section-title">
+              {autocompleteResults.sectionTitle}
+            </div>
+          )}
+        {!!autocompleteResults &&
+          !!autocompletedResults &&
+          autocompletedResults.length > 0 && (
+            <ul className="sui-search-box__results-list">
+              {autocompletedResults.map(result => {
+                index++;
+                const titleSnippet = getSnippet(
+                  result,
+                  autocompleteResults.titleField
+                );
+                const titleRaw = getRaw(result, autocompleteResults.titleField);
+                return (
+                  // eslint-disable-next-line react/jsx-key
+                  <li
+                    {...getItemProps({
+                      key: result.id.raw,
+                      index: index - 1,
+                      item: result
+                    })}
+                  >
+                    {titleSnippet ? (
+                      <span
+                        dangerouslySetInnerHTML={{
+                          __html: titleSnippet
+                        }}
+                      />
+                    ) : (
+                      <span>{titleRaw}</span>
+                    )}
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        {!!autocompleteSuggestions &&
+          Object.entries(autocompletedSuggestions).map(
+            ([suggestionType, suggestions]) => {
+              return (
+                <React.Fragment key={suggestionType}>
+                  {autocompleteSuggestions[suggestionType] &&
+                    autocompleteSuggestions[suggestionType].sectionTitle &&
+                    suggestions.length > 0 && (
+                      <div className="sui-search-box__section-title">
+                        {autocompleteSuggestions[suggestionType].sectionTitle}
+                      </div>
+                    )}
+                  {suggestions.length > 0 && (
+                    <ul className="sui-search-box__suggestion-list">
+                      {suggestions.map(suggestion => {
+                        index++;
+                        return (
+                          // eslint-disable-next-line react/jsx-key
+                          <li
+                            {...getItemProps({
+                              key:
+                                suggestion.suggestion || suggestion.highlight,
+                              index: index - 1,
+                              item: suggestion
+                            })}
+                          >
+                            {suggestion.highlight ? (
+                              <span
+                                dangerouslySetInnerHTML={{
+                                  __html: suggestion.highlight
+                                }}
+                              />
+                            ) : (
+                              <span>{suggestion.suggestion}</span>
+                            )}
+                          </li>
+                        );
+                      })}
+                    </ul>
                   )}
-                <ul>
-                  {suggestions.map(suggestion => {
-                    index++;
-                    return (
-                      // eslint-disable-next-line react/jsx-key
-                      <li
-                        {...getItemProps({
-                          key: suggestion.suggestion || suggestion.highlight,
-                          index: index - 1,
-                          item: suggestion
-                        })}
-                      >
-                        {suggestion.highlight ? (
-                          <span
-                            dangerouslySetInnerHTML={{
-                              __html: suggestion.highlight
-                            }}
-                          />
-                        ) : (
-                          <span>{suggestion.suggestion}</span>
-                        )}
-                      </li>
-                    );
-                  })}
-                </ul>
-              </React.Fragment>
-            );
-          }
-        )}
+                </React.Fragment>
+              );
+            }
+          )}
       </div>
     </div>
   );
 }
 
 Autocomplete.propTypes = {
+  allAutocompletedItemsCount: PropTypes.number.isRequired,
   autocompleteResults: PropTypes.oneOfType([
     PropTypes.bool,
     PropTypes.shape({
@@ -122,11 +135,15 @@ Autocomplete.propTypes = {
   autocompletedResults: PropTypes.arrayOf(Result).isRequired,
   autocompletedSuggestions: PropTypes.objectOf(PropTypes.arrayOf(Suggestion))
     .isRequired,
-  autocompleteSuggestions: PropTypes.objectOf(
-    PropTypes.shape({
-      sectionTitle: PropTypes.string.isRequired
-    })
-  ),
+  autocompletedSuggestionsCount: PropTypes.number.isRequired,
+  autocompleteSuggestions: PropTypes.oneOfType([
+    PropTypes.bool,
+    PropTypes.objectOf(
+      PropTypes.shape({
+        sectionTitle: PropTypes.string.isRequired
+      })
+    )
+  ]),
   getItemProps: PropTypes.func.isRequired,
   getMenuProps: PropTypes.func.isRequired
 };

--- a/packages/react-search-ui-views/src/SearchBox.js
+++ b/packages/react-search-ui-views/src/SearchBox.js
@@ -12,6 +12,7 @@ function SearchBox(props) {
     autocompleteResults,
     allAutocompletedItemsCount,
     autocompleteView,
+    completeSuggestion,
     isFocused,
     inputProps,
     notifyAutocompleteSelected,
@@ -35,6 +36,8 @@ function SearchBox(props) {
           const target = autocompleteResults.linkTarget || "_self";
           window.open(url, target);
         }
+      } else {
+        completeSuggestion(selection.suggestion);
       }
     });
 
@@ -42,7 +45,11 @@ function SearchBox(props) {
     <Downshift
       inputValue={value}
       onChange={onSelectAutocomplete}
-      onInputValueChange={onChange}
+      onInputValueChange={newValue => {
+        // To avoid over dispatching
+        if (value === newValue) return;
+        onChange(newValue);
+      }}
       // Because when a selection is made, we don't really want to change
       // the inputValue. This is supposed to be a "controlled" value, and when
       // this happens we lose control of it.
@@ -91,6 +98,7 @@ SearchBox.propTypes = {
   autocompletedSuggestions: PropTypes.objectOf(PropTypes.arrayOf(Suggestion))
     .isRequired,
   autocompletedSuggestionsCount: PropTypes.number.isRequired,
+  completeSuggestion: PropTypes.func.isRequired,
   notifyAutocompleteSelected: PropTypes.func.isRequired,
   onChange: PropTypes.func.isRequired,
   onSubmit: PropTypes.func.isRequired,

--- a/packages/react-search-ui-views/src/SearchBox.js
+++ b/packages/react-search-ui-views/src/SearchBox.js
@@ -10,8 +10,7 @@ import Autocomplete from "./Autocomplete";
 function SearchBox(props) {
   const {
     autocompleteResults,
-    autocompletedResults,
-    autocompletedSuggestions,
+    allAutocompletedItemsCount,
     autocompleteView,
     isFocused,
     inputProps,
@@ -68,10 +67,7 @@ function SearchBox(props) {
                     className: `sui-search-box__text-input ${focusedClass}`
                   })}
                 />
-                {useAutocomplete &&
-                isOpen &&
-                (autocompletedResults.length > 0 ||
-                  Object.entries(autocompletedSuggestions).length > 0) ? (
+                {useAutocomplete && isOpen && allAutocompletedItemsCount > 0 ? (
                   <AutocompleteView {...props} {...downshiftProps} />
                 ) : null}
               </div>
@@ -90,6 +86,12 @@ function SearchBox(props) {
 
 SearchBox.propTypes = {
   // Provided by container
+  allAutocompletedItemsCount: PropTypes.number.isRequired,
+  autocompletedResults: PropTypes.arrayOf(Result).isRequired,
+  autocompletedSuggestions: PropTypes.objectOf(PropTypes.arrayOf(Suggestion))
+    .isRequired,
+  autocompletedSuggestionsCount: PropTypes.number.isRequired,
+  notifyAutocompleteSelected: PropTypes.func.isRequired,
   onChange: PropTypes.func.isRequired,
   onSubmit: PropTypes.func.isRequired,
   value: PropTypes.string.isRequired,
@@ -102,10 +104,6 @@ SearchBox.propTypes = {
       sectionTitle: PropTypes.string
     })
   ]),
-  autocompletedResults: PropTypes.arrayOf(Result).isRequired,
-  autocompletedSuggestions: PropTypes.objectOf(PropTypes.arrayOf(Suggestion))
-    .isRequired,
-  notifyAutocompleteSelected: PropTypes.func.isRequired,
   autocompleteView: PropTypes.func,
   autocompleteSuggestions: PropTypes.objectOf(
     PropTypes.shape({

--- a/packages/react-search-ui-views/src/__tests__/Autocomplete.test.js
+++ b/packages/react-search-ui-views/src/__tests__/Autocomplete.test.js
@@ -31,6 +31,8 @@ const props = {
       sectionTitle: "Popular"
     }
   },
+  allAutocompletedItemsCount: 5,
+  autocompletedSuggestionsCount: 2,
   autocompletedSuggestions: {
     documents: [
       { highlight: "", suggestion: "bike" },
@@ -53,4 +55,176 @@ const props = {
 it("renders correctly", () => {
   const wrapper = shallow(<Autocomplete {...props} />);
   expect(wrapper).toMatchSnapshot();
+});
+
+describe("When there are results", () => {
+  it("will render results", () => {
+    const wrapper = shallow(
+      <Autocomplete
+        {...props}
+        autocompleteResults={true}
+        autocompleteSuggestions={false}
+      />
+    );
+    expect(wrapper.find(".sui-search-box__results-list li").length).toEqual(3);
+  });
+
+  it("will NOT render results if autocompleteResults is false", () => {
+    const wrapper = shallow(
+      <Autocomplete
+        {...props}
+        autocompleteResults={false}
+        autocompleteSuggestions={false}
+      />
+    );
+    expect(wrapper.find(".sui-search-box__results-list").length).toEqual(0);
+  });
+
+  it("will render a results section title if one is provided", () => {
+    const wrapper = shallow(
+      <Autocomplete
+        {...props}
+        autocompleteResults={{
+          sectionTitle: "Results",
+          titleField: "title",
+          urlField: "nps_link",
+          linkTarget: "_blank"
+        }}
+        autocompleteSuggestions={false}
+      />
+    );
+    expect(wrapper.find(".sui-search-box__section-title").text()).toEqual(
+      "Results"
+    );
+  });
+
+  it("will NOT render a suggestion section title if none is provided", () => {
+    const wrapper = shallow(
+      <Autocomplete
+        {...props}
+        autocompleteResults={{
+          titleField: "title",
+          urlField: "nps_link",
+          linkTarget: "_blank"
+        }}
+        autocompleteSuggestions={false}
+      />
+    );
+    expect(wrapper.find(".sui-search-box__section-title").length).toEqual(0);
+  });
+});
+
+describe("When there are no results", () => {
+  it("will NOT render results", () => {
+    const wrapper = shallow(
+      <Autocomplete
+        {...props}
+        autocompletedResults={[]}
+        autocompleteResults={true}
+        autocompleteSuggestions={false}
+      />
+    );
+    expect(wrapper.find(".sui-search-box__results-list").length).toEqual(0);
+  });
+
+  it("will NOT render a result section title", () => {
+    const wrapper = shallow(
+      <Autocomplete
+        {...props}
+        autocompletedResults={[]}
+        autocompleteResults={{
+          sectionTitle: "Results",
+          titleField: "title",
+          urlField: "nps_link",
+          linkTarget: "_blank"
+        }}
+        autocompleteSuggestions={false}
+      />
+    );
+    expect(wrapper.find(".sui-search-box__section-title").length).toEqual(0);
+  });
+});
+
+describe("When there are suggestions", () => {
+  it("will render suggestions", () => {
+    const wrapper = shallow(
+      <Autocomplete
+        {...props}
+        autocompleteResults={false}
+        autocompleteSuggestions={true}
+      />
+    );
+    expect(wrapper.find(".sui-search-box__suggestion-list li").length).toEqual(
+      6
+    );
+  });
+
+  it("will NOT render suggestions if autocompleteSuggestions is false", () => {
+    const wrapper = shallow(
+      <Autocomplete
+        {...props}
+        autocompleteResults={false}
+        autocompleteSuggestions={false}
+      />
+    );
+    expect(wrapper.find(".sui-search-box__suggestion-list").length).toEqual(0);
+  });
+
+  it("will render a suggestion section title if one is provided", () => {
+    const wrapper = shallow(
+      <Autocomplete
+        {...props}
+        autocompleteResults={false}
+        autocompleteSuggestions={{
+          documents: {
+            sectionTitle: "Suggested"
+          }
+        }}
+      />
+    );
+    expect(wrapper.find(".sui-search-box__section-title").text()).toEqual(
+      "Suggested"
+    );
+  });
+
+  it("will NOT render a suggestion section title if none is provided", () => {
+    const wrapper = shallow(
+      <Autocomplete
+        {...props}
+        autocompleteResults={false}
+        autocompleteSuggestions={true}
+      />
+    );
+    expect(wrapper.find(".sui-search-box__section-title").length).toEqual(0);
+  });
+});
+
+describe("When there are no suggestions", () => {
+  it("will NOT render suggestions", () => {
+    const wrapper = shallow(
+      <Autocomplete
+        {...props}
+        autocompleteResults={false}
+        autocompletedSuggestions={{}}
+        autocompleteSuggestions={true}
+      />
+    );
+    expect(wrapper.find(".sui-search-box__suggestion-list").length).toEqual(0);
+  });
+
+  it("will NOT render a suggestion section title", () => {
+    const wrapper = shallow(
+      <Autocomplete
+        {...props}
+        autocompleteResults={false}
+        autocompletedSuggestions={{}}
+        autocompleteSuggestions={{
+          documents: {
+            sectionTitle: "Suggested"
+          }
+        }}
+      />
+    );
+    expect(wrapper.find(".sui-search-box__section-title").length).toEqual(0);
+  });
 });

--- a/packages/react-search-ui-views/src/__tests__/SearchBox.test.js
+++ b/packages/react-search-ui-views/src/__tests__/SearchBox.test.js
@@ -5,8 +5,10 @@ import { shallow } from "enzyme";
 const requiredProps = {
   onChange: () => {},
   onSubmit: () => {},
+  allAutocompletedItemsCount: 0,
   autocompletedResults: [],
   autocompletedSuggestions: {},
+  autocompletedSuggestionsCount: 0,
   notifyAutocompleteSelected: () => {},
   value: "test"
 };

--- a/packages/react-search-ui-views/src/__tests__/__snapshots__/Autocomplete.test.js.snap
+++ b/packages/react-search-ui-views/src/__tests__/__snapshots__/Autocomplete.test.js.snap
@@ -10,7 +10,9 @@ exports[`renders correctly 1`] = `
     >
       Results
     </div>
-    <ul>
+    <ul
+      className="sui-search-box__results-list"
+    >
       <li
         index={0}
         item={
@@ -83,7 +85,9 @@ exports[`renders correctly 1`] = `
     >
       Suggested
     </div>
-    <ul>
+    <ul
+      className="sui-search-box__suggestion-list"
+    >
       <li
         index={3}
         item={
@@ -132,7 +136,9 @@ exports[`renders correctly 1`] = `
     >
       Popular
     </div>
-    <ul>
+    <ul
+      className="sui-search-box__suggestion-list"
+    >
       <li
         index={6}
         item={

--- a/packages/react-search-ui/src/containers/SearchBox.js
+++ b/packages/react-search-ui/src/containers/SearchBox.js
@@ -60,6 +60,11 @@ export class SearchBoxContainer extends Component {
     });
   };
 
+  completeSuggestion = searchTerm => {
+    const { setSearchTerm } = this.props;
+    setSearchTerm(searchTerm);
+  };
+
   handleSubmit = e => {
     const { searchTerm, setSearchTerm } = this.props;
 
@@ -139,6 +144,7 @@ export class SearchBoxContainer extends Component {
       autocompletedSuggestionsCount: autocompletedSuggestionsCount,
       autocompletedResults: autocompletedResults,
       autocompletedSuggestions: autocompletedSuggestions,
+      completeSuggestion: this.completeSuggestion,
       isFocused: isFocused,
       notifyAutocompleteSelected: this.handleNotifyAutocompleteSelected,
       onChange: value => this.handleChange(value),

--- a/packages/react-search-ui/src/containers/SearchBox.js
+++ b/packages/react-search-ui/src/containers/SearchBox.js
@@ -125,10 +125,18 @@ export class SearchBoxContainer extends Component {
     const useAutocomplete =
       (!!autocompleteResults || !!autocompleteSuggestions) &&
       searchTerm.length >= autocompleteMinimumCharacters;
+    const autocompletedSuggestionsCount = Object.entries(
+      autocompletedSuggestions
+      // eslint-disable-next-line no-unused-vars
+    ).reduce((acc, [_, value]) => acc + value.length, 0);
+    const allAutocompletedItemsCount =
+      autocompletedSuggestionsCount + autocompletedResults.length;
 
     return View({
+      allAutocompletedItemsCount: allAutocompletedItemsCount,
       autocompleteResults: autocompleteResults,
       autocompleteSuggestions: autocompleteSuggestions,
+      autocompletedSuggestionsCount: autocompletedSuggestionsCount,
       autocompletedResults: autocompletedResults,
       autocompletedSuggestions: autocompletedSuggestions,
       isFocused: isFocused,

--- a/packages/react-search-ui/src/containers/__tests__/SearchBox.test.js
+++ b/packages/react-search-ui/src/containers/__tests__/SearchBox.test.js
@@ -42,7 +42,7 @@ it("will keep focus prop in sync with view component", () => {
 });
 
 describe("useAutocomplete", () => {
-  it("will be true  if autocompleteResults configuration has been provided", () => {
+  it("will be true if autocompleteResults configuration has been provided", () => {
     let viewProps;
 
     shallow(
@@ -67,6 +67,43 @@ describe("useAutocomplete", () => {
     viewProps.onChange("new term");
     expect(viewProps.useAutocomplete).toBe(false);
   });
+
+  it("will be true if autocompleteSuggestions configuration has been provided", () => {
+    let viewProps;
+
+    shallow(
+      <SearchBoxContainer
+        {...params}
+        autocompleteSuggestions={{
+          documents: {
+            sectionTitle: "Suggested Queries"
+          }
+        }}
+        view={props => (viewProps = props)}
+      />
+    );
+    viewProps.onChange("new term");
+    expect(viewProps.useAutocomplete).toBe(true);
+  });
+
+  it("will be false if autocompleteMinimumCharacters is below threshold", () => {
+    let viewProps;
+
+    shallow(
+      <SearchBoxContainer
+        {...params}
+        autocompleteMinimumCharacters={4}
+        autocompleteSuggestions={{
+          documents: {
+            sectionTitle: "Suggested Queries"
+          }
+        }}
+        view={props => (viewProps = props)}
+      />
+    );
+    viewProps.onChange("new");
+    expect(viewProps.useAutocomplete).toBe(true);
+  });
 });
 
 it("will call back to setSearchTerm with refresh: false when input is changed", () => {
@@ -82,7 +119,12 @@ it("will call back to setSearchTerm with refresh: false when input is changed", 
   const call = params.setSearchTerm.mock.calls[0];
   expect(call).toEqual([
     "new term",
-    { refresh: false, autocompleteResults: false }
+    {
+      refresh: false,
+      autocompleteResults: false,
+      autocompleteSuggestions: false,
+      autocompleteMinimumCharacters: 0
+    }
   ]);
 });
 
@@ -103,6 +145,7 @@ it("will call back to setSearchTerm with autocompleteMinimumCharacters setting",
     {
       refresh: false,
       autocompleteResults: false,
+      autocompleteSuggestions: false,
       autocompleteMinimumCharacters: 3
     }
   ]);
@@ -125,7 +168,13 @@ it("will call back to setSearchTerm with refresh: true when input is changed and
   const call = params.setSearchTerm.mock.calls[0];
   expect(call).toEqual([
     "new term",
-    { refresh: true, debounce: 200, autocompleteResults: false }
+    {
+      refresh: true,
+      debounce: 200,
+      autocompleteResults: false,
+      autocompleteMinimumCharacters: 0,
+      autocompleteSuggestions: false
+    }
   ]);
 });
 
@@ -147,7 +196,13 @@ it("will call back to setSearchTerm with a specific debounce when input is chang
   const call = params.setSearchTerm.mock.calls[0];
   expect(call).toEqual([
     "new term",
-    { refresh: true, debounce: 500, autocompleteResults: false }
+    {
+      refresh: true,
+      debounce: 500,
+      autocompleteResults: false,
+      autocompleteMinimumCharacters: 0,
+      autocompleteSuggestions: false
+    }
   ]);
 });
 
@@ -172,7 +227,41 @@ it("will call back to setSearchTerm with a specific debounce when input is chang
   const call = params.setSearchTerm.mock.calls[0];
   expect(call).toEqual([
     "new term",
-    { refresh: false, debounce: 500, autocompleteResults: true }
+    {
+      refresh: false,
+      debounce: 500,
+      autocompleteResults: true,
+      autocompleteMinimumCharacters: 0,
+      autocompleteSuggestions: false
+    }
+  ]);
+});
+
+it("will call back to setSearchTerm with a specific debounce when input is changed and autocompleteSuggestions is true and a debounce is provided", () => {
+  let viewProps;
+  shallow(
+    <SearchBoxContainer
+      {...params}
+      autocompleteSuggestions={true}
+      debounceLength={500}
+      view={props => (viewProps = props)}
+    />
+  );
+
+  expect(viewProps.value).toBe("test");
+
+  viewProps.onChange("new term");
+
+  const call = params.setSearchTerm.mock.calls[0];
+  expect(call).toEqual([
+    "new term",
+    {
+      refresh: false,
+      debounce: 500,
+      autocompleteSuggestions: true,
+      autocompleteMinimumCharacters: 0,
+      autocompleteResults: false
+    }
   ]);
 });
 

--- a/packages/react-search-ui/src/containers/__tests__/SearchBox.test.js
+++ b/packages/react-search-ui/src/containers/__tests__/SearchBox.test.js
@@ -41,6 +41,87 @@ it("will keep focus prop in sync with view component", () => {
   expect(viewProps.isFocused).toBe(false);
 });
 
+describe("autocompletedSuggestionsCount", () => {
+  it("will calculate the total count of all suggestions", () => {
+    let viewProps;
+
+    shallow(
+      <SearchBoxContainer
+        {...params}
+        autocompletedSuggestions={{
+          documents: [
+            { suggestion: "carlsbad" },
+            { suggestion: "carlsbad caverns" },
+            { suggestion: "carolina" }
+          ],
+          other: [],
+          another: [{ suggestion: "carlsbad" }]
+        }}
+        view={props => (viewProps = props)}
+      />
+    );
+    viewProps.onChange("new term");
+    expect(viewProps.autocompletedSuggestionsCount).toBe(4);
+  });
+
+  it("will calculate the total count of all suggestions when there are none", () => {
+    let viewProps;
+
+    shallow(
+      <SearchBoxContainer
+        {...params}
+        autocompletedSuggestions={{}}
+        autocompleteSuggestions={false}
+        view={props => (viewProps = props)}
+      />
+    );
+    viewProps.onChange("new term");
+    expect(viewProps.autocompletedSuggestionsCount).toBe(0);
+  });
+});
+
+describe("allAutocompletedItemsCount", () => {
+  it("will calculate the total count of all autocomplete items", () => {
+    let viewProps;
+
+    shallow(
+      <SearchBoxContainer
+        {...params}
+        autocompletedResults={[{ id: { raw: 1 } }, { id: { raw: 2 } }]}
+        autocompletedSuggestions={{
+          documents: [
+            { suggestion: "carlsbad" },
+            { suggestion: "carlsbad caverns" },
+            { suggestion: "carolina" }
+          ],
+          other: [],
+          another: [{ suggestion: "carlsbad" }]
+        }}
+        view={props => (viewProps = props)}
+      />
+    );
+    viewProps.onChange("new term");
+    expect(viewProps.allAutocompletedItemsCount).toBe(6);
+  });
+
+  it("will calculate the total count of all autocomplete items when there are none", () => {
+    let viewProps;
+
+    shallow(
+      <SearchBoxContainer
+        {...params}
+        autocompleteResults={false}
+        autocompletedResults={[]}
+        autocompleteSuggestions={false}
+        autocompletedSuggestions={{}}
+        view={props => (viewProps = props)}
+      />
+    );
+    viewProps.onChange("new term");
+    expect(viewProps.allAutocompletedItemsCount).toBe(0);
+  });
+});
+
 describe("useAutocomplete", () => {
   it("will be true if autocompleteResults configuration has been provided", () => {
     let viewProps;

--- a/packages/react-search-ui/src/types/Suggestion.js
+++ b/packages/react-search-ui/src/types/Suggestion.js
@@ -1,0 +1,7 @@
+import PropTypes from "prop-types";
+
+export default PropTypes.shape({
+  suggestion: PropTypes.string,
+  highlight: PropTypes.string,
+  data: PropTypes.object
+});

--- a/packages/react-search-ui/src/types/index.js
+++ b/packages/react-search-ui/src/types/index.js
@@ -8,5 +8,6 @@ export { default as FilterValue } from "./FilterValue";
 export { default as FilterValueValue } from "./FilterValueValue";
 export { default as FilterValueRange } from "./FilterValueRange";
 export { default as Result } from "./Result";
+export { default as Suggestion } from "./Suggestion";
 
 export { default as SortOption } from "./SortOption";

--- a/packages/search-ui-app-search-connector/src/AppSearchAPIConnector.js
+++ b/packages/search-ui-app-search-connector/src/AppSearchAPIConnector.js
@@ -77,35 +77,41 @@ export default class AppSearchAPIConnector {
     return adaptResponse(response);
   }
 
-  async autocompleteResults({ searchTerm }, queryConfig) {
-    const {
-      current,
-      filters,
-      resultsPerPage,
-      sortDirection,
-      sortField,
-      ...restOfQueryConfig
-    } = queryConfig;
+  async autocomplete({ searchTerm }, queryConfig) {
+    const autocompletedState = {};
 
-    const { query, ...optionsFromState } = adaptRequest({
-      current,
-      searchTerm,
-      filters,
-      resultsPerPage,
-      sortDirection,
-      sortField
-    });
+    if (queryConfig.results) {
+      const {
+        current,
+        filters,
+        resultsPerPage,
+        sortDirection,
+        sortField,
+        ...restOfQueryConfig
+      } = queryConfig.results;
 
-    const withQueryConfigOptions = {
-      ...restOfQueryConfig,
-      ...optionsFromState
-    };
-    const options = {
-      ...withQueryConfigOptions,
-      ...this.additionalOptions(withQueryConfigOptions)
-    };
+      const { query, ...optionsFromState } = adaptRequest({
+        current,
+        searchTerm,
+        filters,
+        resultsPerPage,
+        sortDirection,
+        sortField
+      });
 
-    const response = await this.client.search(query, options);
-    return adaptResponse(response);
+      const withQueryConfigOptions = {
+        ...restOfQueryConfig,
+        ...optionsFromState
+      };
+      const options = {
+        ...withQueryConfigOptions,
+        ...this.additionalOptions(withQueryConfigOptions)
+      };
+
+      const response = await this.client.search(query, options);
+      autocompletedState.autocompletedResults = adaptResponse(response).results;
+    }
+
+    return autocompletedState;
   }
 }

--- a/packages/search-ui-app-search-connector/src/__tests__/AppSearchAPIConnector.test.js
+++ b/packages/search-ui-app-search-connector/src/__tests__/AppSearchAPIConnector.test.js
@@ -317,7 +317,7 @@ describe("AppSearchAPIConnector", () => {
     });
   });
 
-  describe("autocompleteResults", () => {
+  describe("autocomplete", () => {
     function subject(state = {}, queryConfig = {}, additionalOptions) {
       if (!state.searchTerm) state.searchTerm = "searchTerm";
 
@@ -326,12 +326,19 @@ describe("AppSearchAPIConnector", () => {
         additionalOptions
       });
 
-      return connector.autocompleteResults(state, queryConfig);
+      return connector.autocomplete(state, queryConfig);
     }
 
     it("will return updated search state", async () => {
-      const state = await subject();
-      expect(state).toEqual(resultState);
+      const state = await subject({}, { results: {} });
+      expect(state).toEqual({
+        autocompletedResults: resultState.results
+      });
+    });
+
+    it("will return empty state if no autocomplete type is specified", async () => {
+      const state = await subject({}, {});
+      expect(state).toEqual({});
     });
 
     it("will pass searchTerm from state through to search endpoint", async () => {
@@ -339,7 +346,7 @@ describe("AppSearchAPIConnector", () => {
         searchTerm: "searchTerm"
       };
 
-      await subject(state);
+      await subject(state, { results: {} });
       const [passedSearchTerm, passedOptions] = getLastSearchCall();
       expect(passedSearchTerm).toEqual(state.searchTerm);
       expect(passedOptions).toEqual({
@@ -354,13 +361,15 @@ describe("AppSearchAPIConnector", () => {
       };
 
       const queryConfig = {
-        result_fields: {
-          title: { raw: {}, snippet: { size: 20, fallback: true } }
-        },
-        search_fields: {
-          title: {},
-          description: {},
-          states: {}
+        results: {
+          result_fields: {
+            title: { raw: {}, snippet: { size: 20, fallback: true } }
+          },
+          search_fields: {
+            title: {},
+            description: {},
+            states: {}
+          }
         }
       };
 
@@ -387,17 +396,19 @@ describe("AppSearchAPIConnector", () => {
       };
 
       const queryConfig = {
-        current: 2,
-        resultsPerPage: 5,
-        filters: [
-          {
-            field: "world_heritage_site",
-            values: ["true"],
-            type: "all"
-          }
-        ],
-        sortDirection: "desc",
-        sortField: "name"
+        results: {
+          current: 2,
+          resultsPerPage: 5,
+          filters: [
+            {
+              field: "world_heritage_site",
+              values: ["true"],
+              type: "all"
+            }
+          ],
+          sortDirection: "desc",
+          sortField: "name"
+        }
       };
 
       await subject(state, queryConfig);

--- a/packages/search-ui-site-search-connector/src/SiteSearchAPIConnector.js
+++ b/packages/search-ui-site-search-connector/src/SiteSearchAPIConnector.js
@@ -64,18 +64,27 @@ export default class SiteSearchAPIConnector {
     });
   }
 
-  async autocompleteResults({ searchTerm }, queryConfig) {
-    const options = adaptRequest(
-      { searchTerm },
-      queryConfig,
-      this.documentType
-    );
+  async autocomplete({ searchTerm }, queryConfig) {
+    if (queryConfig.results) {
+      const options = adaptRequest(
+        { searchTerm },
+        queryConfig.results,
+        this.documentType
+      );
 
-    return this.request("POST", "engines/suggest.json", {
-      ...options,
-      ...this.additionalOptions(options)
-    }).then(json => {
-      return adaptResponse(json, this.documentType);
-    });
+      return this.request("POST", "engines/suggest.json", {
+        ...options,
+        ...this.additionalOptions(options)
+      }).then(json => {
+        return {
+          autocompletedResults: adaptResponse(json, this.documentType).results
+        };
+      });
+    }
+    if (queryConfig.suggestions) {
+      console.warn(
+        "search-ui-site-search-connector: Site Search does support query suggestions on autocomplete"
+      );
+    }
   }
 }

--- a/packages/search-ui-site-search-connector/src/__tests__/SiteSearchAPIConnector.test.js
+++ b/packages/search-ui-site-search-connector/src/__tests__/SiteSearchAPIConnector.test.js
@@ -212,15 +212,25 @@ describe("#search", () => {
 });
 
 describe("#autocompleteResults", () => {
-  function subject({ state, queryConfig = {} }) {
+  function subject({
+    state,
+    queryConfig = {
+      results: {}
+    }
+  }) {
     const connector = new SiteSearchAPIConnector({
       ...params
     });
-    return connector.autocompleteResults(state, queryConfig);
+    return connector.autocomplete(state, queryConfig);
   }
 
   it("will correctly format an API response", async () => {
-    const response = await subject({ state: {}, queryConfig: {} });
+    const response = await subject({
+      state: {},
+      queryConfig: {
+        results: {}
+      }
+    });
     expect(response).toMatchSnapshot();
   });
 
@@ -243,13 +253,15 @@ describe("#autocompleteResults", () => {
     };
 
     const queryConfig = {
-      result_fields: {
-        title: { raw: {}, snippet: { size: 20, fallback: true } }
-      },
-      search_fields: {
-        title: {},
-        description: {},
-        states: {}
+      results: {
+        result_fields: {
+          title: { raw: {}, snippet: { size: 20, fallback: true } }
+        },
+        search_fields: {
+          title: {},
+          description: {},
+          states: {}
+        }
       }
     };
 
@@ -278,17 +290,19 @@ describe("#autocompleteResults", () => {
     };
 
     const queryConfig = {
-      current: 2,
-      resultsPerPage: 5,
-      filters: [
-        {
-          field: "world_heritage_site",
-          values: ["true"],
-          type: "all"
-        }
-      ],
-      sortDirection: "desc",
-      sortField: "name"
+      results: {
+        current: 2,
+        resultsPerPage: 5,
+        filters: [
+          {
+            field: "world_heritage_site",
+            values: ["true"],
+            type: "all"
+          }
+        ],
+        sortDirection: "desc",
+        sortField: "name"
+      }
     };
 
     await subject({ state, queryConfig });

--- a/packages/search-ui-site-search-connector/src/__tests__/__snapshots__/SiteSearchAPIConnector.test.js.snap
+++ b/packages/search-ui-site-search-connector/src/__tests__/__snapshots__/SiteSearchAPIConnector.test.js.snap
@@ -2,22 +2,7 @@
 
 exports[`#autocompleteResults will correctly format an API response 1`] = `
 Object {
-  "facets": Object {
-    "states": Array [
-      Object {
-        "data": Array [
-          Object {
-            "count": 2,
-            "value": "Maine",
-          },
-        ],
-        "field": "states",
-        "type": "value",
-      },
-    ],
-  },
-  "requestId": "",
-  "results": Array [
+  "autocompletedResults": Array [
     Object {
       "acres": Object {
         "raw": 49057.36,
@@ -71,8 +56,6 @@ Object {
       },
     },
   ],
-  "totalPages": 1,
-  "totalResults": 2,
 }
 `;
 

--- a/packages/search-ui/src/SearchDriver.js
+++ b/packages/search-ui/src/SearchDriver.js
@@ -149,19 +149,22 @@ export default class SearchDriver {
     }
   }
 
-  _updateAutocompleteResults = searchTerm => {
+  _updateAutocomplete = (searchTerm, autocompleteResults) => {
     const requestId = this.requestSequencer.next();
-    const autocompleteQueryResults = this.autocompleteQuery.results || {};
+
+    const queryConfig = {
+      ...(autocompleteResults && {
+        results: this.autocompleteQuery.results || {}
+      })
+    };
 
     return this.apiConnector
-      .autocompleteResults({ searchTerm }, autocompleteQueryResults)
-      .then(autocompletedResults => {
+      .autocomplete({ searchTerm }, queryConfig)
+      .then(autocompleted => {
         if (this.requestSequencer.isOldRequest(requestId)) return;
         this.requestSequencer.completed(requestId);
 
-        this._setState({
-          autocompletedResults: autocompletedResults.results
-        });
+        this._setState(autocompleted);
       });
   };
 

--- a/packages/search-ui/src/SearchDriver.js
+++ b/packages/search-ui/src/SearchDriver.js
@@ -34,6 +34,7 @@ export const DEFAULT_STATE = {
   // Result State -- This state represents state that is updated automatically
   // as the result of changing input state.
   autocompletedResults: [],
+  autocompletedSuggestions: {},
   error: "",
   isLoading: false,
   facets: {},
@@ -149,12 +150,18 @@ export default class SearchDriver {
     }
   }
 
-  _updateAutocomplete = (searchTerm, autocompleteResults) => {
+  _updateAutocomplete = (
+    searchTerm,
+    { autocompleteResults, autocompleteSuggestions } = {}
+  ) => {
     const requestId = this.requestSequencer.next();
 
     const queryConfig = {
       ...(autocompleteResults && {
         results: this.autocompleteQuery.results || {}
+      }),
+      ...(autocompleteSuggestions && {
+        suggestions: this.autocompleteQuery.suggestions || {}
       })
     };
 

--- a/packages/search-ui/src/__tests__/SearchDriver.test.js
+++ b/packages/search-ui/src/__tests__/SearchDriver.test.js
@@ -25,13 +25,12 @@ function getSearchCalls(specificMockApiConnector) {
   return (specificMockApiConnector || mockApiConnector).search.mock.calls;
 }
 
-function getAutocompleteResultsCalls(specificMockApiConnector) {
-  return (specificMockApiConnector || mockApiConnector).autocompleteResults.mock
-    .calls;
+function getAutocompleteCalls(specificMockApiConnector) {
+  return (specificMockApiConnector || mockApiConnector).autocomplete.mock.calls;
 }
 
 beforeEach(() => {
-  mockApiConnector.autocompleteResults.mockClear();
+  mockApiConnector.autocomplete.mockClear();
   mockApiConnector.search.mockClear();
   mockApiConnector.click.mockClear();
 });
@@ -244,7 +243,7 @@ describe("autocompleteQuery config", () => {
   it("will pass through result_fields configuration", () => {
     const result_fields = { test: {} };
     subject({ result_fields });
-    expect(getAutocompleteResultsCalls()[0][1].result_fields).toEqual(
+    expect(getAutocompleteCalls()[0][1].results.result_fields).toEqual(
       result_fields
     );
   });
@@ -252,7 +251,7 @@ describe("autocompleteQuery config", () => {
   it("will pass through search_fields configuration", () => {
     const search_fields = { test: {} };
     subject({ search_fields });
-    expect(getAutocompleteResultsCalls()[0][1].search_fields).toEqual(
+    expect(getAutocompleteCalls()[0][1].results.search_fields).toEqual(
       search_fields
     );
   });

--- a/packages/search-ui/src/__tests__/actions/setSearchTerm.test.js
+++ b/packages/search-ui/src/__tests__/actions/setSearchTerm.test.js
@@ -1,5 +1,5 @@
 import {
-  getAutocompleteResultsCalls,
+  getAutocompleteCalls,
   getSearchCalls,
   setupDriver,
   waitABit
@@ -130,7 +130,7 @@ describe("#setSearchTerm", () => {
         autocompleteResults: true,
         refresh: false
       });
-      expect(getAutocompleteResultsCalls(mockApiConnector)).toHaveLength(3);
+      expect(getAutocompleteCalls(mockApiConnector)).toHaveLength(3);
     });
 
     it("Will debounce requests", async () => {
@@ -151,7 +151,7 @@ describe("#setSearchTerm", () => {
         refresh: false
       });
       await waitABit(100);
-      expect(getAutocompleteResultsCalls(mockApiConnector)).toHaveLength(1);
+      expect(getAutocompleteCalls(mockApiConnector)).toHaveLength(1);
     });
 
     describe("and autocompleteMinimumCharacters is set and less than requirement", () => {
@@ -162,7 +162,7 @@ describe("#setSearchTerm", () => {
           autocompleteResults: true,
           refresh: false
         });
-        expect(getAutocompleteResultsCalls(mockApiConnector)).toHaveLength(0);
+        expect(getAutocompleteCalls(mockApiConnector)).toHaveLength(0);
       });
     });
 
@@ -174,7 +174,7 @@ describe("#setSearchTerm", () => {
           autocompleteResults: true,
           refresh: false
         });
-        expect(getAutocompleteResultsCalls(mockApiConnector)).toHaveLength(1);
+        expect(getAutocompleteCalls(mockApiConnector)).toHaveLength(1);
       });
     });
   });

--- a/packages/search-ui/src/actions/setSearchTerm.js
+++ b/packages/search-ui/src/actions/setSearchTerm.js
@@ -41,8 +41,9 @@ export default function setSearchTerm(
   ) {
     this.debounceManager.runWithDebounce(
       debounce,
-      this._updateAutocompleteResults,
-      searchTerm
+      this._updateAutocomplete,
+      searchTerm,
+      autocompleteResults
     );
   }
 }

--- a/packages/search-ui/src/actions/setSearchTerm.js
+++ b/packages/search-ui/src/actions/setSearchTerm.js
@@ -38,7 +38,7 @@ export default function setSearchTerm(
 
   if (
     (autocompleteResults || autocompleteSuggestions) &&
-    searchTerm.length > autocompleteMinimumCharacters
+    searchTerm.length >= autocompleteMinimumCharacters
   ) {
     this.debounceManager.runWithDebounce(
       debounce,

--- a/packages/search-ui/src/actions/setSearchTerm.js
+++ b/packages/search-ui/src/actions/setSearchTerm.js
@@ -17,6 +17,7 @@ export default function setSearchTerm(
   {
     autocompleteMinimumCharacters = 0,
     autocompleteResults = false,
+    autocompleteSuggestions = false,
     refresh = true,
     debounce = 0
   } = {}
@@ -36,14 +37,17 @@ export default function setSearchTerm(
   }
 
   if (
-    autocompleteResults &&
+    (autocompleteResults || autocompleteSuggestions) &&
     searchTerm.length > autocompleteMinimumCharacters
   ) {
     this.debounceManager.runWithDebounce(
       debounce,
       this._updateAutocomplete,
       searchTerm,
-      autocompleteResults
+      {
+        autocompleteResults,
+        autocompleteSuggestions
+      }
     );
   }
 }

--- a/packages/search-ui/src/test/helpers.js
+++ b/packages/search-ui/src/test/helpers.js
@@ -10,9 +10,12 @@ const searchResponse = {
 
 export function getMockApiConnector() {
   return {
-    autocompleteResults: jest
-      .fn()
-      .mockReturnValue({ then: cb => cb(searchResponse) }),
+    autocomplete: jest.fn().mockReturnValue({
+      then: cb =>
+        cb({
+          autocompletedResults: searchResponse.results
+        })
+    }),
     search: jest.fn().mockReturnValue({ then: cb => cb(searchResponse) }),
     click: jest.fn().mockReturnValue({ then: () => {} }),
     autocompleteClick: jest.fn().mockReturnValue({ then: () => {} })
@@ -85,8 +88,8 @@ export function getSearchCalls(mockApiConnector) {
   return mockApiConnector.search.mock.calls;
 }
 
-export function getAutocompleteResultsCalls(mockApiConnector) {
-  return mockApiConnector.autocompleteResults.mock.calls;
+export function getAutocompleteCalls(mockApiConnector) {
+  return mockApiConnector.autocomplete.mock.calls;
 }
 
 export function getClickCalls(mockApiConnector) {

--- a/packages/search-ui/src/test/helpers.js
+++ b/packages/search-ui/src/test/helpers.js
@@ -1,5 +1,19 @@
 import SearchDriver from "../SearchDriver";
 
+const suggestions = {
+  documents: [
+    {
+      suggestion: "carlsbad"
+    },
+    {
+      suggestion: "carlsbad caverns"
+    },
+    {
+      suggestion: "carolina"
+    }
+  ]
+};
+
 const searchResponse = {
   totalResults: 1000,
   totalPages: 100,
@@ -13,7 +27,8 @@ export function getMockApiConnector() {
     autocomplete: jest.fn().mockReturnValue({
       then: cb =>
         cb({
-          autocompletedResults: searchResponse.results
+          autocompletedResults: searchResponse.results,
+          autocompletedSuggestions: suggestions
         })
     }),
     search: jest.fn().mockReturnValue({ then: cb => cb(searchResponse) }),


### PR DESCRIPTION
This PR adds support for Query Suggestions to the autocomplete dropdown.

This issue documents the full design for this feature: https://github.com/elastic/search-ui/issues/113

Changes:
- Refactored the "autocompleteResults" method in the API Connectors to be a single method, called "autocomplete". This is better, because it's better to emit a single event and have the connector decide how many API calls they will need, rather than evoking two independent events, which an API might possibly be able to combine.

- BugFix: Autocomplete minimum chars ... renders on 3 characters, but doesn't perform new search until 4 characters

Testing:
To test this, run the sandbox app: https://github.com/elastic/search-ui/tree/master/examples/sandbox.

In `App.js`, play around with the `SearchBox` configuration options (which are documented in the Design issue linked above).

![latest](https://user-images.githubusercontent.com/1427475/55757282-93b45380-5a21-11e9-87b6-6414cf00e9e4.gif)
