### PR TITLE
Swapped autocomplete and autosuggest

### DIFF
--- a/examples/sandbox/src/App.js
+++ b/examples/sandbox/src/App.js
@@ -108,7 +108,8 @@ export default function App() {
               documents: {
                 fields: ["title"]
               }
-            }
+            },
+            size: 4
           }
         },
         apiConnector: connector
@@ -129,28 +130,28 @@ export default function App() {
                     shouldTrackClickThrough: true,
                     clickThroughTags: ["test"]
                   }}
-                  autocompleteSuggestions={{
-                    sectionTitle: "Suggested Queries"
-                  }}
+                  autocompleteSuggestions={true}
                 />
               }
               sideContent={
                 <div>
-                  {wasSearched && <Sorting
-                    label={"Sort by"}
-                    sortOptions={[
-                      {
-                        name: "Relevance",
-                        value: "",
-                        direction: ""
-                      },
-                      {
-                        name: "Title",
-                        value: "title",
-                        direction: "asc"
-                      }
-                    ]}
-                  />}
+                  {wasSearched && (
+                    <Sorting
+                      label={"Sort by"}
+                      sortOptions={[
+                        {
+                          name: "Relevance",
+                          value: "",
+                          direction: ""
+                        },
+                        {
+                          name: "Title",
+                          value: "title",
+                          direction: "asc"
+                        }
+                      ]}
+                    />
+                  )}
                   <Facet field="states" label="States" filterType="any" />
                   <Facet
                     field="world_heritage_site"

--- a/packages/react-search-ui-views/src/Autocomplete.js
+++ b/packages/react-search-ui-views/src/Autocomplete.js
@@ -48,48 +48,6 @@ function Autocomplete({
       })}
     >
       <div>
-        {!!autocompleteResults &&
-          !!autocompletedResults &&
-          autocompletedResults.length > 0 &&
-          autocompleteResults.sectionTitle && (
-            <div className="sui-search-box__section-title">
-              {autocompleteResults.sectionTitle}
-            </div>
-          )}
-        {!!autocompleteResults &&
-          !!autocompletedResults &&
-          autocompletedResults.length > 0 && (
-            <ul className="sui-search-box__results-list">
-              {autocompletedResults.map(result => {
-                index++;
-                const titleSnippet = getSnippet(
-                  result,
-                  autocompleteResults.titleField
-                );
-                const titleRaw = getRaw(result, autocompleteResults.titleField);
-                return (
-                  // eslint-disable-next-line react/jsx-key
-                  <li
-                    {...getItemProps({
-                      key: result.id.raw,
-                      index: index - 1,
-                      item: result
-                    })}
-                  >
-                    {titleSnippet ? (
-                      <span
-                        dangerouslySetInnerHTML={{
-                          __html: titleSnippet
-                        }}
-                      />
-                    ) : (
-                      <span>{titleRaw}</span>
-                    )}
-                  </li>
-                );
-              })}
-            </ul>
-          )}
         {!!autocompleteSuggestions &&
           Object.entries(autocompletedSuggestions).map(
             ([suggestionType, suggestions]) => {
@@ -138,6 +96,48 @@ function Autocomplete({
                 </React.Fragment>
               );
             }
+          )}
+        {!!autocompleteResults &&
+          !!autocompletedResults &&
+          autocompletedResults.length > 0 &&
+          autocompleteResults.sectionTitle && (
+            <div className="sui-search-box__section-title">
+              {autocompleteResults.sectionTitle}
+            </div>
+          )}
+        {!!autocompleteResults &&
+          !!autocompletedResults &&
+          autocompletedResults.length > 0 && (
+            <ul className="sui-search-box__results-list">
+              {autocompletedResults.map(result => {
+                index++;
+                const titleSnippet = getSnippet(
+                  result,
+                  autocompleteResults.titleField
+                );
+                const titleRaw = getRaw(result, autocompleteResults.titleField);
+                return (
+                  // eslint-disable-next-line react/jsx-key
+                  <li
+                    {...getItemProps({
+                      key: result.id.raw,
+                      index: index - 1,
+                      item: result
+                    })}
+                  >
+                    {titleSnippet ? (
+                      <span
+                        dangerouslySetInnerHTML={{
+                          __html: titleSnippet
+                        }}
+                      />
+                    ) : (
+                      <span>{titleRaw}</span>
+                    )}
+                  </li>
+                );
+              })}
+            </ul>
           )}
       </div>
     </div>

--- a/packages/react-search-ui-views/src/__tests__/__snapshots__/Autocomplete.test.js.snap
+++ b/packages/react-search-ui-views/src/__tests__/__snapshots__/Autocomplete.test.js.snap
@@ -8,88 +8,13 @@ exports[`renders correctly 1`] = `
     <div
       className="sui-search-box__section-title"
     >
-      Results
-    </div>
-    <ul
-      className="sui-search-box__results-list"
-    >
-      <li
-        index={0}
-        item={
-          Object {
-            "id": Object {
-              "raw": "1",
-            },
-            "title": Object {
-              "snippet": "<em>Bike</em> Cops",
-            },
-          }
-        }
-        key="1"
-      >
-        <span
-          dangerouslySetInnerHTML={
-            Object {
-              "__html": "<em>Bike</em> Cops",
-            }
-          }
-        />
-      </li>
-      <li
-        index={1}
-        item={
-          Object {
-            "id": Object {
-              "raw": "2",
-            },
-            "title": Object {
-              "snippet": "<em>Biker</em> Gang",
-            },
-          }
-        }
-        key="2"
-      >
-        <span
-          dangerouslySetInnerHTML={
-            Object {
-              "__html": "<em>Biker</em> Gang",
-            }
-          }
-        />
-      </li>
-      <li
-        index={2}
-        item={
-          Object {
-            "id": Object {
-              "raw": "3",
-            },
-            "title": Object {
-              "snippet": "<em>Biker</em> Bar",
-            },
-          }
-        }
-        key="3"
-      >
-        <span
-          dangerouslySetInnerHTML={
-            Object {
-              "__html": "<em>Biker</em> Bar",
-            }
-          }
-        />
-      </li>
-    </ul>
-    <div
-      className="sui-search-box__section-title"
-    >
       Suggested
     </div>
     <ul
       className="sui-search-box__suggestion-list"
     >
       <li
-        index={3}
+        index={0}
         item={
           Object {
             "highlight": "",
@@ -103,7 +28,7 @@ exports[`renders correctly 1`] = `
         </span>
       </li>
       <li
-        index={4}
+        index={1}
         item={
           Object {
             "highlight": "",
@@ -117,7 +42,7 @@ exports[`renders correctly 1`] = `
         </span>
       </li>
       <li
-        index={5}
+        index={2}
         item={
           Object {
             "highlight": "",
@@ -140,7 +65,7 @@ exports[`renders correctly 1`] = `
       className="sui-search-box__suggestion-list"
     >
       <li
-        index={6}
+        index={3}
         item={
           Object {
             "highlight": "",
@@ -154,7 +79,7 @@ exports[`renders correctly 1`] = `
         </span>
       </li>
       <li
-        index={7}
+        index={4}
         item={
           Object {
             "highlight": "",
@@ -168,7 +93,7 @@ exports[`renders correctly 1`] = `
         </span>
       </li>
       <li
-        index={8}
+        index={5}
         item={
           Object {
             "highlight": "",
@@ -180,6 +105,81 @@ exports[`renders correctly 1`] = `
         <span>
           is it cool to ride a bike?
         </span>
+      </li>
+    </ul>
+    <div
+      className="sui-search-box__section-title"
+    >
+      Results
+    </div>
+    <ul
+      className="sui-search-box__results-list"
+    >
+      <li
+        index={6}
+        item={
+          Object {
+            "id": Object {
+              "raw": "1",
+            },
+            "title": Object {
+              "snippet": "<em>Bike</em> Cops",
+            },
+          }
+        }
+        key="1"
+      >
+        <span
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "<em>Bike</em> Cops",
+            }
+          }
+        />
+      </li>
+      <li
+        index={7}
+        item={
+          Object {
+            "id": Object {
+              "raw": "2",
+            },
+            "title": Object {
+              "snippet": "<em>Biker</em> Gang",
+            },
+          }
+        }
+        key="2"
+      >
+        <span
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "<em>Biker</em> Gang",
+            }
+          }
+        />
+      </li>
+      <li
+        index={8}
+        item={
+          Object {
+            "id": Object {
+              "raw": "3",
+            },
+            "title": Object {
+              "snippet": "<em>Biker</em> Bar",
+            },
+          }
+        }
+        key="3"
+      >
+        <span
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "<em>Biker</em> Bar",
+            }
+          }
+        />
       </li>
     </ul>
   </div>


### PR DESCRIPTION
## Description

Swapped suggestions to appear on top of results in the default autocomplete view.

![latest](https://user-images.githubusercontent.com/1427475/56759587-4ba66800-6767-11e9-862c-5d3920692e72.gif)


## List of changes

- Swapped suggestions to appear on top of results in the default autocomplete view.
- Updated the sandbox app to have a nicer looking autocomplete experience

## Associated Github Issues

Fixes #216

