### PR TITLE
Fix no configuration queries

### DIFF
--- a/packages/search-ui-app-search-connector/src/AppSearchAPIConnector.js
+++ b/packages/search-ui-app-search-connector/src/AppSearchAPIConnector.js
@@ -3,6 +3,16 @@ import * as SwiftypeAppSearch from "swiftype-app-search-javascript";
 import { adaptResponse } from "./responseAdapter";
 import { adaptRequest } from "./requestAdapters";
 
+// The API will error out if empty facets or filters objects
+// are sent.
+function removeEmptyFacetsAndFilters(options) {
+  const { facets, filters, ...rest } = options;
+  return {
+    ...(facets && Object.entries(facets).length > 0 && { facets }),
+    ...(filters && Object.entries(filters).length > 0 && { filters }),
+    ...rest
+  };
+}
 export default class AppSearchAPIConnector {
   /**
    * @param options Object
@@ -69,7 +79,7 @@ export default class AppSearchAPIConnector {
       ...optionsFromState
     };
     const options = {
-      ...withQueryConfigOptions,
+      ...removeEmptyFacetsAndFilters(withQueryConfigOptions),
       ...this.additionalOptions(withQueryConfigOptions)
     };
 
@@ -105,7 +115,7 @@ export default class AppSearchAPIConnector {
         ...optionsFromState
       };
       const options = {
-        ...withQueryConfigOptions,
+        ...removeEmptyFacetsAndFilters(withQueryConfigOptions),
         ...this.additionalOptions(withQueryConfigOptions)
       };
 

--- a/packages/search-ui-app-search-connector/src/__tests__/AppSearchAPIConnector.test.js
+++ b/packages/search-ui-app-search-connector/src/__tests__/AppSearchAPIConnector.test.js
@@ -242,7 +242,6 @@ describe("AppSearchAPIConnector", () => {
       const [passedSearchTerm, passedOptions] = getLastSearchCall();
       expect(passedSearchTerm).toEqual(state.searchTerm);
       expect(passedOptions).toEqual({
-        filters: {},
         facets: {
           states: {
             type: "value",
@@ -258,6 +257,26 @@ describe("AppSearchAPIConnector", () => {
           description: {},
           states: {}
         }
+      });
+    });
+
+    it("will not pass empty facets or filter state to search endpoint", async () => {
+      const state = {
+        searchTerm: "searchTerm",
+        filters: [],
+        facets: {}
+      };
+
+      const queryConfig = {
+        filters: [],
+        facets: {}
+      };
+
+      await subject(state, queryConfig);
+      // eslint-disable-next-line no-unused-vars
+      const [passedSearchTerm, passedOptions] = getLastSearchCall();
+      expect(passedOptions).toEqual({
+        page: {}
       });
     });
 
@@ -337,7 +356,6 @@ describe("AppSearchAPIConnector", () => {
       const [passedSearchTerm, passedOptions] = getLastSearchCall();
       expect(passedSearchTerm).toEqual(state.searchTerm);
       expect(passedOptions).toEqual({
-        filters: {},
         page: {
           current: 2
         },
@@ -376,7 +394,6 @@ describe("AppSearchAPIConnector", () => {
         const [passedSearchTerm, passedOptions] = getLastSearchCall();
         expect(passedSearchTerm).toEqual(state.searchTerm);
         expect(passedOptions).toEqual({
-          filters: {},
           page: {}
         });
       });
@@ -403,7 +420,6 @@ describe("AppSearchAPIConnector", () => {
         const [passedSearchTerm, passedOptions] = getLastSearchCall();
         expect(passedSearchTerm).toEqual(state.searchTerm);
         expect(passedOptions).toEqual({
-          filters: {},
           page: {},
           result_fields: {
             title: { raw: {}, snippet: { size: 20, fallback: true } }
@@ -413,6 +429,28 @@ describe("AppSearchAPIConnector", () => {
             description: {},
             states: {}
           }
+        });
+      });
+
+      it("will not pass empty facets or filter state to search endpoint", async () => {
+        const state = {
+          searchTerm: "searchTerm",
+          filters: [],
+          facets: {}
+        };
+
+        const queryConfig = {
+          results: {
+            filters: [],
+            facets: {}
+          }
+        };
+
+        await subject(state, queryConfig);
+        // eslint-disable-next-line no-unused-vars
+        const [passedSearchTerm, passedOptions] = getLastSearchCall();
+        expect(passedOptions).toEqual({
+          page: {}
         });
       });
 


### PR DESCRIPTION
When no configuration for facets is provided, the API errors out
because the following is sent on the request body:

```
facets: {}
```

So for example, if you were to take the default example off the README guide, it actually errors out.

```
<SearchProvider
      config={{
        apiConnector: connector
      }}
    >
      {() => (
        <div className="App">
          <Layout
            header={<SearchBox />}
            bodyContent={<Results titleField="title" urlField="nps_link" />}
          />
        </div>
      )}
    </SearchProvider>
```