### PR TITLE
Updated README notices.

### DIFF
--- a/packages/react-search-ui-views/README.md
+++ b/packages/react-search-ui-views/README.md
@@ -1,6 +1,6 @@
 # react-search-ui-views
 
-**NOTE: This library is in an early Beta period, it is not yet recommended for production use**
+Part of the [Search UI](https://github.com/elastic/search-ui) project.
 
 This is the view layer for [react-search-ui](../react-search-ui/README.md).
 

--- a/packages/react-search-ui/README.md
+++ b/packages/react-search-ui/README.md
@@ -1,6 +1,6 @@
 # Search UI: React Framework
 
-**NOTE: This library is in an early Beta period, it is not yet recommended for production use**
+Part of the [Search UI](https://github.com/elastic/search-ui) project.
 
 React library for building search experiences.
 

--- a/packages/search-ui-app-search-connector/README.md
+++ b/packages/search-ui-app-search-connector/README.md
@@ -1,6 +1,6 @@
 # search-ui-app-search-connector
 
-**NOTE: This library is in an early Beta period, it is not yet recommended for production use**
+Part of the [Search UI](https://github.com/elastic/search-ui) project.
 
 This Connector is used to connect Search UI to Elastic's [App Search](https://www.elastic.co/cloud/app-search-service) API.
 

--- a/packages/search-ui-site-search-connector/README.md
+++ b/packages/search-ui-site-search-connector/README.md
@@ -1,6 +1,6 @@
 # search-ui-site-search-connector
 
-**NOTE: This library is in an early Beta period, it is not yet recommended for production use**
+Part of the [Search UI](https://github.com/elastic/search-ui) project.
 
 This Connector is used to connect Search UI to Elastic's [Site Search](https://www.elastic.co/cloud/site-search-service) API.
 

--- a/packages/search-ui/README.md
+++ b/packages/search-ui/README.md
@@ -1,6 +1,6 @@
 # search-ui
 
-**NOTE: This library is in an early Beta period, it is not yet recommended for production use**
+Part of the [Search UI](https://github.com/elastic/search-ui) project.
 
 The "Headless Search UI" that serves as a foundation for the [react-search-ui](../react-search-ui/README.md) library.
 


### PR DESCRIPTION
## Description

2 things I noticed when viewing the package on NPM is that there is the big notice about being in Beta, which I don't think we want any longer. And also, when you're looking at one of these individually, it's easy to miss the context that they are part of a larger project.

## List of changes
- Removed the "beta" warning, since these are find to
 use in production.
- Added a link to the main project, so it's clear from the npm
descriptions that these are a part of a larger project.
