### PR TITLE
Added 'any' support for site search connector

### DIFF
--- a/packages/search-ui-site-search-connector/README.md
+++ b/packages/search-ui-site-search-connector/README.md
@@ -18,6 +18,7 @@ Note that Site Search does not support certain features of Search UI:
 - Cannot apply more than 1 range filter on a single field.
 - Analytics tags are not supported in `click`.
 - `suggestions` are not supported in autocomplete, only `results`
+- The `none` filter type is not supported.
 
 ## Usage
 

--- a/packages/search-ui-site-search-connector/src/__tests__/requestAdapter.test.js
+++ b/packages/search-ui-site-search-connector/src/__tests__/requestAdapter.test.js
@@ -123,6 +123,9 @@ const adaptedRequest = {
         type: "and",
         values: ["values"]
       },
+      another: {
+        values: ["additional values", "and values", "and even more values"]
+      },
       test: {
         type: "range",
         from: 0,

--- a/packages/search-ui-site-search-connector/src/__tests__/requestAdapters.test.js
+++ b/packages/search-ui-site-search-connector/src/__tests__/requestAdapters.test.js
@@ -130,7 +130,7 @@ describe("adaptFilterConfig", () => {
     });
   });
 
-  it("will ignore 'any' filters", () => {
+  it("will adapt 'any' filters", () => {
     expect(
       adaptFilterConfig([
         {
@@ -139,7 +139,11 @@ describe("adaptFilterConfig", () => {
           type: "any"
         }
       ])
-    ).toEqual({});
+    ).toEqual({
+      test: {
+        values: ["values"]
+      }
+    });
   });
 
   it("will ignore 'none' filters", () => {

--- a/packages/search-ui-site-search-connector/src/requestAdapters.js
+++ b/packages/search-ui-site-search-connector/src/requestAdapters.js
@@ -1,3 +1,9 @@
+function adaptFilterType(type) {
+  if (type === "any") return {};
+  if (type === "all") return { type: "and" };
+  return { type: "and" };
+}
+
 export function adaptFacetConfig(facets) {
   if (!facets) return;
 
@@ -46,11 +52,11 @@ export function adaptFilterConfig(filters) {
       return acc;
     }
 
-    if (filter.type && filter.type !== "all") {
+    if (filter.type && (filter.type !== "all" && filter.type !== "any")) {
       console.warn(
-        `search-ui-site-search-connector: Unsupported filter type ${
+        `search-ui-site-search-connector: Unsupported filter type "${
           filter.type
-        } found, only "all" is currently supported`
+        }" found, only "all" and "any" are currently supported`
       );
       return acc;
     }
@@ -83,7 +89,7 @@ export function adaptFilterConfig(filters) {
     }
 
     acc[fieldName] = {
-      type: "and",
+      ...adaptFilterType(filter.type),
       values: fieldValue
     };
 


### PR DESCRIPTION
Add support in the SiteSearchAPIConnector for "any" filters. "none" remains an unsupported type.