### PR TITLE
Fixed a CSS bug

### DIFF
--- a/packages/react-search-ui-views/src/ResultsPerPage.js
+++ b/packages/react-search-ui-views/src/ResultsPerPage.js
@@ -8,7 +8,14 @@ const setDefaultStyle = {
   option: () => ({}),
   control: () => ({}),
   dropdownIndicator: () => ({}),
-  indicatorSeparator: () => ({})
+  indicatorSeparator: () => ({}),
+  singleValue: provided => {
+    // Pulling out CSS that we don't want
+    // eslint-disable-next-line no-unused-vars
+    const { position, top, transform, maxWidth, ...rest } = provided;
+    return { ...rest, lineHeight: 1, marginRight: 0 };
+  },
+  valueContainer: provided => ({ ...provided, paddingRight: 0 })
 };
 
 const wrapOption = option => ({ label: option, value: option });

--- a/packages/react-search-ui-views/src/__tests__/__snapshots__/ResultsPerPage.test.js.snap
+++ b/packages/react-search-ui-views/src/__tests__/__snapshots__/ResultsPerPage.test.js.snap
@@ -35,6 +35,8 @@ exports[`renders correctly when there is a selected value 1`] = `
         "dropdownIndicator": [Function],
         "indicatorSeparator": [Function],
         "option": [Function],
+        "singleValue": [Function],
+        "valueContainer": [Function],
       }
     }
     value={
@@ -82,6 +84,8 @@ exports[`renders correctly when there is not a selected value 1`] = `
         "dropdownIndicator": [Function],
         "indicatorSeparator": [Function],
         "option": [Function],
+        "singleValue": [Function],
+        "valueContainer": [Function],
       }
     }
     value={null}

--- a/packages/react-search-ui-views/src/styles/themes/reference-ui/components/_result.scss
+++ b/packages/react-search-ui-views/src/styles/themes/reference-ui/components/_result.scss
@@ -8,6 +8,8 @@
   background: white;
   border-radius: 4px;
   box-shadow: 0px 0px 1px 0px rgba(0, 0, 0, 0.1);
+  overflow-wrap: break-word;
+  overflow: hidden;
 
   & + & {
     margin-top: $sizeXL;

--- a/packages/react-search-ui-views/src/styles/themes/reference-ui/components/_select.scss
+++ b/packages/react-search-ui-views/src/styles/themes/reference-ui/components/_select.scss
@@ -4,7 +4,7 @@
   font-size: 0.875rem;
   margin-top: $sizeS;
   width: 100%;
-  min-width: 60px;
+  min-width: 65px;
 
   @include modifier('inline') {
     margin-top: 0;

--- a/packages/react-search-ui-views/src/styles/themes/reference-ui/components/_select.scss
+++ b/packages/react-search-ui-views/src/styles/themes/reference-ui/components/_select.scss
@@ -4,7 +4,6 @@
   font-size: 0.875rem;
   margin-top: $sizeS;
   width: 100%;
-  min-width: 65px;
 
   @include modifier('inline') {
     margin-top: 0;

--- a/packages/react-search-ui-views/src/styles/themes/reference-ui/layouts/_layout.scss
+++ b/packages/react-search-ui-views/src/styles/themes/reference-ui/layouts/_layout.scss
@@ -32,17 +32,15 @@
     }
 
     @include block("layout-sidebar") {
-      flex: 0 1 30%;
+      width: 24%;
       padding: 32px 32px 0 0;
     }
 
     @include block("layout-main") {
-      width: 100%;
+      width: 76%;
       padding: 2rem 0;
       padding: 32px 0 32px 32px;
       border-left: none;
-      overflow-wrap: break-word;
-      overflow: hidden;
 
       @include block("layout-main-header") {
         display: flex;

--- a/packages/react-search-ui-views/stories/ResultsPerPage.stories.js
+++ b/packages/react-search-ui-views/stories/ResultsPerPage.stories.js
@@ -12,6 +12,6 @@ const baseProps = {
 };
 
 storiesOf("Results per page", module)
-  .addDecorator(story => <div style={{ maxWidth: "135px" }}>{story()}</div>)
+  .addDecorator(story => <div style={{ display: "flex" }}>{story()}</div>)
   .add("basic", () => <ResultsPerPage {...{ ...baseProps }} />)
   .add("no value", () => <ResultsPerPage {...{ ...baseProps, value: null }} />);

--- a/packages/react-search-ui/src/containers/__tests__/__snapshots__/ResultsPerPage.test.js.snap
+++ b/packages/react-search-ui/src/containers/__tests__/__snapshots__/ResultsPerPage.test.js.snap
@@ -1,56 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`renders when it doesn't have any results or a search term 1`] = `
-<div
-  className="sui-results-per-page"
->
-  <div
-    className="sui-results-per-page__label"
-  >
-    Show
-  </div>
-  <StateManager
-    className="sui-select sui-select--inline"
-    classNamePrefix="sui-select"
-    defaultInputValue=""
-    defaultMenuIsOpen={false}
-    defaultValue={null}
-    isSearchable={false}
-    onChange={[Function]}
-    options={
-      Array [
-        Object {
-          "label": 20,
-          "value": 20,
-        },
-        Object {
-          "label": 40,
-          "value": 40,
-        },
-        Object {
-          "label": 60,
-          "value": 60,
-        },
-      ]
-    }
-    styles={
-      Object {
-        "control": [Function],
-        "dropdownIndicator": [Function],
-        "indicatorSeparator": [Function],
-        "option": [Function],
-      }
-    }
-    value={
-      Object {
-        "label": 20,
-        "value": 20,
-      }
-    }
-  />
-</div>
-`;
-
 exports[`renders the component with custom page options 1`] = `
 <div
   className="sui-results-per-page"
@@ -90,12 +39,67 @@ exports[`renders the component with custom page options 1`] = `
         "dropdownIndicator": [Function],
         "indicatorSeparator": [Function],
         "option": [Function],
+        "singleValue": [Function],
+        "valueContainer": [Function],
       }
     }
     value={
       Object {
         "label": 10,
         "value": 10,
+      }
+    }
+  />
+</div>
+`;
+
+exports[`renders when it doesn't have any results or a search term 1`] = `
+<div
+  className="sui-results-per-page"
+>
+  <div
+    className="sui-results-per-page__label"
+  >
+    Show
+  </div>
+  <StateManager
+    className="sui-select sui-select--inline"
+    classNamePrefix="sui-select"
+    defaultInputValue=""
+    defaultMenuIsOpen={false}
+    defaultValue={null}
+    isSearchable={false}
+    onChange={[Function]}
+    options={
+      Array [
+        Object {
+          "label": 20,
+          "value": 20,
+        },
+        Object {
+          "label": 40,
+          "value": 40,
+        },
+        Object {
+          "label": 60,
+          "value": 60,
+        },
+      ]
+    }
+    styles={
+      Object {
+        "control": [Function],
+        "dropdownIndicator": [Function],
+        "indicatorSeparator": [Function],
+        "option": [Function],
+        "singleValue": [Function],
+        "valueContainer": [Function],
+      }
+    }
+    value={
+      Object {
+        "label": 20,
+        "value": 20,
       }
     }
   />


### PR DESCRIPTION
## Description

After removing the Roboto font, there was an issue with the
ResultPerPage dropdown, where it was too narrow for the font and
was being squashed down to an ellipses.

Additionally, there was an issue where the box shadow of the
dropdown was being cut off due to a change made in #266. I moved
the styles from that change to be more targeted to fix this.

Before:

<img width="1014" alt="css-iussues" src="https://user-images.githubusercontent.com/1427475/60527767-e7e96f80-9cc0-11e9-81e8-1adbebad9278.png">

After:

<img width="733" alt="css-fix" src="https://user-images.githubusercontent.com/1427475/60527830-0cdde280-9cc1-11e9-97cd-b33e6c76b706.png">

