### PR TITLE
Tag Swiftype requests with "search-ui" header

### DIFF
--- a/examples/sandbox/package-lock.json
+++ b/examples/sandbox/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sandbox",
-  "version": "0.1.0",
+  "version": "0.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/search-ui-app-search-connector/package-lock.json
+++ b/packages/search-ui-app-search-connector/package-lock.json
@@ -5465,9 +5465,9 @@
       }
     },
     "swiftype-app-search-javascript": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/swiftype-app-search-javascript/-/swiftype-app-search-javascript-2.3.1.tgz",
-      "integrity": "sha512-UyGX7KJ4qHE1up4SuxCWw4BKz8zVBuk3gZdeVB5bEBZ7nnwtFuBYiBp4iKglhPbcMAajk0DozJ/xwKtcEa8PfQ==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/swiftype-app-search-javascript/-/swiftype-app-search-javascript-2.4.0.tgz",
+      "integrity": "sha512-ObTDFuRAd+6ZrSkbUx/hadYUi1o9Uwm6i4FML6D9PiB1H4IdUClFbD24464P0cVPLxuyvCNZ1cLmtP91Hs9p2A==",
       "requires": {
         "object-hash": "^1.3.0"
       }

--- a/packages/search-ui-app-search-connector/package.json
+++ b/packages/search-ui-app-search-connector/package.json
@@ -38,6 +38,6 @@
   },
   "dependencies": {
     "@babel/polyfill": "^7.2.5",
-    "swiftype-app-search-javascript": "^2.3.0"
+    "swiftype-app-search-javascript": "^2.4.0"
   }
 }

--- a/packages/search-ui-app-search-connector/src/AppSearchAPIConnector.js
+++ b/packages/search-ui-app-search-connector/src/AppSearchAPIConnector.js
@@ -1,4 +1,5 @@
 import * as SwiftypeAppSearch from "swiftype-app-search-javascript";
+import { version } from "../package.json";
 
 import { adaptResponse } from "./responseAdapter";
 import { adaptRequest } from "./requestAdapters";
@@ -40,7 +41,11 @@ export default class AppSearchAPIConnector {
       endpointBase,
       hostIdentifier: hostIdentifier,
       apiKey: searchKey,
-      engineName: engineName
+      engineName: engineName,
+      additionalHeaders: {
+        "x-swiftype-integration": "search-ui",
+        "x-swiftype-integration-version": version
+      }
     });
     this.additionalOptions = additionalOptions;
   }

--- a/packages/search-ui-site-search-connector/src/SiteSearchAPIConnector.js
+++ b/packages/search-ui-site-search-connector/src/SiteSearchAPIConnector.js
@@ -1,8 +1,14 @@
 import adaptRequest from "./requestAdapter";
 import adaptResponse from "./responseAdapter";
 import request from "./request";
+import { version } from "../package.json";
 
 function _get(engineKey, path, params) {
+  const headers = new Headers({
+    "x-swiftype-integration": "search-ui",
+    "x-swiftype-integration-version": version
+  });
+
   const query = Object.entries({ engine_key: engineKey, ...params })
     .map(([paramName, paramValue]) => {
       return `${paramName}=${encodeURIComponent(paramValue)}`;
@@ -13,7 +19,8 @@ function _get(engineKey, path, params) {
     `https://search-api.swiftype.com/api/v1/public/${path}?${query}`,
     {
       method: "GET",
-      credentials: "include"
+      credentials: "include",
+      headers
     }
   );
 }

--- a/packages/search-ui-site-search-connector/src/request.js
+++ b/packages/search-ui-site-search-connector/src/request.js
@@ -1,6 +1,10 @@
+import { version } from "../package.json";
+
 export default async function request(engineKey, method, path, params) {
   const headers = new Headers({
-    "Content-Type": "application/json"
+    "Content-Type": "application/json",
+    "x-swiftype-integration": "search-ui",
+    "x-swiftype-integration-version": version
   });
 
   const response = await fetch(

--- a/packages/search-ui/README.md
+++ b/packages/search-ui/README.md
@@ -55,3 +55,16 @@ of the `react-search-ui` README.
 | `subscribeToStateChanges` | function |                                                       | Function to execute when state changes. ex.<br/><br/>`(state) => {}` |
 | `getActions`              |          | Object[Actions](../react-search-ui/README.md#actions) | All available actions.                                               |
 | `getState`                |          | [State](../react-search-ui/README.md#state)           | Current state.                                                       |
+
+### Does Search UI use telemetry?
+
+If you are using the App Search or Site Search connector, we pass along 2 headers on API requests
+that identify them as Search UI requests. This ONLY happens if you are using our pre-built
+connectors.
+
+Ex.
+
+```
+x-swiftype-integration: search-ui
+x-swiftype-integration-version: 0.6.0
+```


### PR DESCRIPTION
This PR passes two additional headers back to Site Search an App Search for analytical purposes. These are ONLY passed when using one of these two connectors.

<img width="1664" alt="React_App" src="https://user-images.githubusercontent.com/1427475/56369537-8e949880-61c7-11e9-93d5-ba8bbecdcad2.png">
