### PR TITLE
Update inputView documentation example

### DIFF
--- a/ADVANCED.md
+++ b/ADVANCED.md
@@ -331,12 +331,12 @@ like hiding the submit button or rearranging dom structure:
           })}
         />
         {getAutocomplete()}
-        <input
-          {...getButtonProps({
-            "data-custom-attr": "some value"
-          })}
-        />
       </div>
+      <input
+        {...getButtonProps({
+          "data-custom-attr": "some value"
+        })}
+      />
     </>
   )}
 />


### PR DESCRIPTION
## Description
Per our quick Slack convo last Friday - I asked if the code sample in https://github.com/elastic/search-ui/pull/273/files#diff-f959751a4f181dc8bdc2673b10144d0fR323 was meant to have a different DOM structure than the default SearchBox. The answer was no, so I thought I'd update the docs example to match SearchBox :)

## List of changes
- Fixing inputView example to match Search UI's default SearchBox DOM structure