### PR TITLE
Site search connector demo

### DIFF
--- a/examples/sandbox/README.md
+++ b/examples/sandbox/README.md
@@ -35,6 +35,13 @@ by running the following command:
 npm start
 ```
 
+This project can also be started, using a Site Search connector, rather than an
+App Search connector, using the following command.
+
+```shell
+REACT_APP_SOURCE=SITE_SEARCH npm start
+```
+
 If you're actively developing Search UI and testing in this Sandbox, you'll probably want
 to live reload your changes in this application. To do this, navigate to the root
 level of this repository and run the following command.

--- a/examples/sandbox/src/App.js
+++ b/examples/sandbox/src/App.js
@@ -92,10 +92,6 @@ export default function App() {
             }
           }
         },
-        initialState: {
-          sortField: "title",
-          sortDirection: "asc"
-        },
         autocompleteQuery: {
           results: {
             resultsPerPage: 5,

--- a/examples/sandbox/src/App.js
+++ b/examples/sandbox/src/App.js
@@ -1,5 +1,6 @@
 import React from "react";
 import AppSearchAPIConnector from "@elastic/search-ui-app-search-connector";
+import SiteSearchAPIConnector from "@elastic/search-ui-site-search-connector";
 import {
   ErrorBoundary,
   Facet,
@@ -18,13 +19,24 @@ import {
 } from "@elastic/react-search-ui-views";
 import "@elastic/react-search-ui-views/lib/styles/styles.css";
 
-const connector = new AppSearchAPIConnector({
-  searchKey:
-    process.env.REACT_APP_SEARCH_KEY || "search-371auk61r2bwqtdzocdgutmg",
-  engineName: process.env.REACT_APP_SEARCH_ENGINE_NAME || "search-ui-examples",
-  hostIdentifier: process.env.REACT_APP_SEARCH_HOST_IDENTIFIER || "host-2376rb",
-  endpointBase: process.env.REACT_APP_SEARCH_ENDPOINT_BASE || ""
-});
+let connector;
+if (process.env.REACT_APP_SOURCE === "SITE_SEARCH") {
+  connector = new SiteSearchAPIConnector({
+    engineKey:
+      process.env.REACT_SITE_SEARCH_ENGINE_KEY || "Z43R5U3HiDsDgpKawZkA",
+    documentType: process.env.REACT_SITE_SEARCH_ENGINE_NAME || "national-parks"
+  });
+} else {
+  connector = new AppSearchAPIConnector({
+    searchKey:
+      process.env.REACT_APP_SEARCH_KEY || "search-371auk61r2bwqtdzocdgutmg",
+    engineName:
+      process.env.REACT_APP_SEARCH_ENGINE_NAME || "search-ui-examples",
+    hostIdentifier:
+      process.env.REACT_APP_SEARCH_HOST_IDENTIFIER || "host-2376rb",
+    endpointBase: process.env.REACT_APP_SEARCH_ENDPOINT_BASE || ""
+  });
+}
 
 export default function App() {
   return (


### PR DESCRIPTION
## Description

By using the following command, you can now start the Sandbox site using Site Search, rather than App Search. It simply uses a different connector.

```
REACT_APP_SOURCE=SITE_SEARCH npm start
```

The plan is to publish this link, alongside https://search-ui-stable.netlify.com. So it would be something like https://search-ui-site-search-stable.netlify.com.

## List of changes

- Support Site Search in Sandbox application.
- Change default sort to Relevance for a better demo
