### PR TITLE
Additional options

### DIFF
--- a/ADVANCED.md
+++ b/ADVANCED.md
@@ -1083,19 +1083,19 @@ But there may be cases where certain API operations are not supported by Search 
 
 For example, [App Search](https://www.elastic.co/cloud/app-search-service) supports a "grouping" feature, which Search UI does not support out of the box.
 
-We can work around that by using the `additionalOptions` hook on the particular Connector.
+We can work around that by using the `beforeSearchCall` hook on the App Search Connector. This acts as a middleware
+that gives you an opportunity to modify API requests and responses before they are made.
 
 ```js
 const connector = new AppSearchAPIConnector({
   searchKey: "search-371auk61r2bwqtdzocdgutmg",
   engineName: "search-ui-examples",
   hostIdentifier: "host-2376rb",
-  additionalOptions: existingSearchOptions => {
-    const additionalSearchOptions = {
+  beforeSearchCall: (existingSearchOptions, next) =>
+    next({
+      ...existingSearchOptions,
       group: { field: "title" }
-    };
-    return additionalSearchOptions;
-  }
+    })
 });
 ```
 
@@ -1256,15 +1256,6 @@ A connector simply needs to implement the Event Handlers listed above. The handl
 
 While some handlers are meant for fetching data and performing searches, other handlers are meant for recording
 certain user events in analytics services, such as `onResultClick` or `onAutocompleteResultClick`.
-
-#### Configuration
-
-Each Connector will need to be instantiated with its own set of properties. The only properties that Connectors
-need to have in common is an `additionalOptions` parameter.
-
-| option              | type             | required? | source                                                                                                                                                                        |
-| ------------------- | ---------------- | --------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `additionalOptions` | Function(Object) | optional  | A hook that allows you to inject additional, API specific configuration. More information can be found in the [Customizing API calls - additionalOptions](#apicalls) section. |
 
 #### Errors
 

--- a/examples/sandbox/src/App.js
+++ b/examples/sandbox/src/App.js
@@ -50,7 +50,12 @@ if (process.env.REACT_APP_SOURCE === "SITE_SEARCH") {
       process.env.REACT_APP_SEARCH_ENGINE_NAME || "search-ui-examples",
     hostIdentifier:
       process.env.REACT_APP_SEARCH_HOST_IDENTIFIER || "host-2376rb",
-    endpointBase: process.env.REACT_APP_SEARCH_ENDPOINT_BASE || ""
+    endpointBase: process.env.REACT_APP_SEARCH_ENDPOINT_BASE || "",
+    beforeSearchCall: (existingSearchOptions, next) =>
+      next({
+        ...existingSearchOptions,
+        group: { field: "title" }
+      })
   });
 }
 

--- a/examples/sandbox/src/App.js
+++ b/examples/sandbox/src/App.js
@@ -50,12 +50,7 @@ if (process.env.REACT_APP_SOURCE === "SITE_SEARCH") {
       process.env.REACT_APP_SEARCH_ENGINE_NAME || "search-ui-examples",
     hostIdentifier:
       process.env.REACT_APP_SEARCH_HOST_IDENTIFIER || "host-2376rb",
-    endpointBase: process.env.REACT_APP_SEARCH_ENDPOINT_BASE || "",
-    beforeSearchCall: (existingSearchOptions, next) =>
-      next({
-        ...existingSearchOptions,
-        group: { field: "title" }
-      })
+    endpointBase: process.env.REACT_APP_SEARCH_ENDPOINT_BASE || ""
   });
 }
 

--- a/packages/search-ui-app-search-connector/README.md
+++ b/packages/search-ui-app-search-connector/README.md
@@ -17,17 +17,78 @@ const connector = new AppSearchAPIConnector({
   searchKey: "search-371auk61r2bwqtdzocdgutmg",
   engineName: "search-ui-examples",
   hostIdentifier: "host-2376rb",
-  additionalOptions: () => ({
-    group: { field: "title" }
-  })
+  beforeSearchCall: (options, next) =>
+    next({
+      ...options,
+      group: { field: "title" }
+    })
 });
 ```
 
-### Configuration
+## Classes
 
-| option              | type             | required? | source                                                                                                                                 |
-| ------------------- | ---------------- | --------- | -------------------------------------------------------------------------------------------------------------------------------------- |
-| `searchKey`         | String           | required  | From your App Search Account's Credentials                                                                                             |
-| `engineName`        | String           | required  | From your App Search Engine's Name                                                                                                     |
-| `hostIdentifier`    | String           | required  | From your App Search Account's Credentials                                                                                             |
-| `additionalOptions` | Function(Object) | optional  | A hook that allows you to inject additional, API specific configuration.<br/><br/> `currentOptions => ({ group: { field: "title" } })` |
+<dl>
+<dt><a href="#AppSearchAPIConnector">AppSearchAPIConnector</a></dt>
+<dd></dd>
+</dl>
+
+## Typedefs
+
+<dl>
+<dt><a href="#next">next</a> : <code>function</code></dt>
+<dd></dd>
+<dt><a href="#hook">hook</a> : <code>function</code></dt>
+<dd></dd>
+<dt><a href="#Options">Options</a></dt>
+<dd></dd>
+</dl>
+
+<a name="AppSearchAPIConnector"></a>
+
+## AppSearchAPIConnector
+
+**Kind**: global class
+<a name="new_AppSearchAPIConnector_new"></a>
+
+### new AppSearchAPIConnector(options)
+
+| Param   | Type                             |
+| ------- | -------------------------------- |
+| options | [<code>Options</code>](#Options) |
+
+<a name="next"></a>
+
+## next : <code>function</code>
+
+**Kind**: global typedef
+
+| Param               | Type                | Description                    |
+| ------------------- | ------------------- | ------------------------------ |
+| updatedQueryOptions | <code>Object</code> | The options to send to the API |
+
+<a name="hook"></a>
+
+## hook : <code>function</code>
+
+**Kind**: global typedef
+
+| Param        | Type                       | Description                                      |
+| ------------ | -------------------------- | ------------------------------------------------ |
+| queryOptions | <code>Object</code>        | The options that are about to be sent to the API |
+| next         | [<code>next</code>](#next) | The options that are about to be sent to the API |
+
+<a name="Options"></a>
+
+## Options
+
+**Kind**: global typedef
+
+| Param                             | Type                       | Default                                                      | Description                                                                                                                   |
+| --------------------------------- | -------------------------- | ------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------- |
+| searchKey                         | <code>string</code>        |                                                              | Credential found in your App Search Dashboard                                                                                 |
+| engineName                        | <code>string</code>        |                                                              | Engine to query, found in your App Search Dashboard                                                                           |
+| hostIdentifier                    | <code>string</code>        |                                                              | Credential found in your App Search Dashboard Useful when proxying the Swiftype API or developing against a local API server. |
+| beforeSearchCall                  | [<code>hook</code>](#hook) | <code>(queryOptions,next)&#x3D;&gt;next(queryOptions)</code> | A hook to amend query options before the request is sent to the API in a query on an "onSearch" event.                        |
+| beforeAutocompleteResultsCall     | [<code>hook</code>](#hook) | <code>(queryOptions,next)&#x3D;&gt;next(queryOptions)</code> | A hook to amend query options before the request is sent to the API in a "results" query on an "onAutocomplete" event.        |
+| beforeAutocompleteSuggestionsCall | [<code>hook</code>](#hook) | <code>(queryOptions,next)&#x3D;&gt;next(queryOptions)</code> | A hook to amend query options before the request is sent to the API in a "suggestions" query on an "onAutocomplete" event.    |
+| endpointBase                      | <code>string</code>        | <code>""</code>                                              | Overrides the base of the Swiftype API endpoint completely.                                                                   |

--- a/packages/search-ui-app-search-connector/src/AppSearchAPIConnector.js
+++ b/packages/search-ui-app-search-connector/src/AppSearchAPIConnector.js
@@ -15,26 +15,35 @@ function removeEmptyFacetsAndFilters(options) {
     ...rest
   };
 }
-export default class AppSearchAPIConnector {
+class AppSearchAPIConnector {
   /**
    * @callback next
    * @param {Object} updatedQueryOptions The options to send to the API
-   *
+   */
+
+  /**
    * @callback hook
    * @param {Object} queryOptions The options that are about to be sent to the API
    * @param {next} next The options that are about to be sent to the API
-   *
-   * @param {string} {searchKey Credential found in your App Search Dashboard
+   */
+
+  /**
+   * @typedef Options
+   * @param {string} searchKey Credential found in your App Search Dashboard
    * @param {string} engineName Engine to query, found in your App Search Dashboard
    * @param {string} hostIdentifier Credential found in your App Search Dashboard
    *  Useful when proxying the Swiftype API or developing against a local API server.
-   * @param {hook} beforeSearchCall=()=>{} A hook to amend query options before the request is sent to the
+   * @param {hook} beforeSearchCall=(queryOptions,next)=>next(queryOptions) A hook to amend query options before the request is sent to the
    *   API in a query on an "onSearch" event.
-   * @param {hook} beforeAutocompleteResultsCall=()=>{} A hook to amend query options before the request is sent to the
+   * @param {hook} beforeAutocompleteResultsCall=(queryOptions,next)=>next(queryOptions) A hook to amend query options before the request is sent to the
    *   API in a "results" query on an "onAutocomplete" event.
-   * @param {hook} beforeAutocompleteSuggestionsCall=()=>{} A hook to amend query options before the request is sent to
+   * @param {hook} beforeAutocompleteSuggestionsCall=(queryOptions,next)=>next(queryOptions) A hook to amend query options before the request is sent to
    * the API in a "suggestions" query on an "onAutocomplete" event.
-   * @param {string} endpointBase=""} Overrides the base of the Swiftype API endpoint completely.
+   * @param {string} endpointBase="" Overrides the base of the Swiftype API endpoint completely.
+   */
+
+  /**
+   * @param {Options} options
    */
   constructor({
     searchKey,
@@ -167,3 +176,5 @@ export default class AppSearchAPIConnector {
     return autocompletedState;
   }
 }
+
+export default AppSearchAPIConnector;

--- a/packages/search-ui-app-search-connector/src/AppSearchAPIConnector.js
+++ b/packages/search-ui-app-search-connector/src/AppSearchAPIConnector.js
@@ -31,7 +31,7 @@ export default class AppSearchAPIConnector {
     searchKey,
     engineName,
     hostIdentifier,
-    additionalOptions = () => ({}),
+    additionalOptions = options => options,
     endpointBase = ""
   }) {
     if (!engineName || !hostIdentifier || !searchKey) {
@@ -85,8 +85,9 @@ export default class AppSearchAPIConnector {
       ...optionsFromState
     };
     const options = {
-      ...removeEmptyFacetsAndFilters(withQueryConfigOptions),
-      ...this.additionalOptions(withQueryConfigOptions)
+      ...this.additionalOptions(
+        removeEmptyFacetsAndFilters(withQueryConfigOptions)
+      )
     };
 
     const response = await this.client.search(query, options);
@@ -121,8 +122,9 @@ export default class AppSearchAPIConnector {
         ...optionsFromState
       };
       const options = {
-        ...removeEmptyFacetsAndFilters(withQueryConfigOptions),
-        ...this.additionalOptions(withQueryConfigOptions)
+        ...this.additionalOptions(
+          removeEmptyFacetsAndFilters(withQueryConfigOptions)
+        )
       };
 
       promises.push(

--- a/packages/search-ui-app-search-connector/src/AppSearchAPIConnector.js
+++ b/packages/search-ui-app-search-connector/src/AppSearchAPIConnector.js
@@ -17,21 +17,28 @@ function removeEmptyFacetsAndFilters(options) {
 }
 export default class AppSearchAPIConnector {
   /**
-   * @param options Object
-   * engineName  - Engine to query, found in your App Search Dashboard
-   * hostIdentifier - Credential found in your App Search Dashboard
-   * searchKey - Credential found in your App Search Dashboard
-   * endpointBase - (optional) Overrides the base of the Swiftype API endpoint
-   *   completely. Useful when proxying the Swiftype API or developing against
-   *   a local API server.
-   * additionalOptions - (optional) Append additional options / parameter to the
-   *   request before sending to the API.
+   * @callback hook
+   * @param {Object} queryOptions - The options that are about to be sent to the API
+   *
+   * @typedef Options
+   * @property {string} engineName - Engine to query, found in your App Search Dashboard
+   * @property {string} hostIdentifier - Credential found in your App Search Dashboard
+   * @property {string} searchKey - Credential found in your App Search Dashboard
+   * @property {string} [endpointBase] - Overrides the base of the Swiftype API endpoint completely.
+   *  Useful when proxying the Swiftype API or developing against a local API server.
+   * @property {hook} [beforeSearchCall] - A hook to amend query options before the request is sent to the
+   *   API in a query on an "onSearch" event.
+   * @property {hook} [beforeAutocompleteResultsCall] - A hook to amend query options before the request is sent to the
+   *   API in a "results" query on an "onAutocomplete" event.
+   *
+   * @param {Options} options
    */
   constructor({
     searchKey,
     engineName,
     hostIdentifier,
-    additionalOptions = options => options,
+    beforeSearchCall = queryOptions => queryOptions,
+    beforeAutocompleteResultsCall = queryOptions => queryOptions,
     endpointBase = ""
   }) {
     if (!engineName || !hostIdentifier || !searchKey) {
@@ -48,7 +55,8 @@ export default class AppSearchAPIConnector {
         "x-swiftype-integration-version": version
       }
     });
-    this.additionalOptions = additionalOptions;
+    this.beforeSearchCall = beforeSearchCall;
+    this.beforeAutocompleteResultsCall = beforeAutocompleteResultsCall;
   }
 
   onResultClick({ query, documentId, requestId, tags = [] }) {
@@ -85,7 +93,7 @@ export default class AppSearchAPIConnector {
       ...optionsFromState
     };
     const options = {
-      ...this.additionalOptions(
+      ...this.beforeSearchCall(
         removeEmptyFacetsAndFilters(withQueryConfigOptions)
       )
     };
@@ -122,7 +130,7 @@ export default class AppSearchAPIConnector {
         ...optionsFromState
       };
       const options = {
-        ...this.additionalOptions(
+        ...this.beforeAutocompleteResultsCall(
           removeEmptyFacetsAndFilters(withQueryConfigOptions)
         )
       };

--- a/packages/search-ui-app-search-connector/src/__tests__/AppSearchAPIConnector.test.js
+++ b/packages/search-ui-app-search-connector/src/__tests__/AppSearchAPIConnector.test.js
@@ -368,13 +368,14 @@ describe("AppSearchAPIConnector", () => {
     function subject(
       state = {},
       queryConfig = {},
-      beforeAutocompleteResultsCall
+      { beforeAutocompleteResultsCall, beforeAutocompleteSuggestionsCall } = {}
     ) {
       if (!state.searchTerm) state.searchTerm = "searchTerm";
 
       const connector = new AppSearchAPIConnector({
         ...params,
-        beforeAutocompleteResultsCall
+        beforeAutocompleteResultsCall,
+        beforeAutocompleteSuggestionsCall
       });
 
       return connector.onAutocomplete(state, queryConfig);
@@ -562,6 +563,45 @@ describe("AppSearchAPIConnector", () => {
           autocompletedResults: resultState.results,
           autocompletedResultsRequestId: resultState.requestId
         });
+      });
+    });
+
+    describe("beforeAutocompleteResultsCall", () => {
+      it("will use the beforeAutocompleteResultsCall parameter to amend option parameters to the search endpoint call", async () => {
+        await subject(
+          {},
+          { results: {} },
+          {
+            beforeAutocompleteResultsCall: queryOptions => ({
+              ...queryOptions,
+              test: "value"
+            })
+          }
+        );
+        // eslint-disable-next-line no-unused-vars
+        const [_, passedOptions] = getLastSearchCall();
+        expect(passedOptions).toEqual({
+          page: {},
+          test: "value"
+        });
+      });
+    });
+
+    describe("beforeAutocompleteSuggestionsCall", () => {
+      it("will use the beforeAutocompleteSuggestionsCall parameter to amend option parameters to the search endpoint call", async () => {
+        await subject(
+          {},
+          { suggestions: {} },
+          {
+            beforeAutocompleteSuggestionsCall: queryOptions => ({
+              ...queryOptions,
+              test: "value"
+            })
+          }
+        );
+        // eslint-disable-next-line no-unused-vars
+        const [_, passedOptions] = getLastSuggestCall();
+        expect(passedOptions).toEqual({ test: "value" });
       });
     });
 

--- a/packages/search-ui-app-search-connector/src/__tests__/AppSearchAPIConnector.test.js
+++ b/packages/search-ui-app-search-connector/src/__tests__/AppSearchAPIConnector.test.js
@@ -345,17 +345,32 @@ describe("AppSearchAPIConnector", () => {
         current: 2,
         searchTerm: "searchTerm"
       };
-      const beforeSearchCall = (queryOptions, next) =>
-        next({
-          ...queryOptions,
+
+      const queryConfig = {
+        sortDirection: "desc",
+        sortField: "name",
+        resultsPerPage: 5
+      };
+
+      const beforeSearchCall = (options, next) => {
+        // Remove sort_direction and sort_field
+        // eslint-disable-next-line no-unused-vars
+        const { sort, ...rest } = options;
+        return next({
+          ...rest,
+          // Add test
           test: "value"
         });
-      await subject(state, {}, beforeSearchCall);
+      };
+
+      await subject(state, queryConfig, beforeSearchCall);
+
       expect(getLastSearchCall()).toEqual([
         state.searchTerm,
         {
           page: {
-            current: 2
+            current: 2,
+            size: 5
           },
           test: "value"
         }
@@ -567,28 +582,79 @@ describe("AppSearchAPIConnector", () => {
 
     describe("beforeAutocompleteResultsCall", () => {
       it("will use the beforeAutocompleteResultsCall parameter to amend option parameters to the search endpoint call", async () => {
-        await subject(
-          {},
-          { results: {} },
-          {
-            beforeAutocompleteResultsCall: (queryOptions, next) =>
-              next({
-                ...queryOptions,
-                test: "value"
-              })
+        const state = {
+          current: 2,
+          searchTerm: "searchTerm"
+        };
+
+        const queryConfig = {
+          results: {
+            sortDirection: "desc",
+            sortField: "name",
+            resultsPerPage: 5
           }
-        );
-        // eslint-disable-next-line no-unused-vars
-        const [_, passedOptions] = getLastSearchCall();
-        expect(passedOptions).toEqual({
-          page: {},
-          test: "value"
-        });
+        };
+
+        const beforeAutocompleteResultsCall = (options, next) => {
+          // Remove sort_direction and sort_field
+          // eslint-disable-next-line no-unused-vars
+          const { sort, ...rest } = options;
+          return next({
+            ...rest,
+            // Add test
+            test: "value"
+          });
+        };
+
+        await subject(state, queryConfig, { beforeAutocompleteResultsCall });
+
+        expect(getLastSearchCall()).toEqual([
+          state.searchTerm,
+          {
+            page: {
+              size: 5
+            },
+            test: "value"
+          }
+        ]);
       });
     });
 
     describe("beforeAutocompleteSuggestionsCall", () => {
       it("will use the beforeAutocompleteSuggestionsCall parameter to amend option parameters to the search endpoint call", async () => {
+        const state = {
+          current: 2,
+          searchTerm: "searchTerm",
+          sortDirection: "desc",
+          sortField: "name"
+        };
+
+        const queryConfig = {
+          suggestions: {}
+        };
+
+        const beforeAutocompleteSuggestionsCall = (options, next) => {
+          // Remove sort_direction and sort_field
+          // eslint-disable-next-line no-unused-vars
+          const { sort, ...rest } = options;
+          return next({
+            ...rest,
+            // Add test
+            test: "value"
+          });
+        };
+
+        await subject(state, queryConfig, {
+          beforeAutocompleteSuggestionsCall
+        });
+
+        expect(getLastSuggestCall()).toEqual([
+          state.searchTerm,
+          {
+            test: "value"
+          }
+        ]);
+
         await subject(
           {},
           { suggestions: {} },

--- a/packages/search-ui-app-search-connector/src/__tests__/AppSearchAPIConnector.test.js
+++ b/packages/search-ui-app-search-connector/src/__tests__/AppSearchAPIConnector.test.js
@@ -340,27 +340,27 @@ describe("AppSearchAPIConnector", () => {
       });
     });
 
-    it("will use the additionalOptions parameter to append additional parameters to the search endpoint call", async () => {
+    it("will use the additionalOptions parameter to amend option parameters to the search endpoint call", async () => {
       const state = {
         current: 2,
         searchTerm: "searchTerm"
       };
-      const additionalOptions = currentOptions => {
-        if (currentOptions.page.current === 2) {
-          return {
-            test: "value"
-          };
-        }
+      const additionalOptions = body => {
+        return {
+          ...body,
+          test: "value"
+        };
       };
       await subject(state, {}, additionalOptions);
-      const [passedSearchTerm, passedOptions] = getLastSearchCall();
-      expect(passedSearchTerm).toEqual(state.searchTerm);
-      expect(passedOptions).toEqual({
-        page: {
-          current: 2
-        },
-        test: "value"
-      });
+      expect(getLastSearchCall()).toEqual([
+        state.searchTerm,
+        {
+          page: {
+            current: 2
+          },
+          test: "value"
+        }
+      ]);
     });
   });
 

--- a/packages/search-ui-app-search-connector/src/__tests__/AppSearchAPIConnector.test.js
+++ b/packages/search-ui-app-search-connector/src/__tests__/AppSearchAPIConnector.test.js
@@ -345,12 +345,11 @@ describe("AppSearchAPIConnector", () => {
         current: 2,
         searchTerm: "searchTerm"
       };
-      const beforeSearchCall = queryOptions => {
-        return {
+      const beforeSearchCall = (queryOptions, next) =>
+        next({
           ...queryOptions,
           test: "value"
-        };
-      };
+        });
       await subject(state, {}, beforeSearchCall);
       expect(getLastSearchCall()).toEqual([
         state.searchTerm,
@@ -572,10 +571,11 @@ describe("AppSearchAPIConnector", () => {
           {},
           { results: {} },
           {
-            beforeAutocompleteResultsCall: queryOptions => ({
-              ...queryOptions,
-              test: "value"
-            })
+            beforeAutocompleteResultsCall: (queryOptions, next) =>
+              next({
+                ...queryOptions,
+                test: "value"
+              })
           }
         );
         // eslint-disable-next-line no-unused-vars
@@ -593,10 +593,11 @@ describe("AppSearchAPIConnector", () => {
           {},
           { suggestions: {} },
           {
-            beforeAutocompleteSuggestionsCall: queryOptions => ({
-              ...queryOptions,
-              test: "value"
-            })
+            beforeAutocompleteSuggestionsCall: (queryOptions, next) =>
+              next({
+                ...queryOptions,
+                test: "value"
+              })
           }
         );
         // eslint-disable-next-line no-unused-vars

--- a/packages/search-ui-app-search-connector/src/__tests__/AppSearchAPIConnector.test.js
+++ b/packages/search-ui-app-search-connector/src/__tests__/AppSearchAPIConnector.test.js
@@ -159,12 +159,12 @@ describe("AppSearchAPIConnector", () => {
   });
 
   describe("onSearch", () => {
-    function subject(state = {}, queryConfig = {}, additionalOptions) {
+    function subject(state = {}, queryConfig = {}, beforeSearchCall) {
       if (!state.searchTerm) state.searchTerm = "searchTerm";
 
       const connector = new AppSearchAPIConnector({
         ...params,
-        additionalOptions
+        beforeSearchCall
       });
 
       return connector.onSearch(state, queryConfig);
@@ -340,18 +340,18 @@ describe("AppSearchAPIConnector", () => {
       });
     });
 
-    it("will use the additionalOptions parameter to amend option parameters to the search endpoint call", async () => {
+    it("will use the beforeSearchCall parameter to amend option parameters to the search endpoint call", async () => {
       const state = {
         current: 2,
         searchTerm: "searchTerm"
       };
-      const additionalOptions = body => {
+      const beforeSearchCall = queryOptions => {
         return {
-          ...body,
+          ...queryOptions,
           test: "value"
         };
       };
-      await subject(state, {}, additionalOptions);
+      await subject(state, {}, beforeSearchCall);
       expect(getLastSearchCall()).toEqual([
         state.searchTerm,
         {
@@ -365,12 +365,16 @@ describe("AppSearchAPIConnector", () => {
   });
 
   describe("onAutocomplete", () => {
-    function subject(state = {}, queryConfig = {}, additionalOptions) {
+    function subject(
+      state = {},
+      queryConfig = {},
+      beforeAutocompleteResultsCall
+    ) {
       if (!state.searchTerm) state.searchTerm = "searchTerm";
 
       const connector = new AppSearchAPIConnector({
         ...params,
-        additionalOptions
+        beforeAutocompleteResultsCall
       });
 
       return connector.onAutocomplete(state, queryConfig);

--- a/packages/search-ui-site-search-connector/README.md
+++ b/packages/search-ui-site-search-connector/README.md
@@ -35,11 +35,67 @@ const connector = new SiteSearchAPIConnector({
 });
 ```
 
-### Configuration
+## Classes
 
-| option                                            | type             | required? | source                                                                                                                       |
-| ------------------------------------------------- | ---------------- | --------- | ---------------------------------------------------------------------------------------------------------------------------- |
-| `documentType`                                    | String           | required  | From your Site Search Account's Credentials                                                                                  |
-| `engineKey`                                       | String           | required  | From your Site Search Engine's Name                                                                                          |
-| `additionalOptions`                               | Function(Object) | optional  | A hook that allows you to inject additional, API specific configuration.<br/><br/> `currentOptions => ({ someOption: 'a' })` |
-| options before the request is sent to the server. |
+<dl>
+<dt><a href="#SiteSearchAPIConnector">SiteSearchAPIConnector</a></dt>
+<dd></dd>
+</dl>
+
+## Typedefs
+
+<dl>
+<dt><a href="#next">next</a> : <code>function</code></dt>
+<dd></dd>
+<dt><a href="#hook">hook</a> : <code>function</code></dt>
+<dd></dd>
+<dt><a href="#Options">Options</a></dt>
+<dd></dd>
+</dl>
+
+<a name="SiteSearchAPIConnector"></a>
+
+## SiteSearchAPIConnector
+
+**Kind**: global class
+<a name="new_SiteSearchAPIConnector_new"></a>
+
+### new SiteSearchAPIConnector(options)
+
+| Param   | Type                             |
+| ------- | -------------------------------- |
+| options | [<code>Options</code>](#Options) |
+
+<a name="next"></a>
+
+## next : <code>function</code>
+
+**Kind**: global typedef
+
+| Param               | Type                | Description                    |
+| ------------------- | ------------------- | ------------------------------ |
+| updatedQueryOptions | <code>Object</code> | The options to send to the API |
+
+<a name="hook"></a>
+
+## hook : <code>function</code>
+
+**Kind**: global typedef
+
+| Param        | Type                       | Description                                      |
+| ------------ | -------------------------- | ------------------------------------------------ |
+| queryOptions | <code>Object</code>        | The options that are about to be sent to the API |
+| next         | [<code>next</code>](#next) | The options that are about to be sent to the API |
+
+<a name="Options"></a>
+
+## Options
+
+**Kind**: global typedef
+
+| Param                         | Type                       | Default                                                      | Description                                                                                                            |
+| ----------------------------- | -------------------------- | ------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------- |
+| documentType                  | <code>string</code>        |                                                              | Document Type found in your Site Search Dashboard                                                                      |
+| engineKey                     | <code>string</code>        |                                                              | Credential found in your Site Search Dashboard                                                                         |
+| beforeSearchCall              | [<code>hook</code>](#hook) | <code>(queryOptions,next)&#x3D;&gt;next(queryOptions)</code> | A hook to amend query options before the request is sent to the API in a query on an "onSearch" event.                 |
+| beforeAutocompleteResultsCall | [<code>hook</code>](#hook) | <code>(queryOptions,next)&#x3D;&gt;next(queryOptions)</code> | A hook to amend query options before the request is sent to the API in a "results" query on an "onAutocomplete" event. |

--- a/packages/search-ui-site-search-connector/src/SiteSearchAPIConnector.js
+++ b/packages/search-ui-site-search-connector/src/SiteSearchAPIConnector.js
@@ -25,19 +25,30 @@ function _get(engineKey, path, params) {
   );
 }
 
-export default class SiteSearchAPIConnector {
+class SiteSearchAPIConnector {
   /**
    * @callback next
    * @param {Object} updatedQueryOptions The options to send to the API
-   *
+   */
+
+  /**
    * @callback hook
    * @param {Object} queryOptions The options that are about to be sent to the API
    * @param {next} next The options that are about to be sent to the API
-   *
-   * @param  {string} {documentType Document Type found in your Site Search Dashboard
+   */
+
+  /**
+   * @typedef Options
+   * @param  {string} documentType Document Type found in your Site Search Dashboard
    * @param  {string} engineKey Credential found in your Site Search Dashboard
-   * @param  {hook} beforeSearchCall=()=>{}
-   * @param  {hook} beforeAutocompleteResultsCall=()=>{}}
+   * @param  {hook} beforeSearchCall=(queryOptions,next)=>next(queryOptions) A hook to amend query options before the request is sent to the
+   *   API in a query on an "onSearch" event.
+   * @param  {hook} beforeAutocompleteResultsCall=(queryOptions,next)=>next(queryOptions) A hook to amend query options before the request is sent to the
+   *   API in a "results" query on an "onAutocomplete" event.
+   */
+
+  /**
+   * @param {Options} options
    */
   constructor({
     documentType,
@@ -110,3 +121,5 @@ export default class SiteSearchAPIConnector {
     }
   }
 }
+
+export default SiteSearchAPIConnector;

--- a/packages/search-ui-site-search-connector/src/__tests__/SiteSearchAPIConnector.test.js
+++ b/packages/search-ui-site-search-connector/src/__tests__/SiteSearchAPIConnector.test.js
@@ -27,10 +27,10 @@ it("can be initialized", () => {
 });
 
 describe("#onSearch", () => {
-  function subject({ additionalOptions, state, queryConfig = {} }) {
+  function subject({ beforeSearchCall, state, queryConfig = {} }) {
     const connector = new SiteSearchAPIConnector({
       ...params,
-      additionalOptions
+      beforeSearchCall
     });
     return connector.onSearch(state, queryConfig);
   }
@@ -192,33 +192,36 @@ describe("#onSearch", () => {
     });
   });
 
-  it("will use the additionalOptions parameter to append additional parameters to the search endpoint call", async () => {
-    const groupFields = {
-      group: { field: "title" }
-    };
-    const additionalOptions = () => groupFields;
+  it("will use the beforeSearchCall parameter to append additional parameters to the search endpoint call", async () => {
+    const beforeSearchCall = (options, next) =>
+      next({
+        ...options,
+        group: { field: "title" }
+      });
     const searchTerm = "searchTerm";
     await subject({
-      additionalOptions,
+      beforeSearchCall,
       state: { searchTerm },
       queryConfig: {}
     });
     expect(JSON.parse(global.fetch.mock.calls[0][1].body)).toEqual({
       engine_key: engineKey,
       q: "searchTerm",
-      ...groupFields
+      group: { field: "title" }
     });
   });
 });
 
 describe("#onAutocomplete", () => {
   function subject({
+    beforeAutocompleteResultsCall,
     state,
     queryConfig = {
       results: {}
     }
   }) {
     const connector = new SiteSearchAPIConnector({
+      beforeAutocompleteResultsCall,
       ...params
     });
     return connector.onAutocomplete(state, queryConfig);
@@ -326,6 +329,33 @@ describe("#onAutocomplete", () => {
       sort_field: {
         "national-parks": "name"
       }
+    });
+  });
+
+  it("will use the beforeAutocompleteResultsCall parameter to append additional parameters to the search endpoint call", async () => {
+    const beforeAutocompleteResultsCall = (options, next) =>
+      next({
+        ...options,
+        group: { field: "title" }
+      });
+
+    const state = {
+      searchTerm: "searchTerm"
+    };
+
+    const queryConfig = {
+      results: {
+        resultsPerPage: 5
+      }
+    };
+
+    await subject({ beforeAutocompleteResultsCall, state, queryConfig });
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(global.fetch.mock.calls[0][1].body)).toEqual({
+      engine_key: engineKey,
+      q: "searchTerm",
+      per_page: 5,
+      group: { field: "title" }
     });
   });
 });

--- a/packages/search-ui-site-search-connector/src/__tests__/SiteSearchAPIConnector.test.js
+++ b/packages/search-ui-site-search-connector/src/__tests__/SiteSearchAPIConnector.test.js
@@ -192,19 +192,34 @@ describe("#onSearch", () => {
     });
   });
 
-  it("will use the beforeSearchCall parameter to append additional parameters to the search endpoint call", async () => {
-    const beforeSearchCall = (options, next) =>
-      next({
-        ...options,
+  it("will use the beforeSearchCall parameter to to amend option parameters to the search endpoint call", async () => {
+    const searchTerm = "searchTerm";
+
+    const queryConfig = {
+      sortDirection: "desc",
+      sortField: "name",
+      resultsPerPage: 5
+    };
+
+    const beforeSearchCall = (options, next) => {
+      // Remove sort_direction and sort_field
+      // eslint-disable-next-line no-unused-vars
+      const { sort_direction, sort_field, ...rest } = options;
+      return next({
+        ...rest,
+        // Add group
         group: { field: "title" }
       });
-    const searchTerm = "searchTerm";
+    };
+
     await subject({
       beforeSearchCall,
       state: { searchTerm },
-      queryConfig: {}
+      queryConfig
     });
+
     expect(JSON.parse(global.fetch.mock.calls[0][1].body)).toEqual({
+      per_page: 5,
       engine_key: engineKey,
       q: "searchTerm",
       group: { field: "title" }
@@ -332,21 +347,28 @@ describe("#onAutocomplete", () => {
     });
   });
 
-  it("will use the beforeAutocompleteResultsCall parameter to append additional parameters to the search endpoint call", async () => {
-    const beforeAutocompleteResultsCall = (options, next) =>
-      next({
-        ...options,
-        group: { field: "title" }
-      });
-
+  it("will use the beforeAutocompleteResultsCall parameter to amend option parameters to the search endpoint call", async () => {
     const state = {
       searchTerm: "searchTerm"
     };
 
     const queryConfig = {
       results: {
+        sortDirection: "desc",
+        sortField: "name",
         resultsPerPage: 5
       }
+    };
+
+    const beforeAutocompleteResultsCall = (options, next) => {
+      // Remove sort_direction and sort_field
+      // eslint-disable-next-line no-unused-vars
+      const { sort_direction, sort_field, ...rest } = options;
+      return next({
+        ...rest,
+        // Add group
+        group: { field: "title" }
+      });
     };
 
     await subject({ beforeAutocompleteResultsCall, state, queryConfig });


### PR DESCRIPTION
## Description

Made `additionalOptions` more useful.

Example:

```js
connector = new AppSearchAPIConnector({
    beforeSearchCall: (existingSearchOptions, next) =>
      next({
        ...existingSearchOptions,
        group: { field: "title" }
      })
  });
```

## List of changes
- Updated hooks to amend, not just append

    Previously the function simply merged in additional options to existing,
    instead, it should allow you to amend the entire object, in case
    there are some you'd like to remove.

- Made hooks work like middleware

    Hook functions now accept a "next" parameter, to allow for adapting
    the response as well, not just the incoming options.

- Separated out `additionalOptions` into 3 distinct hooks:

  `beforeAutocompleteSuggestionsCall`
  `beforeAutocompleteResultsCall`
  `beforeSearchCall`

- Updated docs. Used jsdoc comments and generated markdown for README with https://github.com/jsdoc2md/jsdoc-to-markdown

## Associated Github Issues

Closes #156 
