### PR TITLE
Allow meta

### DIFF
--- a/packages/search-ui-app-search-connector/src/responseAdapter.js
+++ b/packages/search-ui-app-search-connector/src/responseAdapter.js
@@ -58,13 +58,7 @@ export function adaptResponse(response, options = {}) {
   return {
     ...(facets && { facets: adaptFacets(facets, options) }),
     requestId,
-    results: response.rawResults.map(r => {
-      // eslint-disable-next-line
-      const { _meta, ...rest } = r;
-      return {
-        ...rest
-      };
-    }),
+    results: response.rawResults,
     ...(totalPages !== undefined && { totalPages }),
     ...(totalResults !== undefined && { totalResults })
   };


### PR DESCRIPTION
## Description

Since we have now loosened the Result schema to allow arbitrary fields (https://github.com/elastic/search-ui/pull/271), and the Result view now filters out those arbitrary fields, there is no reason to continue filtering out the `_meta` tag from App Search responses, which users may need (https://github.com/elastic/search-ui/issues/274).

This was a trivial change, and there were no tests for this case to begin with, so there are no tests to update either.

## List of changes

- Removed filtering of `_meta` from results on App Search API Responses

## Associated Github Issues

#274 