### PR TITLE
Result container component no longer passes `fields` property to its views

### DIFF
--- a/packages/react-search-ui-views/src/Result.js
+++ b/packages/react-search-ui-views/src/Result.js
@@ -1,7 +1,48 @@
 import PropTypes from "prop-types";
 import React from "react";
 
-function Result({ fields, onClickLink, title, url }) {
+function getFieldType(result, field, type) {
+  if (result[field]) return result[field][type];
+}
+
+function getRaw(result, field) {
+  return getFieldType(result, field, "raw");
+}
+
+function getSnippet(result, field) {
+  return getFieldType(result, field, "snippet");
+}
+
+function htmlEscape(str) {
+  if (!str) return "";
+
+  return String(str)
+    .replace(/&/g, "&amp;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+function getEscapedField(result, field) {
+  // Fallback to raw values here, because non-string fields
+  // will not have a snippet fallback. Raw values MUST be html escaped.
+  const safeField =
+    getSnippet(result, field) || htmlEscape(getRaw(result, field));
+  return Array.isArray(safeField) ? safeField.join(", ") : safeField;
+}
+
+function getEscapedFields(result) {
+  return Object.keys(result).reduce((acc, field) => {
+    return { ...acc, [field]: getEscapedField(result, field) };
+  }, {});
+}
+
+function Result({ result, onClickLink, titleField, urlField }) {
+  const fields = getEscapedFields(result);
+  const title = getEscapedField(result, titleField);
+  const url = getRaw(result, urlField);
+
   return (
     <li className="sui-result">
       <div className="sui-result__header">
@@ -40,10 +81,10 @@ function Result({ fields, onClickLink, title, url }) {
 }
 
 Result.propTypes = {
-  fields: PropTypes.object.isRequired,
+  result: PropTypes.object.isRequired,
   onClickLink: PropTypes.func.isRequired,
-  title: PropTypes.string,
-  url: PropTypes.string
+  titleField: PropTypes.string,
+  urlField: PropTypes.string
 };
 
 export default Result;

--- a/packages/react-search-ui-views/src/__tests__/Result.test.js
+++ b/packages/react-search-ui-views/src/__tests__/Result.test.js
@@ -2,17 +2,15 @@ import React from "react";
 import Result from "../Result";
 import { shallow } from "enzyme";
 
+const TITLE_FIELD = "title"
+const URL_FIELD = "url"
+const TITLE_RESULT_VALUE = "Title"
+const URL_RESULT_VALUE = "http://www.example.com"
+
 const requiredProps = {
-  fields: { field: "value" },
+  result: { field: { raw: "value" } },
   onClickLink: () => {}
 };
-
-it("renders correctly when there is a URL", () => {
-  const wrapper = shallow(
-    <Result {...requiredProps} url="http://www.example.com" />
-  );
-  expect(wrapper).toMatchSnapshot();
-});
 
 it("renders correctly when there is not a URL or title", () => {
   const wrapper = shallow(<Result {...requiredProps} />);
@@ -20,13 +18,30 @@ it("renders correctly when there is not a URL or title", () => {
 });
 
 it("renders correctly when there is a title", () => {
-  const wrapper = shallow(<Result {...requiredProps} title="Title" />);
+  const wrapper = shallow(<Result {...{...requiredProps,  result: {...requiredProps.result, [TITLE_FIELD]: {raw: TITLE_RESULT_VALUE}}, titleField: TITLE_FIELD}} />);
+  expect(wrapper).toMatchSnapshot();
+});
+
+it("renders correctly when there is a titleField but it is not defined in result", () => {
+  const wrapper = shallow(<Result {...{...requiredProps, titleField: TITLE_FIELD}}  />);
+  expect(wrapper).toMatchSnapshot();
+});
+
+it("renders correctly when there is a URL", () => {
+  const wrapper = shallow(
+    <Result {...{...requiredProps,  result: {...requiredProps.result, [URL_FIELD]: {raw: URL_RESULT_VALUE}}, urlField: URL_FIELD}} />
+  );
+  expect(wrapper).toMatchSnapshot();
+});
+
+it("renders correctly when there is a urlField but it is not defined in result", () => {
+  const wrapper = shallow(<Result {...{...requiredProps, urlField: URL_FIELD}} />);
   expect(wrapper).toMatchSnapshot();
 });
 
 it("renders correctly when there is a title and url", () => {
   const wrapper = shallow(
-    <Result {...requiredProps} title="Title" url="http://www.example.com" />
+    <Result {...{...requiredProps,  result: {...requiredProps.result, [TITLE_FIELD]: {raw: TITLE_RESULT_VALUE}, [URL_FIELD]: {raw: URL_RESULT_VALUE}}, titleField: TITLE_FIELD, urlField: URL_FIELD}} />
   );
   expect(wrapper).toMatchSnapshot();
 });

--- a/packages/react-search-ui-views/src/__tests__/__snapshots__/Result.test.js.snap
+++ b/packages/react-search-ui-views/src/__tests__/__snapshots__/Result.test.js.snap
@@ -31,6 +31,24 @@ exports[`renders correctly when there is a URL 1`] = `
           }
         />
       </li>
+      <li
+        key="url"
+      >
+        <span
+          className="sui-result__key"
+        >
+          url
+        </span>
+         
+        <span
+          className="sui-result__value"
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "http://www.example.com",
+            }
+          }
+        />
+      </li>
     </ul>
   </div>
 </li>
@@ -76,6 +94,24 @@ exports[`renders correctly when there is a title 1`] = `
           }
         />
       </li>
+      <li
+        key="title"
+      >
+        <span
+          className="sui-result__key"
+        >
+          title
+        </span>
+         
+        <span
+          className="sui-result__value"
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "Title",
+            }
+          }
+        />
+      </li>
     </ul>
   </div>
 </li>
@@ -101,6 +137,114 @@ exports[`renders correctly when there is a title and url 1`] = `
       target="_blank"
     />
   </div>
+  <div
+    className="sui-result__body"
+  >
+    <ul
+      className="sui-result__details"
+    >
+      <li
+        key="field"
+      >
+        <span
+          className="sui-result__key"
+        >
+          field
+        </span>
+         
+        <span
+          className="sui-result__value"
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "value",
+            }
+          }
+        />
+      </li>
+      <li
+        key="title"
+      >
+        <span
+          className="sui-result__key"
+        >
+          title
+        </span>
+         
+        <span
+          className="sui-result__value"
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "Title",
+            }
+          }
+        />
+      </li>
+      <li
+        key="url"
+      >
+        <span
+          className="sui-result__key"
+        >
+          url
+        </span>
+         
+        <span
+          className="sui-result__value"
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "http://www.example.com",
+            }
+          }
+        />
+      </li>
+    </ul>
+  </div>
+</li>
+`;
+
+exports[`renders correctly when there is a titleField but it is not defined in result 1`] = `
+<li
+  className="sui-result"
+>
+  <div
+    className="sui-result__header"
+  />
+  <div
+    className="sui-result__body"
+  >
+    <ul
+      className="sui-result__details"
+    >
+      <li
+        key="field"
+      >
+        <span
+          className="sui-result__key"
+        >
+          field
+        </span>
+         
+        <span
+          className="sui-result__value"
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "value",
+            }
+          }
+        />
+      </li>
+    </ul>
+  </div>
+</li>
+`;
+
+exports[`renders correctly when there is a urlField but it is not defined in result 1`] = `
+<li
+  className="sui-result"
+>
+  <div
+    className="sui-result__header"
+  />
   <div
     className="sui-result__body"
   >

--- a/packages/react-search-ui-views/stories/Result.stories.js
+++ b/packages/react-search-ui-views/stories/Result.stories.js
@@ -6,44 +6,48 @@ import { action } from "@storybook/addon-actions";
 import { Result } from "../src";
 
 const baseProps = {
-  fields: {
-    one: 1,
-    two: 2,
-    highlighted: "Result with a <em>highlight</em>"
-  },
   onClickLink: action("clicked"),
-  title: "The title with <em>highlight</em>",
-  url: "The URL"
+  result: {
+    title: {raw: "The title with <em>highlight</em>"},
+    url: {raw: "The URL"},
+    one: {raw: 1},
+    two: {raw: 2},
+    highlighted: {raw: "Result with a <em>highlight</em>"}
+  },
+  titleField: "title",
+  urlField: "url"
 };
 
-const moreFields = {
-  zéro: 0,
-  un: 1,
-  deux: 2,
-  trois: 3,
-  quatre: 4,
-  cinq: 5,
-  six: 6,
-  sept: 7,
-  huit: 8,
-  neuf: 9,
-  dix: 10,
-  onze: 11,
-  douze: 12,
-  treize: 13,
-  quatorze: 14,
-  quinze: 15,
-  seize: 16,
-  "dix-sept": 17,
-  "dix-huit": 18,
-  "dix-neuf": 19,
-  vingt: 20
+const expandedResult = {
+  title: {raw: "The title with <em>highlight</em>"},
+  url: {raw: "The URL"},
+  zéro: {raw: 0},
+  un: {raw: 1},
+  deux: {raw: 2},
+  trois: {raw: 3},
+  quatre: {raw: 4},
+  cinq: {raw: 5},
+  six: {raw: 6},
+  sept: {raw: 7},
+  huit: {raw: 8},
+  neuf: {raw: 9},
+  dix: {raw: 10},
+  onze: {raw: 11},
+  douze: {raw: 12},
+  treize: {raw: 13},
+  quatorze: {raw: 14},
+  quinze: {raw: 15},
+  seize: {raw: 16},
+  "dix-sept": {raw: 17},
+  "dix-huit": {raw: 18},
+  "dix-neuf": {raw: 19},
+  vingt: {raw: 20}
 };
 
 storiesOf("Result", module)
   .add("basic", () => <Result {...{ ...baseProps }} />)
-  .add("no URL", () => <Result {...{ ...baseProps, url: null }} />)
-  .add("no title", () => <Result {...{ ...baseProps, title: null }} />)
+  .add("no URL", () => <Result {...{ ...baseProps, result: {...baseProps.result, url: undefined}, urlField: undefined }} />)
+  .add("no title", () => <Result {...{ ...baseProps, result: {...baseProps.result, title: undefined}, titleField: undefined }} />)
   .add("fields overflow container", () => (
-    <Result {...{ ...baseProps, fields: moreFields }} />
+    <Result {...{ ...baseProps, result: expandedResult }} />
   ));

--- a/packages/react-search-ui-views/stories/ResultsContainer.stories.js
+++ b/packages/react-search-ui-views/stories/ResultsContainer.stories.js
@@ -7,38 +7,42 @@ import { Results } from "../src";
 import { Result } from "../src";
 
 const baseProps = {
-  fields: {
-    one: 1,
-    two: 2,
-    highlighted: "Result with a <em>highlight</em>"
-  },
   onClickLink: action("clicked"),
-  title: "The title with <em>highlight</em>",
-  url: "The URL"
+  result: {
+    title: {raw: "The title with <em>highlight</em>"},
+    url: {raw: "The URL"},
+    one: {raw: 1},
+    two: {raw: 2},
+    highlighted: {raw: "Result with a <em>highlight</em>"}
+  },
+  titleField: "title",
+  urlField: "url"
 };
 
-const moreFields = {
-  zéro: 0,
-  un: 1,
-  deux: 2,
-  trois: 3,
-  quatre: 4,
-  cinq: 5,
-  six: 6,
-  sept: 7,
-  huit: 8,
-  neuf: 9,
-  dix: 10,
-  onze: 11,
-  douze: 12,
-  treize: 13,
-  quatorze: 14,
-  quinze: 15,
-  seize: 16,
-  "dix-sept": 17,
-  "dix-huit": 18,
-  "dix-neuf": 19,
-  vingt: 20
+const expandedResult = {
+  title: {raw: "The title with <em>highlight</em>"},
+  url: {raw: "The URL"},
+  zéro: {raw: 0},
+  un: {raw: 1},
+  deux: {raw: 2},
+  trois: {raw: 3},
+  quatre: {raw: 4},
+  cinq: {raw: 5},
+  six: {raw: 6},
+  sept: {raw: 7},
+  huit: {raw: 8},
+  neuf: {raw: 9},
+  dix: {raw: 10},
+  onze: {raw: 11},
+  douze: {raw: 12},
+  treize: {raw: 13},
+  quatorze: {raw: 14},
+  quinze: {raw: 15},
+  seize: {raw: 16},
+  "dix-sept": {raw: 17},
+  "dix-huit": {raw: 18},
+  "dix-neuf": {raw: 19},
+  vingt: {raw: 20}
 };
 
 storiesOf("Results Container", module)
@@ -53,28 +57,28 @@ storiesOf("Results Container", module)
   ))
   .add("long results", () => (
     <Results>
-      <Result {...{ ...baseProps, fields: moreFields }} />
-      <Result {...{ ...baseProps, fields: moreFields }} />
-      <Result {...{ ...baseProps, fields: moreFields }} />
-      <Result {...{ ...baseProps, fields: moreFields }} />
-      <Result {...{ ...baseProps, fields: moreFields }} />
+      <Result {...{ ...baseProps, result: expandedResult }} />
+      <Result {...{ ...baseProps, result: expandedResult }} />
+      <Result {...{ ...baseProps, result: expandedResult }} />
+      <Result {...{ ...baseProps, result: expandedResult }} />
+      <Result {...{ ...baseProps, result: expandedResult }} />
     </Results>
   ))
   .add("results without titles", () => (
     <Results>
-      <Result {...{ ...baseProps, title: null }} />
-      <Result {...{ ...baseProps, title: null }} />
-      <Result {...{ ...baseProps, title: null }} />
-      <Result {...{ ...baseProps, title: null }} />
-      <Result {...{ ...baseProps, title: null }} />
+      <Result {...{ ...baseProps, result: {...baseProps.result, title: undefined}, titleField: undefined }} />
+      <Result {...{ ...baseProps, result: {...baseProps.result, title: undefined}, titleField: undefined }} />
+      <Result {...{ ...baseProps, result: {...baseProps.result, title: undefined}, titleField: undefined }} />
+      <Result {...{ ...baseProps, result: {...baseProps.result, title: undefined}, titleField: undefined }} />
+      <Result {...{ ...baseProps, result: {...baseProps.result, title: undefined}, titleField: undefined }} />
     </Results>
   ))
   .add("results without urls", () => (
     <Results>
-      <Result {...{ ...baseProps, url: null }} />
-      <Result {...{ ...baseProps, url: null }} />
-      <Result {...{ ...baseProps, url: null }} />
-      <Result {...{ ...baseProps, url: null }} />
-      <Result {...{ ...baseProps, url: null }} />
+      <Result {...{ ...baseProps, result: {...baseProps.result, url: undefined}, urlField: undefined }} />
+      <Result {...{ ...baseProps, result: {...baseProps.result, url: undefined}, urlField: undefined }} />
+      <Result {...{ ...baseProps, result: {...baseProps.result, url: undefined}, urlField: undefined }} />
+      <Result {...{ ...baseProps, result: {...baseProps.result, url: undefined}, urlField: undefined }} />
+      <Result {...{ ...baseProps, result: {...baseProps.result, url: undefined}, urlField: undefined }} />
     </Results>
   ));

--- a/packages/react-search-ui/src/containers/Result.js
+++ b/packages/react-search-ui/src/containers/Result.js
@@ -5,49 +5,6 @@ import { Result } from "@elastic/react-search-ui-views";
 import { withSearch } from "..";
 import { Result as ResultType } from "../types";
 
-function getFieldType(result, field, type) {
-  if (!result[field] || !result[field][type]) return;
-  return result[field][type];
-}
-
-function getRaw(result, field) {
-  return getFieldType(result, field, 'raw');
-}
-
-function getSnippet(result, field) {
-  return getFieldType(result, field, 'snippet');
-}
-
-function htmlEscape(str) {
-  return String(str)
-    .replace(/&/g, "&amp;")
-    .replace(/"/g, "&quot;")
-    .replace(/'/g, "&#39;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;");
-}
-
-function getSafe(result, field) {
-  // Fallback to raw values here, because non-string fields
-  // will not have a snippet fallback. Raw values MUST be html escaped.
-  let safeField = getSnippet(result, field) || htmlEscape(getRaw(result, field));
-  return Array.isArray(safeField) ? safeField.join(", ") : safeField;
-}
-
-/*
-  Our `Result` component expects result fields to be formatted in an object
-  like:
-  {
-    field1: "value1",
-    field2: "value2"
-  }
-*/
-function getSafeResult(result) {
-  return Object.keys(result).reduce((acc, field) => {
-    return { ...acc, [field]: getSafe(result, field) };
-  }, {});
-}
-
 export class ResultContainer extends Component {
   static propTypes = {
     // Props
@@ -82,16 +39,11 @@ export class ResultContainer extends Component {
     const { result, titleField, urlField, view } = this.props;
     const View = view || Result;
 
-    const safeResult = getSafeResult(result)
-
     return View({
-      fields: safeResult,
       result: result,
-      key: `result-${getRaw(result, 'id')}`,
-      onClickLink: () => this.handleClickLink(getRaw(result, 'id')),
-      title: getSafe(result, titleField),
+      key: `result-${result.id.raw}`,
+      onClickLink: () => this.handleClickLink(result.id.raw),
       titleField,
-      url: getRaw(result, urlField),
       urlField
     });
   }


### PR DESCRIPTION
**This is a breaking change.**

Updates the `Result` container component so that it no longer passes a `fields` prop to its view, only the `result` prop.  We believe this will lessen the confusion around `fields` vs `result` for developers wishing to implement their own view for the `Result` or `Results` container components.

Based on feedback from @qhoxie:
https://github.com/elastic/search-ui/pull/175#discussion_r275045206
https://github.com/elastic/search-ui/pull/175#discussion_r275047967