### PR TITLE
Added a inputView option to SearchBox

### DIFF
--- a/ADVANCED.md
+++ b/ADVANCED.md
@@ -314,20 +314,37 @@ customizations, like simply hiding the search button, this is often overkill.
 ```
 
 You can also just customize the input section of the search box. Useful for things
-like hiding the submit button:
+like hiding the submit button or rearranging dom structure:
 
 ```jsx
 <SearchBox
-  inputView={({ getAutocomplete, getInputProps }) => (
+  inputView={({ getAutocomplete, getInputProps, getButtonProps }) => (
     <>
       <div className="sui-search-box__wrapper">
-        <input {...getInputProps()} />
+        <input
+          {...getInputProps({
+            placeholder: "I am a custom placeholder"
+          })}
+        />
         {getAutocomplete()}
+        <input
+          {...getButtonProps({
+            "data-custom-attr": "some value"
+          })}
+        />
       </div>
     </>
   )}
 />
 ```
+
+Note that `getInputProps` and `getButtonProps` are meant to be spread over their corresponding
+UI elements. This lets you arrange elements however you'd like in the DOM. It also lets you pass
+additional properties. You should pass properties through these functions, rather directly on elements,
+in order to not override base values. For instance, adding a `className` through these functions will
+assure that the className is only appended, not overriding base class values on those values.
+
+`getAutocomplete` is used to determine where the autocomplete dropdown will be shown.
 
 Or you can also just customize the autocomplete dropdown:
 

--- a/ADVANCED.md
+++ b/ADVANCED.md
@@ -338,11 +338,12 @@ like hiding the submit button or rearranging dom structure:
 />
 ```
 
-Note that `getInputProps` and `getButtonProps` are meant to be spread over their corresponding
-UI elements. This lets you arrange elements however you'd like in the DOM. It also lets you pass
-additional properties. You should pass properties through these functions, rather directly on elements,
-in order to not override base values. For instance, adding a `className` through these functions will
-assure that the className is only appended, not overriding base class values on those values.
+Note that `getInputProps` and `getButtonProps` are
+[prop getters](https://kentcdodds.com/blog/how-to-give-rendering-control-to-users-with-prop-getters).
+They are meant return a props object to spread over their corresponding UI elements. This lets you arrange
+elements however you'd like in the DOM. It also lets you pass additional properties. You should pass properties
+through these functions, rather directly on elements, in order to not override base values. For instance,
+adding a `className` through these functions will assure that the className is only appended, not overriding base class values on those values.
 
 `getAutocomplete` is used to determine where the autocomplete dropdown will be shown.
 

--- a/ADVANCED.md
+++ b/ADVANCED.md
@@ -336,7 +336,6 @@ Or you can also just customize the autocomplete dropdown:
   autocompleteView={({ autocompletedResults, getItemProps }) => (
     <div className="sui-search-box__autocomplete-container">
       {autocompletedResults.map((result, i) => (
-        // eslint-disable-next-line react/jsx-key
         <div
           {...getItemProps({
             key: result.id.raw,

--- a/ADVANCED.md
+++ b/ADVANCED.md
@@ -286,7 +286,7 @@ import { SearchBox } from "@elastic/react-search-ui";
 
 ...
 
-<SearchBox inputProps={{ placeholder: "custom placeholder" }}/>
+<SearchBox />
 ```
 
 ### Configuring search queries
@@ -294,6 +294,62 @@ import { SearchBox } from "@elastic/react-search-ui";
 The input from `SearchBox` will be used to trigger a new search query. That query can be further customized
 in the `SearchProvider` configuration, using the `searchQuery` property. See the
 [Advanced Configuration](#advanced-configuration) guide for more information.
+
+### Example of passing custom props to text input element
+
+```jsx
+<SearchBox inputProps={{ placeholder: "custom placeholder" }} />
+```
+
+### Example of view customizations
+
+You can customize the entire view. This is useful to use an entirely different
+autocomplete library (we use [downshift](https://github.com/downshift-js/downshift)). But for making small
+customizations, like simply hiding the search button, this is often overkill.
+
+```jsx
+<SearchBox
+  view={({ onChange, value }) => <input value={value} onChange={onChange} />}
+/>
+```
+
+You can also just customize the input section of the search box. Useful for things
+like hiding the submit button:
+
+```jsx
+<SearchBox
+  inputView={({ getAutocomplete, getInputProps }) => (
+    <>
+      <div className="sui-search-box__wrapper">
+        <input {...getInputProps()} />
+        {getAutocomplete()}
+      </div>
+    </>
+  )}
+/>
+```
+
+Or you can also just customize the autocomplete dropdown:
+
+```jsx
+<SearchBox
+  autocompleteView={({ autocompletedResults, getItemProps }) => (
+    <div className="sui-search-box__autocomplete-container">
+      {autocompletedResults.map((result, i) => (
+        // eslint-disable-next-line react/jsx-key
+        <div
+          {...getItemProps({
+            key: result.id.raw,
+            item: result
+          })}
+        >
+          Result {i}: {result.title.snippet}
+        </div>
+      ))}
+    </div>
+  )}
+/>
+```
 
 ### Example using autocomplete results
 
@@ -459,6 +515,7 @@ page for suggestions, and maintaining the default behavior when selecting a resu
 | autocompleteSuggestions       | Boolean or [AutocompleteSuggestionsOptions](#AutocompleteSuggestionsOptions) | Object    | no                                                                 |         | Configure and autocomplete query suggestions. Boolean option is primarily available for implementing custom views. Configuration may or may not be keyed by "Suggestion Type", as APIs for suggestions may support may than 1 type of suggestion. If it is not keyed by Suggestion Type, then the configuration will be applied to the first type available. |
 | autocompleteMinimumCharacters | Integer                                                                      | no        | 0                                                                  |         | Minimum number of characters before autocompleting.                                                                                                                                                                                                                                                                                                          |
 | autocompleteView              | Render Function                                                              | no        | [Autocomplete](packages/react-search-ui-views/src/Autocomplete.js) |         | Provide a different view just for the autocomplete dropdown.                                                                                                                                                                                                                                                                                                 |
+| inputView                     | Render Function                                                              | no        | [SearchInput](packages/react-search-ui-views/src/SearchInput.js)   |         | Provide a different view just for the input section.                                                                                                                                                                                                                                                                                                         |
 | onSelectAutocomplete          | Function(selection. options, defaultOnSelectAutocomplete)                    | no        |                                                                    |         | Allows overriding behavior when selected, to avoid creating an entirely new view. In addition to the current `selection`, various helpers are passed as `options` to the second parameter. This third parameter is the default `onSelectAutocomplete`, which allows you to defer to the original behavior.                                                   |
 | onSubmit                      | Function(searchTerm)                                                         | no        |                                                                    |         | Allows overriding behavior when submitted. Receives the search term from the search box.                                                                                                                                                                                                                                                                     |
 

--- a/packages/react-search-ui-views/src/SearchBox.js
+++ b/packages/react-search-ui-views/src/SearchBox.js
@@ -7,6 +7,7 @@ import { Suggestion } from "./types";
 import { appendClassName } from "./view-helpers";
 
 import Autocomplete from "./Autocomplete";
+import SearchInput from "./SearchInput";
 
 function SearchBox(props) {
   const {
@@ -15,6 +16,7 @@ function SearchBox(props) {
     autocompleteView,
     isFocused,
     inputProps = {},
+    inputView,
     onChange,
     onSelectAutocomplete,
     onSubmit,
@@ -23,6 +25,7 @@ function SearchBox(props) {
   } = props;
   const focusedClass = isFocused ? "focus" : "";
   const AutocompleteView = autocompleteView || Autocomplete;
+  const InputView = inputView || SearchInput;
 
   return (
     <Downshift
@@ -53,25 +56,35 @@ function SearchBox(props) {
                 appendClassName("sui-search-box", className) + autocompleteClass
               }
             >
-              <div className="sui-search-box__wrapper">
-                <input
-                  {...getInputProps({
+              <InputView
+                getInputProps={additionalProps =>
+                  getInputProps({
                     placeholder: "Search your documents",
                     ...inputProps,
                     className: `${appendClassName(
                       "sui-search-box__text-input",
                       inputProps.className
-                    )} ${focusedClass}`
-                  })}
-                />
-                {useAutocomplete && isOpen && allAutocompletedItemsCount > 0 ? (
-                  <AutocompleteView {...props} {...downshiftProps} />
-                ) : null}
-              </div>
-              <input
-                type="submit"
-                value="Search"
-                className="button sui-search-box__submit"
+                    )} ${focusedClass}`,
+                    ...additionalProps
+                  })
+                }
+                getButtonProps={additionalProps => ({
+                  type: "submit",
+                  value: "Search",
+                  className: "button sui-search-box__submit",
+                  ...additionalProps
+                })}
+                getAutocomplete={() => {
+                  if (
+                    useAutocomplete &&
+                    isOpen &&
+                    allAutocompletedItemsCount > 0
+                  ) {
+                    return <AutocompleteView {...props} {...downshiftProps} />;
+                  } else {
+                    return null;
+                  }
+                }}
               />
             </div>
           </form>
@@ -116,6 +129,7 @@ SearchBox.propTypes = {
   ]),
   className: PropTypes.string,
   inputProps: PropTypes.object,
+  inputView: PropTypes.func,
   isFocused: PropTypes.bool,
   useAutocomplete: PropTypes.bool,
 

--- a/packages/react-search-ui-views/src/SearchBox.js
+++ b/packages/react-search-ui-views/src/SearchBox.js
@@ -57,23 +57,31 @@ function SearchBox(props) {
               }
             >
               <InputView
-                getInputProps={additionalProps =>
-                  getInputProps({
+                getInputProps={additionalProps => {
+                  const { className, ...rest } = additionalProps || {};
+                  return getInputProps({
                     placeholder: "Search your documents",
                     ...inputProps,
-                    className: `${appendClassName(
-                      "sui-search-box__text-input",
-                      inputProps.className
-                    )} ${focusedClass}`,
-                    ...additionalProps
-                  })
-                }
-                getButtonProps={additionalProps => ({
-                  type: "submit",
-                  value: "Search",
-                  className: "button sui-search-box__submit",
-                  ...additionalProps
-                })}
+                    className: appendClassName("sui-search-box__text-input", [
+                      inputProps.className,
+                      className,
+                      focusedClass
+                    ]),
+                    ...rest
+                  });
+                }}
+                getButtonProps={additionalProps => {
+                  const { className, ...rest } = additionalProps || {};
+                  return {
+                    type: "submit",
+                    value: "Search",
+                    className: appendClassName(
+                      "button sui-search-box__submit",
+                      className
+                    ),
+                    ...rest
+                  };
+                }}
                 getAutocomplete={() => {
                   if (
                     useAutocomplete &&

--- a/packages/react-search-ui-views/src/SearchInput.js
+++ b/packages/react-search-ui-views/src/SearchInput.js
@@ -1,0 +1,22 @@
+import PropTypes from "prop-types";
+import React from "react";
+
+function SearchInput({ getAutocomplete, getButtonProps, getInputProps }) {
+  return (
+    <>
+      <div className="sui-search-box__wrapper">
+        <input {...getInputProps()} />
+        {getAutocomplete()}
+      </div>
+      <input {...getButtonProps()} />
+    </>
+  );
+}
+
+SearchInput.propTypes = {
+  getAutocomplete: PropTypes.func.isRequired,
+  getButtonProps: PropTypes.func.isRequired,
+  getInputProps: PropTypes.func.isRequired
+};
+
+export default SearchInput;

--- a/packages/react-search-ui-views/src/__tests__/SearchBox.test.js
+++ b/packages/react-search-ui-views/src/__tests__/SearchBox.test.js
@@ -60,7 +60,95 @@ it("applies className from inputProps to input element", () => {
     .find("SearchInput")
     .shallow();
   const input = downshift.find(".sui-search-box__text-input");
-  expect(input.props().className).toBe(
-    "sui-search-box__text-input test-class "
-  );
+  expect(input.props().className).toBe("sui-search-box__text-input test-class");
+});
+
+describe("inputView prop", () => {
+  let wrapper, input, button;
+
+  function setup() {
+    wrapper = shallow(
+      <SearchBox
+        {...requiredProps}
+        inputView={({ getAutocomplete, getInputProps, getButtonProps }) => {
+          return (
+            <>
+              <div className="some_custom_wrapper_class">
+                <input
+                  {...getInputProps({
+                    className: "some_custom_input_class"
+                  })}
+                />
+                {getAutocomplete()}
+                <input
+                  {...getButtonProps({
+                    className: "some_custom_button_class"
+                  })}
+                />
+              </div>
+            </>
+          );
+        }}
+      />
+    );
+
+    input = wrapper
+      .dive("Downshift")
+      .find("inputView")
+      .shallow()
+      .find("input")
+      .at(0);
+
+    button = wrapper
+      .dive("Downshift")
+      .find("inputView")
+      .shallow()
+      .find("input")
+      .at(1);
+  }
+
+  it("will render a custom view just for the input section", () => {
+    setup();
+    expect(
+      wrapper
+        .dive("Downshift")
+        .find("inputView")
+        .shallow()
+        .find(".some_custom_wrapper_class")
+    ).toHaveLength(1);
+  });
+
+  describe("when getInputProps is used", () => {
+    it("will render custom props on input", () => {
+      setup();
+      expect(input.hasClass("some_custom_input_class")).toBe(true);
+    });
+
+    it("will not overwrite the base class on input", () => {
+      setup();
+      expect(input.hasClass("sui-search-box__text-input")).toBe(true);
+    });
+
+    it("will render base props on input", () => {
+      setup();
+      expect(input.props().placeholder).toBe("Search your documents");
+    });
+  });
+
+  describe("when getButtonProps is used", () => {
+    it("will render custom props on button", () => {
+      setup();
+      expect(button.hasClass("some_custom_button_class")).toBe(true);
+    });
+
+    it("will not overwrite the base class on button", () => {
+      setup();
+      expect(button.hasClass("sui-search-box__submit")).toBe(true);
+    });
+
+    it("will render base props on button", () => {
+      setup();
+      expect(button.props().type).toBe("submit");
+    });
+  });
 });

--- a/packages/react-search-ui-views/src/__tests__/SearchBox.test.js
+++ b/packages/react-search-ui-views/src/__tests__/SearchBox.test.js
@@ -21,7 +21,10 @@ it("renders correctly", () => {
 
 it("applies 'focused' class when `isFocused` is true", () => {
   const wrapper = shallow(<SearchBox {...requiredProps} isFocused={true} />);
-  const downshift = wrapper.dive("Downshift");
+  const downshift = wrapper
+    .dive("Downshift")
+    .find("SearchInput")
+    .shallow();
   const input = downshift.find(".sui-search-box__text-input");
   expect(input.hasClass("focus")).toBe(true);
 });
@@ -52,7 +55,10 @@ it("applies className from inputProps to input element", () => {
     <SearchBox {...requiredProps} inputProps={{ className: customClassName }} />
   );
 
-  const downshift = wrapper.dive("Downshift");
+  const downshift = wrapper
+    .dive("Downshift")
+    .find("SearchInput")
+    .shallow();
   const input = downshift.find(".sui-search-box__text-input");
   expect(input.props().className).toBe(
     "sui-search-box__text-input test-class "

--- a/packages/react-search-ui-views/src/__tests__/view-helpers/appendClassName.test.js
+++ b/packages/react-search-ui-views/src/__tests__/view-helpers/appendClassName.test.js
@@ -1,0 +1,21 @@
+import { appendClassName } from "../../view-helpers";
+
+it("will append a className", () => {
+  expect(appendClassName("a", "b")).toBe("a b");
+});
+
+it("will handle an empty base className", () => {
+  expect(appendClassName("", "b")).toBe("b");
+});
+
+it("will handle an empty new className", () => {
+  expect(appendClassName("a")).toBe("a");
+});
+
+it("will handle a missing new className", () => {
+  expect(appendClassName()).toBe("");
+});
+
+it("will accept an array", () => {
+  expect(appendClassName("a", ["b", null, "", "c"])).toBe("a b c");
+});

--- a/packages/react-search-ui-views/src/view-helpers/appendClassName.js
+++ b/packages/react-search-ui-views/src/view-helpers/appendClassName.js
@@ -1,4 +1,11 @@
+function getNewClassName(newClassName) {
+  if (!Array.isArray(newClassName)) return newClassName;
+
+  return newClassName.filter(name => name).join(" ");
+}
+
 export default function appendClassName(baseClassName, newClassName) {
-  if (!newClassName) return baseClassName;
-  return `${baseClassName} ${newClassName}`;
+  if (!newClassName) return baseClassName || "";
+  if (!baseClassName) return getNewClassName(newClassName) || "";
+  return `${baseClassName} ${getNewClassName(newClassName)}`;
 }

--- a/packages/react-search-ui-views/stories/SearchBox.stories.js
+++ b/packages/react-search-ui-views/stories/SearchBox.stories.js
@@ -182,4 +182,25 @@ storiesOf("SearchBox", module)
         </div>
       )}
     />
+  ))
+  .add("with custom input template", () => (
+    <Wrapper
+      inputView={({ getAutocomplete, getInputProps }) => {
+        return (
+          <>
+            <div className="sui-search-box__wrapper">
+              <input
+                {...getInputProps({
+                  style: {
+                    backgroundColor: "black",
+                    color: "white"
+                  }
+                })}
+              />
+              {getAutocomplete()}
+            </div>
+          </>
+        );
+      }}
+    />
   ));

--- a/packages/react-search-ui/src/containers/SearchBox.js
+++ b/packages/react-search-ui/src/containers/SearchBox.js
@@ -35,6 +35,7 @@ export class SearchBoxContainer extends Component {
     className: PropTypes.string,
     debounceLength: PropTypes.number,
     inputProps: PropTypes.object,
+    inputView: PropTypes.func,
     onSelectAutocomplete: PropTypes.func,
     onSubmit: PropTypes.func,
     searchAsYouType: PropTypes.bool,
@@ -149,6 +150,7 @@ export class SearchBoxContainer extends Component {
       className,
       autocompleteView,
       inputProps,
+      inputView,
       onSelectAutocomplete,
       onSubmit,
       searchTerm,
@@ -208,7 +210,8 @@ export class SearchBoxContainer extends Component {
         onFocus: this.handleFocus,
         onBlur: this.handleBlur,
         ...inputProps
-      }
+      },
+      inputView
     });
   }
 }


### PR DESCRIPTION
## Description

Adding this allows for much simpler, targeted view customization.
Instead of having to deal with all of the Downshift plumbing and logic,
this lets you very easily target just the html.

For example, if you just want to hide the search button, or inject an icon, etc. This makes it much easier. CC @scottybollinger @zumwalt, this is something you had dealt with before.

```jsx
                    <SearchBox
                      inputView={({
                        getAutocomplete,
                        getButtonProps,
                        getInputProps
                      }) => (
                        <>
                          <div className="sui-search-box__wrapper">
                            <input
                              {...getInputProps({ placeholder: "I am thor" })}
                            />
                            {getAutocomplete()}
                          </div>
                          <input {...getButtonProps()} />
                        </>
                      )}
```

See the ADVANCED.md updates for some more examples.

## List of changes

- Added a inputView option to SearchBox

## Associated Github Issues

#163