### PR TITLE
Fixed layout issue in Results css

### DIFF
--- a/packages/react-search-ui-views/src/styles/themes/reference-ui/layouts/_layout.scss
+++ b/packages/react-search-ui-views/src/styles/themes/reference-ui/layouts/_layout.scss
@@ -41,6 +41,8 @@
       padding: 2rem 0;
       padding: 32px 0 32px 32px;
       border-left: none;
+      overflow-wrap: break-word;
+      overflow: hidden;
 
       @include block("layout-main-header") {
         display: flex;


### PR DESCRIPTION
## Description

Fixed layout issue in Results css when there are long values.

Before:

<img width="1679" alt="Screenshot 2019-06-17 09 51 05" src="https://user-images.githubusercontent.com/1427475/59609542-96988800-90e5-11e9-9593-76c9dc0c40fc.png">

After:

<img width="1676" alt="Screenshot 2019-06-17 09 46 49" src="https://user-images.githubusercontent.com/1427475/59609554-9d26ff80-90e5-11e9-9414-c6047b7fa693.png">

## List of changes

Fixed layout issue in Results css when there are long values.

## Associated Github Issues

Fixes #265
