### PR TITLE
Fixed issue with state not updating

### DIFF
--- a/packages/search-ui/src/SearchDriver.js
+++ b/packages/search-ui/src/SearchDriver.js
@@ -272,8 +272,8 @@ export default class SearchDriver {
     const state = { ...this.state, ...newState };
     // eslint-disable-next-line no-console
     if (this.debug) console.log("State Update", newState, state);
-    this.subscriptions.forEach(subscription => subscription(state));
     this.state = state;
+    this.subscriptions.forEach(subscription => subscription(state));
   }
 
   /**

--- a/packages/search-ui/src/__tests__/SearchDriver.test.js
+++ b/packages/search-ui/src/__tests__/SearchDriver.test.js
@@ -279,6 +279,21 @@ describe("subscribeToStateChanges", () => {
     expect(called1).toBe(true);
     expect(called2).toBe(true);
   });
+
+  it("will update own state before notifying subscribers", () => {
+    const { driver } = setupDriver();
+    let searchTermFromDriver, searchTermFromSubscription, called;
+    driver.subscribeToStateChanges(state => {
+      // So that this subscription does not run multiple times
+      if (called) return;
+      called = true;
+      searchTermFromDriver = driver.getState().searchTerm;
+      searchTermFromSubscription = state.searchTerm;
+    });
+    driver.setSearchTerm("newValue");
+    expect(searchTermFromDriver).toBe("newValue");
+    expect(searchTermFromSubscription).toBe("newValue");
+  });
 });
 
 describe("unsubscribeToStateChanges", () => {


### PR DESCRIPTION
## Description

This fixes an issue described in #279, where if you had components
nested under a `WithSearch`, that used state from `WithSearch` to
conditionally render, they would be one state update behind.

This is because the conditional components are initialized after
a state update on the higher level `WithSearch`, who's update was
triggered because they are subscribed to the driver's state.

When the nested component's constructor runs, they grab the most
recent state from the driver. However, the way the driver was set up,
subscriptions were executed BEFORE the driver's own state was updated.
Therefore, the nested component's state was being derived from the
outdated driver state.

## List of changes

- Changed driver to update own state before notifying subscriptions

## Associated Github Issues

Fixes #279 
