### PR TITLE
Simplified the usage of suggestions

### DIFF
--- a/ADVANCED.md
+++ b/ADVANCED.md
@@ -273,19 +273,89 @@ import { SearchBox } from "@elastic/react-search-ui";
 <SearchBox inputProps={{ placeholder: "custom placeholder" }}/>
 ```
 
+### Example using Autocompleted Results
+
+```jsx
+
+import { SearchBox } from "@elastic/react-search-ui";
+
+...
+
+<SearchBox
+  autocompleteResults={{
+    titleField: "title",
+    urlField: "nps_link"
+  }}
+/>
+```
+
+### Example using Autocompleted Suggestions
+
+```jsx
+
+import { SearchBox } from "@elastic/react-search-ui";
+
+...
+
+<SearchBox
+  autocompleteSuggestions={true}
+/>
+```
+
+### Example using multiple types of Autocompleted Suggestions
+
+```jsx
+
+import { SearchBox } from "@elastic/react-search-ui";
+
+...
+
+<SearchBox
+  autocompleteSuggestions={{
+    documents: {
+      sectionTitle: "Suggested Queries"
+    },
+    popular_queries: {
+      sectionTitle: "Popular Queries"
+    }
+  }}
+/>
+```
+
+### Example using Autocompleted Suggestions and Autocompleted Results
+
+```jsx
+
+import { SearchBox } from "@elastic/react-search-ui";
+
+...
+
+<SearchBox
+  autocompleteMinimumCharacters={3}
+  autocompleteResults={{
+    sectionTitle: "Suggested Results",
+    titleField: "title",
+    urlField: "nps_link"
+  }}
+  autocompleteSuggestions={{
+    sectionTitle: "Suggested Queries"
+  }}
+/>
+```
+
 ### Properties
 
-| Name                          | type                                                                         | Required? | Default                                                            | Options | Description                                                                                                                                                                                                                                                                                                |
-| ----------------------------- | ---------------------------------------------------------------------------- | --------- | ------------------------------------------------------------------ | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| inputProps                    | Object                                                                       | no        |                                                                    |         | Props for underlying 'input' element. I.e., `{ placeholder: "Enter Text"}`                                                                                                                                                                                                                                 |
-| searchAsYouType               | Boolean                                                                      | no        | false                                                              |         | Executes a new search query with every key stroke. You can fine tune the number of queries made by adjusting the `debounceLength` parameter.                                                                                                                                                               |
-| debounceLength                | Number                                                                       | no        | 200                                                                |         | When using `searchAsYouType`, it can be useful to "debounce" search requests to avoid creating an excessive number of requests. This controls the length to debounce / wait.                                                                                                                               |
-| view                          | Component                                                                    | no        | [SearchBox](packages/react-search-ui-views/src/SearchBox.js)       |         | Used to override the default view for this Component. See the [Customization: Component views and HTML](#component-views-and-html) section for more information.                                                                                                                                           |
-| autocompleteResults           | Boolean or [AutocompleteResultsOptions](#AutocompleteResultsOptions)         | Object    | no                                                                 |         | Configure and autocomplete search results. Boolean option is primarily available for implementing custom views.                                                                                                                                                                                            |
-| autocompleteQuerySuggestions  | Boolean or [AutocompleteSuggestionsOptions](#AutocompleteSuggestionsOptions) | Object    | no                                                                 |         | Configure and autocomplete query suggestions. Boolean option is primarily available for implementing custom views.                                                                                                                                                                                         |
-| autocompleteMinimumCharacters | Integer                                                                      | no        | 0                                                                  |         | Minimum number of characters before autocompleting.                                                                                                                                                                                                                                                        |
-| autocompleteView              | Render Function                                                              | no        | [Autocomplete](packages/react-search-ui-views/src/Autocomplete.js) |         | Provide a different view just for the autocomplete dropdown.                                                                                                                                                                                                                                               |
-| onSelectAutocomplete          | Function(selection. options, defaultOnSelectAutocomplete)                    | no        |                                                                    |         | Allows overriding behavior when selected, to avoid creating an entirely new view. In addition to the current `selection`, various helpers are passed as `options` to the second parameter. This third parameter is the default `onSelectAutocomplete`, which allows you to defer to the original behavior. |
+| Name                          | type                                                                         | Required? | Default                                                            | Options | Description                                                                                                                                                                                                                                                                                                                                                  |
+| ----------------------------- | ---------------------------------------------------------------------------- | --------- | ------------------------------------------------------------------ | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| inputProps                    | Object                                                                       | no        |                                                                    |         | Props for underlying 'input' element. I.e., `{ placeholder: "Enter Text"}`                                                                                                                                                                                                                                                                                   |
+| searchAsYouType               | Boolean                                                                      | no        | false                                                              |         | Executes a new search query with every key stroke. You can fine tune the number of queries made by adjusting the `debounceLength` parameter.                                                                                                                                                                                                                 |
+| debounceLength                | Number                                                                       | no        | 200                                                                |         | When using `searchAsYouType`, it can be useful to "debounce" search requests to avoid creating an excessive number of requests. This controls the length to debounce / wait.                                                                                                                                                                                 |
+| view                          | Component                                                                    | no        | [SearchBox](packages/react-search-ui-views/src/SearchBox.js)       |         | Used to override the default view for this Component. See the [Customization: Component views and HTML](#component-views-and-html) section for more information.                                                                                                                                                                                             |
+| autocompleteResults           | Boolean or [AutocompleteResultsOptions](#AutocompleteResultsOptions)         | Object    | no                                                                 |         | Configure and autocomplete search results. Boolean option is primarily available for implementing custom views.                                                                                                                                                                                                                                              |
+| autocompleteQuerySuggestions  | Boolean or [AutocompleteSuggestionsOptions](#AutocompleteSuggestionsOptions) | Object    | no                                                                 |         | Configure and autocomplete query suggestions. Boolean option is primarily available for implementing custom views. Configuration may or may not be keyed by "Suggestion Type", as APIs for suggestions may support may than 1 type of suggestion. If it is not keyed by Suggestion Type, then the configuration will be applied to the first type available. |
+| autocompleteMinimumCharacters | Integer                                                                      | no        | 0                                                                  |         | Minimum number of characters before autocompleting.                                                                                                                                                                                                                                                                                                          |
+| autocompleteView              | Render Function                                                              | no        | [Autocomplete](packages/react-search-ui-views/src/Autocomplete.js) |         | Provide a different view just for the autocomplete dropdown.                                                                                                                                                                                                                                                                                                 |
+| onSelectAutocomplete          | Function(selection. options, defaultOnSelectAutocomplete)                    | no        |                                                                    |         | Allows overriding behavior when selected, to avoid creating an entirely new view. In addition to the current `selection`, various helpers are passed as `options` to the second parameter. This third parameter is the default `onSelectAutocomplete`, which allows you to defer to the original behavior.                                                   |
 
 #### AutocompleteResultsOptions
 
@@ -375,8 +445,10 @@ import { MultiCheckboxFacet } from "@elastic/react-search-ui-views";
 
 <SearchProvider config={{
   ...otherConfig,
-  facets: {
-    states: { type: "value", size: 30 }
+  searchQuery: {
+    facets: {
+     states: { type: "value", size: 30 }
+    }
   }
 }}>
   {() => (

--- a/examples/sandbox/src/App.js
+++ b/examples/sandbox/src/App.js
@@ -113,9 +113,7 @@ export default function App() {
                     clickThroughTags: ["test"]
                   }}
                   autocompleteSuggestions={{
-                    documents: {
-                      sectionTitle: "Suggested Queries"
-                    }
+                    sectionTitle: "Suggested Queries"
                   }}
                 />
               }

--- a/packages/react-search-ui-views/src/Autocomplete.js
+++ b/packages/react-search-ui-views/src/Autocomplete.js
@@ -14,6 +14,19 @@ function getSnippet(result, value) {
   return result[value].snippet;
 }
 
+function getSuggestionTitle(suggestionType, autocompleteSuggestions) {
+  if (autocompleteSuggestions.sectionTitle) {
+    return autocompleteSuggestions.sectionTitle;
+  }
+
+  if (
+    autocompleteSuggestions[suggestionType] &&
+    autocompleteSuggestions[suggestionType].sectionTitle
+  ) {
+    return autocompleteSuggestions[suggestionType].sectionTitle;
+  }
+}
+
 function Autocomplete({
   autocompleteResults,
   autocompletedResults,
@@ -77,11 +90,16 @@ function Autocomplete({
             ([suggestionType, suggestions]) => {
               return (
                 <React.Fragment key={suggestionType}>
-                  {autocompleteSuggestions[suggestionType] &&
-                    autocompleteSuggestions[suggestionType].sectionTitle &&
+                  {getSuggestionTitle(
+                    suggestionType,
+                    autocompleteSuggestions
+                  ) &&
                     suggestions.length > 0 && (
                       <div className="sui-search-box__section-title">
-                        {autocompleteSuggestions[suggestionType].sectionTitle}
+                        {getSuggestionTitle(
+                          suggestionType,
+                          autocompleteSuggestions
+                        )}
                       </div>
                     )}
                   {suggestions.length > 0 && (
@@ -138,9 +156,12 @@ Autocomplete.propTypes = {
   autocompletedSuggestionsCount: PropTypes.number.isRequired,
   autocompleteSuggestions: PropTypes.oneOfType([
     PropTypes.bool,
+    PropTypes.exact({
+      sectionTitle: PropTypes.string
+    }),
     PropTypes.objectOf(
-      PropTypes.shape({
-        sectionTitle: PropTypes.string.isRequired
+      PropTypes.exact({
+        sectionTitle: PropTypes.string
       })
     )
   ]),

--- a/packages/react-search-ui-views/src/SearchBox.js
+++ b/packages/react-search-ui-views/src/SearchBox.js
@@ -94,11 +94,17 @@ SearchBox.propTypes = {
     })
   ]),
   autocompleteView: PropTypes.func,
-  autocompleteSuggestions: PropTypes.objectOf(
-    PropTypes.shape({
-      sectionTitle: PropTypes.string.isRequired
-    })
-  ),
+  autocompleteSuggestions: PropTypes.oneOfType([
+    PropTypes.bool,
+    PropTypes.exact({
+      sectionTitle: PropTypes.string
+    }),
+    PropTypes.objectOf(
+      PropTypes.exact({
+        sectionTitle: PropTypes.string
+      })
+    )
+  ]),
   inputProps: PropTypes.object,
   isFocused: PropTypes.bool,
   useAutocomplete: PropTypes.bool,

--- a/packages/react-search-ui-views/src/__tests__/Autocomplete.test.js
+++ b/packages/react-search-ui-views/src/__tests__/Autocomplete.test.js
@@ -187,6 +187,30 @@ describe("When there are suggestions", () => {
     );
   });
 
+  it("will render a suggestion section title for all suggestion types if one is provided without a suggestion type", () => {
+    const wrapper = shallow(
+      <Autocomplete
+        {...props}
+        autocompleteResults={false}
+        autocompleteSuggestions={{
+          sectionTitle: "Suggested"
+        }}
+      />
+    );
+    expect(
+      wrapper
+        .find(".sui-search-box__section-title")
+        .at(0)
+        .text()
+    ).toEqual("Suggested");
+    expect(
+      wrapper
+        .find(".sui-search-box__section-title")
+        .at(1)
+        .text()
+    ).toEqual("Suggested");
+  });
+
   it("will NOT render a suggestion section title if none is provided", () => {
     const wrapper = shallow(
       <Autocomplete

--- a/packages/react-search-ui-views/stories/SearchBox.stories.js
+++ b/packages/react-search-ui-views/stories/SearchBox.stories.js
@@ -6,6 +6,12 @@ import { action } from "@storybook/addon-actions";
 import { SearchBox } from "../src";
 
 const baseProps = {
+  allAutocompletedItemsCount: 0,
+  autocompletedResults: [],
+  autocompletedSuggestions: {},
+  autocompletedSuggestionsCount: 0,
+  notifyAutocompleteSelected: () => {},
+  completeSuggestion: () => {},
   onChange: action("changed"),
   onSubmit: e => {
     e.preventDefault();
@@ -56,6 +62,8 @@ const autocompletedSuggestions = {
 
 const autocompleteProps = {
   useAutocomplete: true,
+  allAutocompletedItemsCount: 9,
+  autocompletedSuggestionsCount: 6,
   autocompleteResults: {
     sectionTitle: "Results",
     titleField: "title",
@@ -64,6 +72,12 @@ const autocompleteProps = {
   autocompletedResults: autocompletedResults,
   autocompleteSuggestions: autocompleteSuggestions,
   autocompletedSuggestions: autocompletedSuggestions,
+  notifyAutocompleteSelected: selection => {
+    action("selectAutocomplete")(selection);
+  },
+  completeSuggestion: suggestion => {
+    action("selectAutocomplete")(suggestion);
+  },
   onSelectAutocomplete: selection => {
     action("selectAutocomplete")(selection);
   }
@@ -104,7 +118,6 @@ class Wrapper extends React.Component {
 storiesOf("SearchBox", module)
   .add("no value", () => <SearchBox {...baseProps} />)
   .add("with value", () => <SearchBox {...baseProps} value="value" />)
-  .add("with focus", () => <SearchBox {...baseProps} isFocused={true} />)
   .add("with inputProps", () => (
     <SearchBox
       {...baseProps}
@@ -117,14 +130,55 @@ storiesOf("SearchBox", module)
       autocompleteResults={{
         ...{ ...autocompleteProps.autocompleteResults, sectionTitle: "" }
       }}
-      autocompleteSuggestions={{}}
+      autocompleteSuggestions={true}
     />
   ))
+  .add("with autocomplete and just results", () => (
+    <Wrapper
+      autocompleteResults={{
+        ...{ ...autocompleteProps.autocompleteResults, sectionTitle: "" }
+      }}
+      autocompleteSuggestions={undefined}
+    />
+  ))
+  .add("with autocomplete and just suggestions", () => (
+    <Wrapper
+      autocompleteResults={undefined}
+      autocompleteSuggestions={true}
+      autocompletedSuggestions={{
+        documents: autocompletedSuggestions.documents
+      }}
+    />
+  ))
+  .add(
+    "with autocomplete suggestions configuration without specifying suggestion type",
+    () => (
+      <Wrapper
+        autocompleteResults={undefined}
+        autocompleteSuggestions={{
+          sectionTitle: "Suggestions"
+        }}
+        autocompletedSuggestions={{
+          documents: autocompletedSuggestions.documents
+        }}
+      />
+    )
+  )
   .add("with custom autocomplete template", () => (
     <Wrapper
-      autocompleteView={props => (
+      autocompleteView={({ autocompletedResults, getItemProps }) => (
         <div className="sui-search-box__autocomplete-container">
-          Custom View
+          {autocompletedResults.map((result, i) => (
+            // eslint-disable-next-line react/jsx-key
+            <div
+              {...getItemProps({
+                key: result.id.raw,
+                item: result
+              })}
+            >
+              Result {i}: {result.title.snippet}
+            </div>
+          ))}
         </div>
       )}
     />

--- a/packages/react-search-ui/src/containers/SearchBox.js
+++ b/packages/react-search-ui/src/containers/SearchBox.js
@@ -22,9 +22,14 @@ export class SearchBoxContainer extends Component {
     ]),
     autocompleteSuggestions: PropTypes.oneOfType([
       PropTypes.bool,
-      PropTypes.shape({
+      PropTypes.exact({
         sectionTitle: PropTypes.string
-      })
+      }),
+      PropTypes.objectOf(
+        PropTypes.exact({
+          sectionTitle: PropTypes.string
+        })
+      )
     ]),
     autocompleteView: PropTypes.func,
     debounceLength: PropTypes.number,


### PR DESCRIPTION
Primarily updated suggestions so that you do not have to specify
a suggestion type on the component configuration.

So you can do this:

```jsx
<SearchBox
  autocompleteSuggestions={{
    sectionTitle: "Suggested Queries"
  }}
/>
```

And don't necessarily have to know what type of query suggestions are coming back, as you did previously (although it is supported and valid syntax):

```jsx
<SearchBox
  autocompleteSuggestions={{
    documents: {
      sectionTitle: "Suggested Queries"
    }
  }}
/>
```

Also provided some examples in the ADVANCED.md guide to help users get started
with the Autocomplete features.

