### PR TITLE
Release v0.5.3

### DIFF
--- a/examples/sandbox/package.json
+++ b/examples/sandbox/package.json
@@ -1,13 +1,13 @@
 {
   "name": "sandbox",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "private": true,
   "dependencies": {
-    "@elastic/react-search-ui": "^0.5.2",
-    "@elastic/react-search-ui-views": "^0.5.2",
-    "@elastic/search-ui": "^0.5.2",
-    "@elastic/search-ui-app-search-connector": "^0.5.2",
-    "@elastic/search-ui-site-search-connector": "^0.5.2",
+    "@elastic/react-search-ui": "^0.5.3",
+    "@elastic/react-search-ui-views": "^0.5.3",
+    "@elastic/search-ui": "^0.5.3",
+    "@elastic/search-ui-app-search-connector": "^0.5.3",
+    "@elastic/search-ui-site-search-connector": "^0.5.3",
     "react": "^16.8.1",
     "react-dom": "^16.8.1",
     "react-scripts": "2.1.5"

--- a/examples/sandbox/src/App.js
+++ b/examples/sandbox/src/App.js
@@ -26,43 +26,41 @@ export default function App() {
   return (
     <SearchProvider
       config={{
-        searchQuery: {
-          search_fields: {
-            title: {},
-            description: {}
-          },
-          result_fields: {
-            title: {
-              snippet: {
-                size: 100,
-                fallback: true
-              }
-            },
-            nps_link: {
-              raw: {}
-            },
-            description: {
-              snippet: {
-                size: 100,
-                fallback: true
-              }
+        apiConnector: connector,
+        search_fields: {
+          title: {},
+          description: {}
+        },
+        result_fields: {
+          title: {
+            snippet: {
+              size: 100,
+              fallback: true
             }
           },
-          disjunctiveFacets: ["acres"],
-          facets: {
-            states: { type: "value", size: 30 },
-            acres: {
-              type: "range",
-              ranges: [
-                { from: -1, name: "Any" },
-                { from: 0, to: 1000, name: "Small" },
-                { from: 1001, to: 100000, name: "Medium" },
-                { from: 100001, name: "Large" }
-              ]
+          nps_link: {
+            raw: {}
+          },
+          description: {
+            snippet: {
+              size: 100,
+              fallback: true
             }
           }
         },
-        apiConnector: connector
+        disjunctiveFacets: ["acres"],
+        facets: {
+          states: { type: "value", size: 30 },
+          acres: {
+            type: "range",
+            ranges: [
+              { from: -1, name: "Any" },
+              { from: 0, to: 1000, name: "Small" },
+              { from: 1001, to: 100000, name: "Medium" },
+              { from: 100001, name: "Large" }
+            ]
+          }
+        }
       }}
     >
       {_ => (

--- a/lerna.json
+++ b/lerna.json
@@ -3,7 +3,7 @@
     "examples/*",
     "packages/*"
   ],
-  "version": "0.5.2",
+  "version": "0.5.3",
   "command": {
     "publish": {
       "ignoreChanges": [

--- a/packages/react-search-ui-views/package.json
+++ b/packages/react-search-ui-views/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elastic/react-search-ui-views",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "A collection of React UI components for building search experiences",
   "license": "Apache-2.0",
   "main": "lib",

--- a/packages/react-search-ui/CHANGELOG.md
+++ b/packages/react-search-ui/CHANGELOG.md
@@ -31,3 +31,9 @@ Breaking Changes:
 ## 0.5.1 (March 7, 2019)
 
 Fixed this error: "ReferenceError: regeneratorRuntime is not defined"
+
+## 0.5.3 (April 10, 2019)
+
+- Fixed inter-package dependencies so they are fixed to current version.
+- Reverted breaking change introduced in version 0.5.2, which moved
+  certain configuration in the SearchDriver to a 'queryConfig' property.

--- a/packages/react-search-ui/package.json
+++ b/packages/react-search-ui/package.json
@@ -32,8 +32,8 @@
   },
   "dependencies": {
     "@babel/polyfill": "^7.2.5",
-    "@elastic/react-search-ui-views": "^0.5.2",
-    "@elastic/search-ui": "^0.5.2",
+    "@elastic/react-search-ui-views": "0.5.2",
+    "@elastic/search-ui": "0.5.2",
     "debounce-fn": "^1.0.0"
   },
   "peerDependencies": {

--- a/packages/react-search-ui/package.json
+++ b/packages/react-search-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elastic/react-search-ui",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "A React library for building search experiences",
   "license": "Apache-2.0",
   "main": "lib",
@@ -32,8 +32,8 @@
   },
   "dependencies": {
     "@babel/polyfill": "^7.2.5",
-    "@elastic/react-search-ui-views": "0.5.2",
-    "@elastic/search-ui": "0.5.2",
+    "@elastic/react-search-ui-views": "^0.5.3",
+    "@elastic/search-ui": "^0.5.3",
     "debounce-fn": "^1.0.0"
   },
   "peerDependencies": {

--- a/packages/search-ui-app-search-connector/package.json
+++ b/packages/search-ui-app-search-connector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elastic/search-ui-app-search-connector",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "A Search UI connector for Elastic's App Search Service",
   "license": "Apache-2.0",
   "main": "lib",

--- a/packages/search-ui-elasticsearch-connector/package.json
+++ b/packages/search-ui-elasticsearch-connector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elastic/search-ui-elasticsearch-connector",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "A Search UI connector for elasticsearch",
   "license": "Apache-2.0",
   "main": "lib",

--- a/packages/search-ui-site-search-connector/package.json
+++ b/packages/search-ui-site-search-connector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elastic/search-ui-site-search-connector",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "A Search UI connector for Elastic's Site Search Service",
   "license": "Apache-2.0",
   "main": "lib",

--- a/packages/search-ui/CHANGELOG.md
+++ b/packages/search-ui/CHANGELOG.md
@@ -39,3 +39,8 @@ Breaking Changes:
 ## 0.5.1 (March 7, 2019)
 
 Fixed this error: "ReferenceError: regeneratorRuntime is not defined"
+
+## 0.5.3 (April 10, 2019)
+
+- Reverted breaking change introduced in version 0.5.2, which moved
+  certain configuration in the SearchDriver to a 'queryConfig' property.

--- a/packages/search-ui/package.json
+++ b/packages/search-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elastic/search-ui",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "A Headless Search UI library",
   "license": "Apache-2.0",
   "main": "lib",

--- a/packages/search-ui/src/SearchDriver.js
+++ b/packages/search-ui/src/SearchDriver.js
@@ -72,8 +72,13 @@ export default class SearchDriver {
 
   constructor({
     apiConnector,
+    conditionalFacets,
+    disjunctiveFacets,
+    disjunctiveFacetsAnalyticsTags,
+    facets,
     initialState,
-    searchQuery = {},
+    result_fields,
+    search_fields,
     trackUrlState = true,
     urlPushDebounceLength = 500
   }) {
@@ -95,7 +100,12 @@ export default class SearchDriver {
     this.requestSequencer = new RequestSequencer();
     this.debounceManager = new DebounceManager();
     this.apiConnector = apiConnector;
-    this.searchQuery = searchQuery;
+    this.conditionalFacets = conditionalFacets;
+    this.disjunctiveFacets = disjunctiveFacets;
+    this.disjunctiveFacetsAnalyticsTags = disjunctiveFacetsAnalyticsTags;
+    this.facets = facets;
+    this.result_fields = result_fields;
+    this.search_fields = search_fields;
     this.subscriptions = [];
     this.trackUrlState = trackUrlState;
     this.urlPushDebounceLength = urlPushDebounceLength;
@@ -179,12 +189,15 @@ export default class SearchDriver {
     const requestId = this.requestSequencer.next();
 
     const queryConfig = {
-      ...this.searchQuery,
+      disjunctiveFacets: this.disjunctiveFacets,
+      disjunctiveFacetsAnalyticsTags: this.disjunctiveFacetsAnalyticsTags,
       facets: removeConditionalFacets(
-        this.searchQuery.facets,
-        this.searchQuery.conditionalFacets,
+        this.facets,
+        this.conditionalFacets,
         filters
-      )
+      ),
+      result_fields: this.result_fields,
+      search_fields: this.search_fields
     };
 
     const requestState = filterSearchParameters(this.state);

--- a/packages/search-ui/src/__tests__/SearchDriver.test.js
+++ b/packages/search-ui/src/__tests__/SearchDriver.test.js
@@ -113,113 +113,94 @@ it("will not sync initial state to the URL if trackURLState is set to false", ()
   expect(URLManager.mock.instances).toHaveLength(0);
 });
 
-describe("searchQuery config", () => {
-  describe("conditional facets", () => {
-    function subject(conditional) {
-      const driver = new SearchDriver({
-        ...params,
-        initialState: {
-          filters: [{ field: "initial", values: ["value"], type: "all" }],
-          searchTerm: "test"
-        },
-        searchQuery: {
-          facets: {
-            initial: {
-              type: "value"
-            }
-          },
-          conditionalFacets: {
-            initial: conditional
-          }
-        }
-      });
-
-      driver.setSearchTerm("test");
-    }
-
-    it("will fetch a conditional facet that passes its check", () => {
-      subject(filters => !!filters);
-
-      // 'initial' WAS included in request to server
-      expect(getSearchCalls()[1][1].facets).toEqual({
+describe("conditional facets", () => {
+  function subject(conditional) {
+    const driver = new SearchDriver({
+      ...params,
+      initialState: {
+        filters: [{ field: "initial", values: ["value"], type: "all" }],
+        searchTerm: "test"
+      },
+      facets: {
         initial: {
           type: "value"
         }
-      });
+      },
+      conditionalFacets: {
+        initial: conditional
+      }
     });
 
-    it("will not fetch a conditional facet that fails its check", () => {
-      subject(filters => !filters);
+    driver.setSearchTerm("test");
+  }
 
-      // 'initial' was NOT included in request to server
-      expect(getSearchCalls()[1][1].facets).toEqual({});
+  it("will fetch a conditional facet that passes its check", () => {
+    subject(filters => !!filters);
+
+    // 'initial' WAS included in request to server
+    expect(getSearchCalls()[1][1].facets).toEqual({
+      initial: {
+        type: "value"
+      }
     });
   });
 
-  describe("pass through values", () => {
-    function subject({
+  it("will not fetch a conditional facet that fails its check", () => {
+    subject(filters => !filters);
+
+    // 'initial' was NOT included in request to server
+    expect(getSearchCalls()[1][1].facets).toEqual({});
+  });
+});
+
+// disjunctiveFacetsAnalyticsTags
+describe("pass through values", () => {
+  function subject({
+    disjunctiveFacets,
+    disjunctiveFacetsAnalyticsTags,
+    result_fields,
+    search_fields
+  }) {
+    const driver = new SearchDriver({
+      ...params,
+      facets: {
+        initial: {
+          type: "value"
+        }
+      },
       disjunctiveFacets,
       disjunctiveFacetsAnalyticsTags,
       result_fields,
       search_fields
-    }) {
-      const driver = new SearchDriver({
-        ...params,
-        searchQuery: {
-          facets: {
-            initial: {
-              type: "value"
-            }
-          },
-          disjunctiveFacets,
-          disjunctiveFacetsAnalyticsTags,
-          result_fields,
-          search_fields
-        }
-      });
-
-      driver.setSearchTerm("test");
-    }
-
-    it("will pass through facet configuration", () => {
-      const facets = {
-        initial: {
-          type: "value"
-        }
-      };
-      subject({ facets });
-      expect(getSearchCalls()[0][1].facets).toEqual({
-        initial: {
-          type: "value"
-        }
-      });
     });
 
-    it("will pass through disjunctive facet configuration", () => {
-      const disjunctiveFacets = ["initial"];
-      subject({ disjunctiveFacets });
-      expect(getSearchCalls()[0][1].disjunctiveFacets).toEqual(["initial"]);
-    });
+    driver.setSearchTerm("test");
+  }
 
-    it("will pass through disjunctive facet analytics tags", () => {
-      const disjunctiveFacetsAnalyticsTags = ["Test"];
-      subject({ disjunctiveFacetsAnalyticsTags });
-      expect(getSearchCalls()[0][1].disjunctiveFacetsAnalyticsTags).toEqual([
-        "Test"
-      ]);
-    });
+  it("will pass through disjunctive facet configuration", () => {
+    const disjunctiveFacets = ["initial"];
+    subject({ disjunctiveFacets });
+    expect(getSearchCalls()[0][1].disjunctiveFacets).toEqual(["initial"]);
+  });
 
-    it("will pass through result_fields configuration", () => {
-      const result_fields = { test: {} };
-      subject({ result_fields });
-      expect(getSearchCalls()[0][1].result_fields).toEqual(result_fields);
-    });
+  it("will pass through disjunctive facet analytics tags", () => {
+    const disjunctiveFacetsAnalyticsTags = ["Test"];
+    subject({ disjunctiveFacetsAnalyticsTags });
+    expect(getSearchCalls()[0][1].disjunctiveFacetsAnalyticsTags).toEqual([
+      "Test"
+    ]);
+  });
 
-    it("will pass through search_fields configuration", () => {
-      const search_fields = { test: {} };
-      subject({ search_fields });
-      expect(getSearchCalls()[0][1].search_fields).toEqual(search_fields);
-    });
+  it("will pass through result_fields configuration", () => {
+    const result_fields = { test: {} };
+    subject({ result_fields });
+    expect(getSearchCalls()[0][1].result_fields).toEqual(result_fields);
+  });
+
+  it("will pass through search_fields configuration", () => {
+    const search_fields = { test: {} };
+    subject({ search_fields });
+    expect(getSearchCalls()[0][1].search_fields).toEqual(search_fields);
   });
 });
 


### PR DESCRIPTION
This is a patch release for v0.5.x.

v0.5.2 included an unintentional breaking change. I reverted this change as it was meant for v0.6.x, not v0.5.x: https://github.com/elastic/search-ui/pull/164/commits/a65b0567340baac0593749098e0dab4aaf5c06fa.

I also fixed the dependencies in `@elastic/react-search-ui` to use fixed dependencies on other search-ui packages of the same version. That way, if you install `@elastic/react-search-ui@0.5.1`, you won't get `@elastic/search-ui@0.5.2`, which is not compatible.

