### PR TITLE
Apply passed className prop to Layout component

### DIFF
--- a/packages/react-search-ui-views/src/__tests__/layouts/Layout.test.js
+++ b/packages/react-search-ui-views/src/__tests__/layouts/Layout.test.js
@@ -36,3 +36,9 @@ it("will accept children instead of bodyContent", () => {
   );
   expect(wrapper).toMatchSnapshot();
 });
+
+it("renders with className prop applied", () => {
+  const wrapper = shallow(<Layout className="test-class" />);
+
+  expect(wrapper.hasClass("test-class")).toBeTruthy();
+});

--- a/packages/react-search-ui-views/src/layouts/Layout.js
+++ b/packages/react-search-ui-views/src/layouts/Layout.js
@@ -1,7 +1,10 @@
 import PropTypes from "prop-types";
 import React from "react";
 
+import { appendClassName } from "../view-helpers";
+
 function Layout({
+  className,
   children,
   header,
   bodyContent,
@@ -10,7 +13,7 @@ function Layout({
   sideContent
 }) {
   return (
-    <div className="sui-layout">
+    <div className={appendClassName("sui-layout", className)}>
       <div className="sui-layout-header">
         <div className="sui-layout-header__inner">{header}</div>
       </div>
@@ -33,6 +36,7 @@ function Layout({
 }
 
 Layout.propTypes = {
+  className: PropTypes.string,
   children: PropTypes.node,
   header: PropTypes.node,
   bodyContent: PropTypes.node,


### PR DESCRIPTION
## Description

Initial question/ask:

> Do we want to consider allowing a custom `className` on Layout.js? We allow custom classNames on multiple other components (e.g. `SearchBox`, etc.) so it seemed a little odd that I couldn’t do something like `<Layout className="container container--wide">`.

## List of changes

- The Layout component should now pass/apply custom `className` props to the parent container.

## Associated Github Issues

Fixes #302