### PR TITLE
Fix issue where paging info would show a higher end than possible

### DIFF
--- a/packages/react-search-ui-views/src/PagingInfo.js
+++ b/packages/react-search-ui-views/src/PagingInfo.js
@@ -8,7 +8,7 @@ function PagingInfo({ className, end, searchTerm, start, totalResults }) {
     <div className={appendClassName("sui-paging-info", className)}>
       Showing{" "}
       <strong>
-        {start} - {end}
+        {start} - {Math.min(end, totalResults)}
       </strong>{" "}
       out of <strong>{totalResults}</strong> for: <em>{searchTerm}</em>
     </div>

--- a/packages/react-search-ui-views/src/__tests__/PagingInfo.test.js
+++ b/packages/react-search-ui-views/src/__tests__/PagingInfo.test.js
@@ -22,3 +22,8 @@ it("renders with className prop applied", () => {
   const { className } = wrapper.props();
   expect(className).toEqual("sui-paging-info test-class");
 });
+
+it("does not render a higher end than the total # of results", () => {
+  const wrapper = shallow(<PagingInfo {...props} totalResults={15} />);
+  expect(wrapper).toMatchSnapshot();
+});

--- a/packages/react-search-ui-views/src/__tests__/__snapshots__/PagingInfo.test.js.snap
+++ b/packages/react-search-ui-views/src/__tests__/__snapshots__/PagingInfo.test.js.snap
@@ -1,5 +1,28 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`does not render a higher end than the total # of results 1`] = `
+<div
+  className="sui-paging-info"
+>
+  Showing
+   
+  <strong>
+    0
+     - 
+    15
+  </strong>
+   
+  out of 
+  <strong>
+    15
+  </strong>
+   for: 
+  <em>
+    grok
+  </em>
+</div>
+`;
+
 exports[`renders correctly 1`] = `
 <div
   className="sui-paging-info"

--- a/packages/react-search-ui-views/stories/PagingInfo.stories.js
+++ b/packages/react-search-ui-views/stories/PagingInfo.stories.js
@@ -11,6 +11,10 @@ const baseProps = {
   totalResults: 20
 };
 
-storiesOf("Paging Info", module).add("Basic", () => (
-  <PagingInfo {...{ ...baseProps }} />
+storiesOf("Paging Info", module).add("basic", () => (
+  <PagingInfo {...baseProps} />
+));
+
+storiesOf("Paging Info", module).add("page capped at total results", () => (
+  <PagingInfo {...baseProps} start={15} end={30} />
 ));


### PR DESCRIPTION
## Description

Caught this issue while doing some accessibility testing! It's pretty minor but I think it'll reduce confusion slightly.

### Before

(Notice 41 - **80**, when the results max/cap out at 59) 
<img width="948" alt="" src="https://user-images.githubusercontent.com/549407/60860476-9282f600-a1cb-11e9-8338-a4816430808b.png">

### After

(Using the correct results max)
<img width="952" alt="" src="https://user-images.githubusercontent.com/549407/60860485-9adb3100-a1cb-11e9-9b96-8789345eadec.png">

## List of changes
- Adds a `Math.min()` check to obtain the lesser of `end` and `totalResults`
