### PR TITLE
Loosened the "Result" object schema

### DIFF
--- a/examples/sandbox/src/App.js
+++ b/examples/sandbox/src/App.js
@@ -58,15 +58,20 @@ const config = {
   debug: true,
   searchQuery: {
     result_fields: {
+      visitors: { raw: {} },
+      world_heritage_site: { raw: {} },
+      location: { raw: {} },
+      acres: { raw: {} },
+      square_km: { raw: {} },
       title: {
         snippet: {
           size: 100,
           fallback: true
         }
       },
-      nps_link: {
-        raw: {}
-      },
+      nps_link: { raw: {} },
+      states: { raw: {} },
+      date_established: { raw: {} },
       description: {
         snippet: {
           size: 100,

--- a/packages/react-search-ui-views/src/Result.js
+++ b/packages/react-search-ui-views/src/Result.js
@@ -2,6 +2,7 @@ import PropTypes from "prop-types";
 import React from "react";
 
 import { appendClassName } from "./view-helpers";
+import { isFieldValueWrapper } from "./types/FieldValueWrapper";
 
 function getFieldType(result, field, type) {
   if (result[field]) return result[field][type];
@@ -36,6 +37,14 @@ function getEscapedField(result, field) {
 
 function getEscapedFields(result) {
   return Object.keys(result).reduce((acc, field) => {
+    // Because if it is an arbitrary value from the response, we may not properly
+    // handle it, so we filter out arbitrary values here.
+    //
+    // I.e.,
+    // Arbitrary value: "_metaField: '1939191'"
+    // vs.
+    // FieldValueWrapper: "_metaField: {raw: '1939191'}"
+    if (!isFieldValueWrapper(result[field])) return acc;
     return { ...acc, [field]: getEscapedField(result, field) };
   }, {});
 }
@@ -67,12 +76,12 @@ function Result({ className, result, onClickLink, titleField, urlField }) {
       </div>
       <div className="sui-result__body">
         <ul className="sui-result__details">
-          {Object.keys(fields).map(key => (
-            <li key={key}>
-              <span className="sui-result__key">{key}</span>{" "}
+          {Object.entries(fields).map(([fieldName, fieldValue]) => (
+            <li key={fieldName}>
+              <span className="sui-result__key">{fieldName}</span>{" "}
               <span
                 className="sui-result__value"
-                dangerouslySetInnerHTML={{ __html: fields[key] }}
+                dangerouslySetInnerHTML={{ __html: fieldValue }}
               />
             </li>
           ))}

--- a/packages/react-search-ui-views/src/Result.js
+++ b/packages/react-search-ui-views/src/Result.js
@@ -37,8 +37,8 @@ function getEscapedField(result, field) {
 
 function getEscapedFields(result) {
   return Object.keys(result).reduce((acc, field) => {
-    // Because if it is an arbitrary value from the response, we may not properly
-    // handle it, so we filter out arbitrary values here.
+    // If we receive an arbitrary value from the response, we may not properly
+    // handle it, so we should filter out arbitrary values here.
     //
     // I.e.,
     // Arbitrary value: "_metaField: '1939191'"

--- a/packages/react-search-ui-views/src/__tests__/Result.test.js
+++ b/packages/react-search-ui-views/src/__tests__/Result.test.js
@@ -6,6 +6,7 @@ const TITLE_FIELD = "title";
 const URL_FIELD = "url";
 const TITLE_RESULT_VALUE = "Title";
 const URL_RESULT_VALUE = "http://www.example.com";
+const ARBITRARY_FIELD = { _meta: "data" };
 
 const requiredProps = {
   result: { field: { raw: "value" } },
@@ -75,6 +76,21 @@ it("renders correctly when there is a title and url", () => {
         },
         titleField: TITLE_FIELD,
         urlField: URL_FIELD
+      }}
+    />
+  );
+  expect(wrapper).toMatchSnapshot();
+});
+
+it("filters out arbitrary fields from results, and does not render them", () => {
+  const wrapper = shallow(
+    <Result
+      {...{
+        ...requiredProps,
+        result: {
+          ...requiredProps.result,
+          ...ARBITRARY_FIELD
+        }
       }}
     />
   );

--- a/packages/react-search-ui-views/src/__tests__/__snapshots__/Result.test.js.snap
+++ b/packages/react-search-ui-views/src/__tests__/__snapshots__/Result.test.js.snap
@@ -1,5 +1,41 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`filters out arbitrary fields from results, and does not render them 1`] = `
+<li
+  className="sui-result"
+>
+  <div
+    className="sui-result__header"
+  />
+  <div
+    className="sui-result__body"
+  >
+    <ul
+      className="sui-result__details"
+    >
+      <li
+        key="field"
+      >
+        <span
+          className="sui-result__key"
+        >
+          field
+        </span>
+         
+        <span
+          className="sui-result__value"
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "value",
+            }
+          }
+        />
+      </li>
+    </ul>
+  </div>
+</li>
+`;
+
 exports[`renders correctly when there is a URL 1`] = `
 <li
   className="sui-result"

--- a/packages/react-search-ui-views/src/types/FieldValueWrapper.js
+++ b/packages/react-search-ui-views/src/types/FieldValueWrapper.js
@@ -9,3 +9,9 @@ export default PropTypes.shape({
   // result'
   snippet: PropTypes.string
 });
+
+export function isFieldValueWrapper(object) {
+  return (
+    object && (object.hasOwnProperty("raw") || object.hasOwnProperty("snippet"))
+  );
+}

--- a/packages/react-search-ui-views/src/types/Result.js
+++ b/packages/react-search-ui-views/src/types/Result.js
@@ -2,6 +2,15 @@ import PropTypes from "prop-types";
 
 import FieldValueWrapper from "./FieldValueWrapper";
 
-// An object where keys are the field names, and values are the values
-// corresponding to that
-export default PropTypes.objectOf(FieldValueWrapper);
+// Typically an object where keys are the field names, and values are field values.
+// Also could be literally any other arbitrary value depending on the particular Search API response.
+// Default views in Search UI know what to do with FieldValueWrapper values, but not arbitrary values, so it
+// is typically better to work with FieldValueWrapper values. So we encourage FieldValueWrapper, but we accept
+// anything because we don't want users to have type error warnings unnecessarily.
+//
+// An example would be if a user requests "grouping" in an App Search API request. That will come back
+// as "_group: {..}". It *should* be there in the Result so that a developer has it available to work
+// with.
+export default PropTypes.objectOf(
+  PropTypes.oneOfType([PropTypes.any, FieldValueWrapper])
+);

--- a/packages/react-search-ui-views/src/types/Result.js
+++ b/packages/react-search-ui-views/src/types/Result.js
@@ -5,7 +5,7 @@ import FieldValueWrapper from "./FieldValueWrapper";
 // Typically an object where keys are the field names, and values are field values.
 // Also could be literally any other arbitrary value depending on the particular Search API response.
 // Default views in Search UI know what to do with FieldValueWrapper values, but not arbitrary values, so it
-// is typically better to work with FieldValueWrapper values. So we encourage FieldValueWrapper, but we accept
+// is usually better to work with FieldValueWrapper values. We encourage FieldValueWrapper, but we accept
 // anything because we don't want users to have type error warnings unnecessarily.
 //
 // An example would be if a user requests "grouping" in an App Search API request. That will come back

--- a/packages/react-search-ui/src/types/FieldValueWrapper.js
+++ b/packages/react-search-ui/src/types/FieldValueWrapper.js
@@ -3,9 +3,17 @@ import PropTypes from "prop-types";
 import FieldValue from "./FieldValue";
 
 export default PropTypes.shape({
-  // A raw field value, like 'I am a raw result', or 2, or true
+  // A raw field value, like 'I am a raw result', or 2, or true. Raw values may
+  // or may not be html escaped, so *always* sanitize a raw value before rendering
+  // it on a page as html.
   raw: FieldValue,
   // A snippet value contains a highlighted value. I.e., 'I <em>am</em> a raw
-  // result'
+  // result'. These are always sanitized and safe to render as html.
   snippet: PropTypes.string
 });
+
+export function isFieldValueWrapper(object) {
+  return (
+    object && (object.hasOwnProperty("raw") || object.hasOwnProperty("snippet"))
+  );
+}

--- a/packages/react-search-ui/src/types/Result.js
+++ b/packages/react-search-ui/src/types/Result.js
@@ -2,5 +2,15 @@ import PropTypes from "prop-types";
 
 import FieldValueWrapper from "./FieldValueWrapper";
 
-// An object where keys are the field names, and values are field values
-export default PropTypes.objectOf(FieldValueWrapper);
+// Typically an object where keys are the field names, and values are field values.
+// Also could be literally any other arbitrary value depending on the particular Search API response.
+// Default views in Search UI know what to do with FieldValueWrapper values, but not arbitrary values, so it
+// is typically better to work with FieldValueWrapper values. So we encourage FieldValueWrapper, but we accept
+// anything because we don't want users to have type error warnings unnecessarily.
+//
+// An example would be if a user requests "grouping" in an App Search API request. That will come back
+// as "_group: {..}". It *should* be there in the Result so that a developer has it available to work
+// with.
+export default PropTypes.objectOf(
+  PropTypes.oneOfType([PropTypes.any, FieldValueWrapper])
+);

--- a/packages/react-search-ui/src/types/Result.js
+++ b/packages/react-search-ui/src/types/Result.js
@@ -5,7 +5,7 @@ import FieldValueWrapper from "./FieldValueWrapper";
 // Typically an object where keys are the field names, and values are field values.
 // Also could be literally any other arbitrary value depending on the particular Search API response.
 // Default views in Search UI know what to do with FieldValueWrapper values, but not arbitrary values, so it
-// is typically better to work with FieldValueWrapper values. So we encourage FieldValueWrapper, but we accept
+// is usually better to work with FieldValueWrapper values. We encourage FieldValueWrapper, but we accept
 // anything because we don't want users to have type error warnings unnecessarily.
 //
 // An example would be if a user requests "grouping" in an App Search API request. That will come back


### PR DESCRIPTION
## Description

In our type definition for a "Result", we required it to have
a raw and snippet key:

```
{
  raw: "",
  snippet: ""
}
```

However, while this is the most common scenario, it's actually
technically possible to get other stuff back in a "Result".
For instance, when using the "group" feature in the App Search API,
you can get back a "_group" key in results. Or if you are using
this project with Elasticsearch, you might get a nested object back.
This schema was too arbitrarily strict. It's better to accept
anything here.

## List of changes
- Expanded results shown in the Sandbox application, just for a better demo and also for testing.
- Updated BOTH `Result.js` types, which are duplicated in two separate packages currently, but we should definitely find a way to consolidate in the future.
- Changed the `Result.js` view to filter out arbitrary `Result` values, since we've now loosened the schema. It only attempts to render things that look like a `FieldValueWrapper` (i.e., they have a `raw` and `snippet` value, which is how App Search returns field values).

## Associated Github Issues

Fixes: #256