### PR TITLE
ResultsPerPage component should have configurable options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 lerna-debug.log
 storybook-static
+.idea

--- a/ADVANCED.md
+++ b/ADVANCED.md
@@ -133,7 +133,7 @@ Request state can be set by:
 | ---------------- | -------------------------------------- | --------- | -------------------------------------- |
 | `current`        | Integer                                | optional  | Current page number                    |
 | `filters`        | Array[[Filter](./src/types/Filter.js)] | optional  |                                        |
-| `resultsPerPage` | Integer                                | optional  | Number of results to show on each page |
+| <a name="resultsPerPageProp"></a>`resultsPerPage` | Integer                                | optional  | Number of results to show on each page |
 | `searchTerm`     | String                                 | optional  | Search terms to search for             |
 | `sortDirection`  | String ["asc" \| "desc"]               | optional  | Direction to sort                      |
 | `sortField`      | String                                 | optional  | Name of field to sort on               |
@@ -408,7 +408,11 @@ import { Results } from "@elastic/react-search-ui";
 
 Shows a dropdown for selecting the number of results to show per page.
 
-Uses 20, 40, 60 as options.
+Uses [20, 40, 60] as a default options. You can use `resultsPerPageOptions` prop to pass custom options. 
+
+**Note:** When passing custom options make sure one of the option value matches 
+the current [`resultsPerPage`](#resultsPerPageProp) value, which is 20 by default.
+To override `resultsPerPage` default value [Refer the custom options example](#Example-using-custom-options).
 
 ### Example
 
@@ -421,10 +425,29 @@ import { ResultsPerPage } from "@elastic/react-search-ui";
 <ResultsPerPage />
 ```
 
+### Example using custom options
+
+```jsx
+
+import { SearchProvider, ResultsPerPage } from "@elastic/react-search-ui";
+
+<SearchProvider
+    config={
+        ...
+        initialState: {
+            resultsPerPage: 5
+        }
+    }
+>
+    <ResultsPerPage resultsPerPageOptions={[5, 10, 15]} />
+</SearchProvider>
+```
+
 ### Properties
 
 | Name | type      | Required? | Default                                                                | Options | Description                                                                                                                                          |
 | ---- | --------- | --------- | ---------------------------------------------------------------------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| resultsPerPageOptions | Array[Number] | no | [20, 40, 60] | | Dropdown options to select the number of results to show per page.
 | view | Component | no        | [ResultsPerPage](packages/react-search-ui-views/src/ResultsPerPage.js) |         | Used to override the default view for this Component. See [Customization: Component views and HTML](#component-views-and-html) for more information. |
 
 ---

--- a/ADVANCED.md
+++ b/ADVANCED.md
@@ -408,11 +408,11 @@ import { Results } from "@elastic/react-search-ui";
 
 Shows a dropdown for selecting the number of results to show per page.
 
-Uses [20, 40, 60] as a default options. You can use `resultsPerPageOptions` prop to pass custom options. 
+Uses [20, 40, 60] as a default options. You can use `options` prop to pass custom options. 
 
-**Note:** When passing custom options make sure one of the option value matches 
+**Note:** When passing custom options make sure one of the option values match 
 the current [`resultsPerPage`](#resultsPerPageProp) value, which is 20 by default.
-To override `resultsPerPage` default value [Refer the custom options example](#Example-using-custom-options).
+To override `resultsPerPage` default value [refer to the custom options example](#Example-using-custom-options).
 
 ### Example
 
@@ -439,7 +439,7 @@ import { SearchProvider, ResultsPerPage } from "@elastic/react-search-ui";
         }
     }
 >
-    <ResultsPerPage resultsPerPageOptions={[5, 10, 15]} />
+    <ResultsPerPage options={[5, 10, 15]} />
 </SearchProvider>
 ```
 
@@ -447,7 +447,7 @@ import { SearchProvider, ResultsPerPage } from "@elastic/react-search-ui";
 
 | Name | type      | Required? | Default                                                                | Options | Description                                                                                                                                          |
 | ---- | --------- | --------- | ---------------------------------------------------------------------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
-| resultsPerPageOptions | Array[Number] | no | [20, 40, 60] | | Dropdown options to select the number of results to show per page.
+| options | Array[Number] | no | [20, 40, 60] | | Dropdown options to select the number of results to show per page.
 | view | Component | no        | [ResultsPerPage](packages/react-search-ui-views/src/ResultsPerPage.js) |         | Used to override the default view for this Component. See [Customization: Component views and HTML](#component-views-and-html) for more information. |
 
 ---

--- a/packages/react-search-ui-views/src/ResultsPerPage.js
+++ b/packages/react-search-ui-views/src/ResultsPerPage.js
@@ -19,6 +19,15 @@ function ResultsPerPage({ className, onChange, options, value }) {
     ? wrapOption(options.find(option => option === selectedValue))
     : null;
 
+  if (selectedOption && !selectedOption.value) {
+    console.warn(
+      "Unable to select the results per page option! The `resultsPerPageOptions` prop " +
+        `[${options.join(
+          ", "
+        )}] does not contain current page results size ${value}`
+    );
+  }
+
   return (
     <div className={appendClassName("sui-results-per-page", className)}>
       <div className="sui-results-per-page__label">Show</div>

--- a/packages/react-search-ui-views/src/ResultsPerPage.js
+++ b/packages/react-search-ui-views/src/ResultsPerPage.js
@@ -11,21 +11,20 @@ const setDefaultStyle = {
   indicatorSeparator: () => ({})
 };
 
-function ResultsPerPage({ className, onChange, options, value }) {
-  const selectedValue = value;
-  const wrapOption = option => ({ label: option, value: option });
+const wrapOption = option => ({ label: option, value: option });
 
-  const selectedOption = selectedValue
-    ? wrapOption(options.find(option => option === selectedValue))
-    : null;
+function ResultsPerPage({
+  className,
+  onChange,
+  options,
+  value: selectedValue
+}) {
+  let selectedOption = null;
 
-  if (selectedOption && !selectedOption.value) {
-    console.warn(
-      "Unable to select the results per page option! The `resultsPerPageOptions` prop " +
-        `[${options.join(
-          ", "
-        )}] does not contain current page results size ${value}`
-    );
+  if (selectedValue) {
+    selectedOption = wrapOption(selectedValue);
+
+    if (!options.includes(selectedValue)) options = [selectedValue, ...options];
   }
 
   return (

--- a/packages/react-search-ui/src/containers/ResultsPerPage.js
+++ b/packages/react-search-ui/src/containers/ResultsPerPage.js
@@ -8,6 +8,7 @@ export class ResultsPerPageContainer extends Component {
     // Props
     className: PropTypes.string,
     view: PropTypes.func,
+    resultsPerPageOptions: PropTypes.arrayOf(PropTypes.number),
     // State
     results: PropTypes.arrayOf(PropTypes.object).isRequired,
     resultsPerPage: PropTypes.number.isRequired,
@@ -16,12 +17,17 @@ export class ResultsPerPageContainer extends Component {
     setResultsPerPage: PropTypes.func.isRequired
   };
 
+  static defaultProps = {
+    resultsPerPageOptions: [20, 40, 60]
+  };
+
   render() {
     const {
       className,
       resultsPerPage,
       setResultsPerPage,
-      view
+      view,
+      resultsPerPageOptions
     } = this.props;
 
     const View = view || ResultsPerPage;
@@ -31,7 +37,7 @@ export class ResultsPerPageContainer extends Component {
       onChange: value => {
         setResultsPerPage(value);
       },
-      options: [20, 40, 60],
+      options: resultsPerPageOptions,
       value: resultsPerPage
     });
   }

--- a/packages/react-search-ui/src/containers/ResultsPerPage.js
+++ b/packages/react-search-ui/src/containers/ResultsPerPage.js
@@ -8,7 +8,7 @@ export class ResultsPerPageContainer extends Component {
     // Props
     className: PropTypes.string,
     view: PropTypes.func,
-    resultsPerPageOptions: PropTypes.arrayOf(PropTypes.number),
+    options: PropTypes.arrayOf(PropTypes.number),
     // State
     results: PropTypes.arrayOf(PropTypes.object).isRequired,
     resultsPerPage: PropTypes.number.isRequired,
@@ -18,7 +18,7 @@ export class ResultsPerPageContainer extends Component {
   };
 
   static defaultProps = {
-    resultsPerPageOptions: [20, 40, 60]
+    options: [20, 40, 60]
   };
 
   render() {
@@ -27,7 +27,7 @@ export class ResultsPerPageContainer extends Component {
       resultsPerPage,
       setResultsPerPage,
       view,
-      resultsPerPageOptions
+      options
     } = this.props;
 
     const View = view || ResultsPerPage;
@@ -37,7 +37,7 @@ export class ResultsPerPageContainer extends Component {
       onChange: value => {
         setResultsPerPage(value);
       },
-      options: resultsPerPageOptions,
+      options,
       value: resultsPerPage
     });
   }

--- a/packages/react-search-ui/src/containers/__tests__/ResultsPerPage.test.js
+++ b/packages/react-search-ui/src/containers/__tests__/ResultsPerPage.test.js
@@ -65,10 +65,10 @@ it("passes className through to the view", () => {
 });
 
 it("renders the component with custom page options", () => {
-  const resultsPerPageOptions = [5, 10, 15];
+  const options = [5, 10, 15];
   const resultsPerPage = 10;
   const wrapper = shallow(
-      <ResultsPerPageContainer {...{...params, resultsPerPage, resultsPerPageOptions}} />
+      <ResultsPerPageContainer {...{...params, resultsPerPage, options}} />
   );
 
   expect(wrapper).toMatchSnapshot();

--- a/packages/react-search-ui/src/containers/__tests__/ResultsPerPage.test.js
+++ b/packages/react-search-ui/src/containers/__tests__/ResultsPerPage.test.js
@@ -63,3 +63,13 @@ it("passes className through to the view", () => {
   );
   expect(viewProps.className).toEqual(className);
 });
+
+it("renders the component with custom page options", () => {
+  const resultsPerPageOptions = [5, 10, 15];
+  const resultsPerPage = 10;
+  const wrapper = shallow(
+      <ResultsPerPageContainer {...{...params, resultsPerPage, resultsPerPageOptions}} />
+  );
+
+  expect(wrapper).toMatchSnapshot();
+});

--- a/packages/react-search-ui/src/containers/__tests__/__snapshots__/ResultsPerPage.test.js.snap
+++ b/packages/react-search-ui/src/containers/__tests__/__snapshots__/ResultsPerPage.test.js.snap
@@ -51,6 +51,57 @@ exports[`renders when it doesn't have any results or a search term 1`] = `
 </div>
 `;
 
+exports[`renders the component with custom page options 1`] = `
+<div
+  className="sui-results-per-page"
+>
+  <div
+    className="sui-results-per-page__label"
+  >
+    Show
+  </div>
+  <StateManager
+    className="sui-select sui-select--inline"
+    classNamePrefix="sui-select"
+    defaultInputValue=""
+    defaultMenuIsOpen={false}
+    defaultValue={null}
+    isSearchable={false}
+    onChange={[Function]}
+    options={
+      Array [
+        Object {
+          "label": 5,
+          "value": 5,
+        },
+        Object {
+          "label": 10,
+          "value": 10,
+        },
+        Object {
+          "label": 15,
+          "value": 15,
+        },
+      ]
+    }
+    styles={
+      Object {
+        "control": [Function],
+        "dropdownIndicator": [Function],
+        "indicatorSeparator": [Function],
+        "option": [Function],
+      }
+    }
+    value={
+      Object {
+        "label": 10,
+        "value": 10,
+      }
+    }
+  />
+</div>
+`;
+
 exports[`supports a render prop 1`] = `
 <div>
   20


### PR DESCRIPTION
## Description
ResultsPerPage component should have configurable options

## List of changes
* Added new prop `resultsPerPageOptions` to the `<ResultsPerPage />` component to configure results per page options.
* Documented `resultsPerPageOptions` prop usage.
* Added test case for`resultsPerPageOptions` 

## Associated Github Issues
#60 
