### PR TITLE
[a11y] More accessible MultiCheckboxFacets

### DIFF
--- a/packages/react-search-ui-views/src/MultiCheckboxFacet.js
+++ b/packages/react-search-ui-views/src/MultiCheckboxFacet.js
@@ -19,13 +19,13 @@ function MultiCheckboxFacet({
   searchPlaceholder
 }) {
   return (
-    <div
+    <fieldset
       className={appendClassName(
         "sui-multi-checkbox-facet sui-facet",
         className
       )}
     >
-      <div className="sui-multi-checkbox-facet__label">{label}</div>
+      <legend className="sui-multi-checkbox-facet__label">{label}</legend>
 
       {showSearch && (
         <div className="sui-facet-search">
@@ -91,7 +91,7 @@ function MultiCheckboxFacet({
           + More
         </button>
       )}
-    </div>
+    </fieldset>
   );
 }
 

--- a/packages/react-search-ui-views/src/__tests__/__snapshots__/MultiCheckboxFacet.test.js.snap
+++ b/packages/react-search-ui-views/src/__tests__/__snapshots__/MultiCheckboxFacet.test.js.snap
@@ -1,14 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`renders 1`] = `
-<div
+<fieldset
   className="sui-multi-checkbox-facet sui-facet"
 >
-  <div
+  <legend
     className="sui-multi-checkbox-facet__label"
   >
     A Facet
-  </div>
+  </legend>
   <div
     className="sui-multi-checkbox-facet__options-list"
   >
@@ -75,18 +75,18 @@ exports[`renders 1`] = `
   >
     + More
   </button>
-</div>
+</fieldset>
 `;
 
 exports[`renders range filters 1`] = `
-<div
+<fieldset
   className="sui-multi-checkbox-facet sui-facet"
 >
-  <div
+  <legend
     className="sui-multi-checkbox-facet__label"
   >
     A Facet
-  </div>
+  </legend>
   <div
     className="sui-multi-checkbox-facet__options-list"
   >
@@ -153,5 +153,5 @@ exports[`renders range filters 1`] = `
   >
     + More
   </button>
-</div>
+</fieldset>
 `;

--- a/packages/react-search-ui-views/src/styles/themes/reference-ui/components/_multi-checkbox-facet.scss
+++ b/packages/react-search-ui-views/src/styles/themes/reference-ui/components/_multi-checkbox-facet.scss
@@ -4,12 +4,18 @@
   font-size: 13px;
   display: flex;
   flex-direction: column;
+  // fieldset reset
+  margin: 0;
+  padding: 0;
+  border: 0;
 
   @include element("label") {
     font-size: $sizeM;
     color: $facetLabel;
     text-transform: uppercase;
     letter-spacing: 1px;
+    // legend reset
+    padding: 0;
   }
 
   @include element("options-list") {


### PR DESCRIPTION
## Description

This is a quick semantic markup change which enhances many screen readers' ability to associate multiple checkbox groups with its parent group label.

### Before

<img width="363" alt="" src="https://user-images.githubusercontent.com/549407/60906146-5c755e80-a22b-11e9-92fe-9ab8213c4e85.png">

### After

<img width="460" alt="" src="https://user-images.githubusercontent.com/549407/60906164-6303d600-a22b-11e9-8532-1a791f1e205f.png">

Notice how California now reads out the parent "States" label, giving more context to keyboard tabbing users.

### Screencap

![fieldset](https://user-images.githubusercontent.com/549407/60906302-acecbc00-a22b-11e9-8bce-6ffbb74e4f85.gif)

^ Posting for general edification - note how the parent `legend` is only read out when the user tabs into the **first** input within the `fieldset` group, and is not read out again when tabbing to other items within the group. This is great behavior for context while not becoming repetitive.

## List of changes

- Changes MultiCheckboxFacet markup from `div`s to `fieldset`/`legend` tags.

## QA

- [x] Tested in MacOS Voiceover
- [x] Tested in Chrome for no visual regressions
- [x] Tested in Firefox for no visual regressions
- [x] Tested in Edge for no visual regressions
