### PR TITLE
Removed Roboto font

### DIFF
--- a/packages/react-search-ui-views/src/styles/themes/reference-ui/_base.scss
+++ b/packages/react-search-ui-views/src/styles/themes/reference-ui/_base.scss
@@ -1,12 +1,12 @@
 html {
   box-sizing: border-box;
 }
-*, *:before, *:after {
+*,
+*:before,
+*:after {
   box-sizing: inherit;
 }
 
-
-@import url("https://fonts.googleapis.com/css?family=Roboto:400,700");
 @import "modules/variables";
 @import "modules/mixins";
 @import "layouts/layout";

--- a/packages/react-search-ui-views/src/styles/themes/reference-ui/modules/_variables.scss
+++ b/packages/react-search-ui-views/src/styles/themes/reference-ui/modules/_variables.scss
@@ -30,7 +30,8 @@ $fieldHoverColor: #f6f6f6 !default;
 $resultKeyTextColor: #777777 !default;
 
 // Font Variables
-$fontFamily: 'Roboto', sans-serif !default;
+$fontFamily: system, -apple-system, ".SFNSText-Regular", "San Francisco",
+  "Roboto", "Segoe UI", "Helvetica Neue", "Lucida Grande", sans-serif !default;
 $fontWeightNormal: 400 !default;
 $fontWeightBold: 700 !default;
 $lineHeight: 1.5 !default;

--- a/packages/react-search-ui-views/src/styles/themes/reference-ui/modules/_variables.scss
+++ b/packages/react-search-ui-views/src/styles/themes/reference-ui/modules/_variables.scss
@@ -30,8 +30,8 @@ $fieldHoverColor: #f6f6f6 !default;
 $resultKeyTextColor: #777777 !default;
 
 // Font Variables
-$fontFamily: system, -apple-system, ".SFNSText-Regular", "San Francisco",
-  "Roboto", "Segoe UI", "Helvetica Neue", "Lucida Grande", sans-serif !default;
+$fontFamily: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica,
+  Arial, sans-serif !default;
 $fontWeightNormal: 400 !default;
 $fontWeightBold: 700 !default;
 $lineHeight: 1.5 !default;


### PR DESCRIPTION
## Description

Please compare the following two sites.

Without Roboto (new): https://search-ui-canary.netlify.com
With Roboto (current): https://search-ui-stable.netlify.com

The difference is very subtle, and I think this will be fine.

## List of changes

- Removed Roboto font and replaced with system styles suggested by @zumwalt 

## Associated Github Issues

Fixes: https://github.com/elastic/search-ui/issues/293
