### PR TITLE
[a11y] Adding a screen reader live region and announcements for actions

### DIFF
--- a/packages/react-search-ui-views/src/MultiCheckboxFacet.js
+++ b/packages/react-search-ui-views/src/MultiCheckboxFacet.js
@@ -3,7 +3,11 @@ import React from "react";
 import deepEqual from "deep-equal";
 
 import { FacetValue, FilterValue } from "./types";
-import { appendClassName, getFilterValueDisplay } from "./view-helpers";
+import {
+  appendClassName,
+  getFilterValueDisplay,
+  ScreenReaderStatus
+} from "./view-helpers";
 
 function MultiCheckboxFacet({
   className,
@@ -12,6 +16,7 @@ function MultiCheckboxFacet({
   onRemove,
   onSelect,
   options,
+  optionsCount,
   showMore,
   values,
   showSearch,
@@ -82,14 +87,28 @@ function MultiCheckboxFacet({
       </div>
 
       {showMore && (
-        <button
-          type="button"
-          className="sui-multi-checkbox-facet__view-more"
-          onClick={onMoreClick}
-          aria-label="Show more options"
-        >
-          + More
-        </button>
+        <ScreenReaderStatus
+          render={announceToScreenReader => (
+            <button
+              type="button"
+              className="sui-multi-checkbox-facet__view-more"
+              aria-label="Show more options"
+              onClick={() => {
+                onMoreClick();
+
+                const newLimit = options.length + 10;
+                const showingAll = newLimit >= optionsCount;
+                const message = `${
+                  showingAll ? `All ${optionsCount}` : newLimit
+                } options shown.`;
+
+                announceToScreenReader(message);
+              }}
+            >
+              + More
+            </button>
+          )}
+        />
       )}
     </fieldset>
   );
@@ -102,6 +121,7 @@ MultiCheckboxFacet.propTypes = {
   onSelect: PropTypes.func.isRequired,
   onSearch: PropTypes.func.isRequired,
   options: PropTypes.arrayOf(FacetValue).isRequired,
+  optionsCount: PropTypes.number,
   showMore: PropTypes.bool.isRequired,
   values: PropTypes.arrayOf(FilterValue).isRequired,
   className: PropTypes.string,

--- a/packages/react-search-ui-views/src/PagingInfo.js
+++ b/packages/react-search-ui-views/src/PagingInfo.js
@@ -1,17 +1,27 @@
 import PropTypes from "prop-types";
 import React from "react";
 
-import { appendClassName } from "./view-helpers";
+import { appendClassName, ScreenReaderStatus } from "./view-helpers";
 
 function PagingInfo({ className, end, searchTerm, start, totalResults }) {
+  end = Math.min(end, totalResults);
   return (
-    <div className={appendClassName("sui-paging-info", className)}>
-      Showing{" "}
-      <strong>
-        {start} - {Math.min(end, totalResults)}
-      </strong>{" "}
-      out of <strong>{totalResults}</strong> for: <em>{searchTerm}</em>
-    </div>
+    <>
+      <div className={appendClassName("sui-paging-info", className)}>
+        Showing{" "}
+        <strong>
+          {start} - {end}
+        </strong>{" "}
+        out of <strong>{totalResults}</strong> for: <em>{searchTerm}</em>
+      </div>
+      <ScreenReaderStatus
+        render={announceToScreenReader => {
+          let message = `Showing ${start} to ${end} results out of ${totalResults}`;
+          if (searchTerm) message += `, searching for "${searchTerm}".`;
+          return announceToScreenReader(message);
+        }}
+      />
+    </>
   );
 }
 

--- a/packages/react-search-ui-views/src/__tests__/MultiCheckboxFacet.test.js
+++ b/packages/react-search-ui-views/src/__tests__/MultiCheckboxFacet.test.js
@@ -18,6 +18,7 @@ const params = {
       count: 5
     }
   ],
+  optionsCount: 20,
   showMore: true,
   values: ["fieldValue2"]
 };
@@ -70,16 +71,55 @@ it("renders range filters", () => {
   expect(wrapper).toMatchSnapshot();
 });
 
-it("will render 'more' button if more param is true", () => {
-  const wrapper = shallow(
-    <MultiCheckboxFacet
-      {...{
-        ...params,
-        showMore: true
-      }}
-    />
-  );
-  expect(wrapper.find(".sui-multi-checkbox-facet__view-more")).toHaveLength(1);
+describe("'more' button behavior", () => {
+  const announceToScreenReader = jest.fn();
+  const divePastScreenReaderStatus = wrapper =>
+    shallow(
+      wrapper.find("ScreenReaderStatus").prop("render")(announceToScreenReader)
+    );
+
+  it("renders button if showMore param is true", () => {
+    const wrapper = shallow(<MultiCheckboxFacet {...params} showMore={true} />);
+    const button = divePastScreenReaderStatus(wrapper);
+
+    expect(button.find(".sui-multi-checkbox-facet__view-more")).toHaveLength(1);
+    expect(button).toMatchSnapshot();
+  });
+
+  it("does not render button or screen reader status if there are no more options to show", () => {
+    const wrapper = shallow(
+      <MultiCheckboxFacet {...params} showMore={false} />
+    );
+
+    expect(wrapper.find("ScreenReaderStatus")).toHaveLength(0);
+  });
+
+  it("fires onMoreClick", () => {
+    const wrapper = shallow(<MultiCheckboxFacet {...params} showMore={true} />);
+    const button = divePastScreenReaderStatus(wrapper);
+
+    button.simulate("click");
+
+    expect(params.onMoreClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("fires announceToScreenReader with the correct option counts", () => {
+    const wrapper = shallow(<MultiCheckboxFacet {...params} showMore={true} />);
+    const button = divePastScreenReaderStatus(wrapper);
+
+    button.simulate("click");
+    expect(announceToScreenReader).toHaveBeenCalledWith("12 options shown.");
+  });
+
+  it("fires announceToScreenReader with the correct maximum option count", () => {
+    const wrapper = shallow(
+      <MultiCheckboxFacet {...params} showMore={true} optionsCount={5} />
+    );
+    const button = divePastScreenReaderStatus(wrapper);
+
+    button.simulate("click");
+    expect(announceToScreenReader).toHaveBeenCalledWith("All 5 options shown.");
+  });
 });
 
 it("will render a no results message is no options are available", () => {

--- a/packages/react-search-ui-views/src/__tests__/PagingInfo.test.js
+++ b/packages/react-search-ui-views/src/__tests__/PagingInfo.test.js
@@ -19,11 +19,28 @@ it("renders with className prop applied", () => {
   const wrapper = shallow(
     <PagingInfo className={customClassName} {...props} />
   );
-  const { className } = wrapper.props();
+  const { className } = wrapper.childAt(0).props();
   expect(className).toEqual("sui-paging-info test-class");
 });
 
 it("does not render a higher end than the total # of results", () => {
   const wrapper = shallow(<PagingInfo {...props} totalResults={15} />);
   expect(wrapper).toMatchSnapshot();
+});
+
+it("renders ScreenReaderStatus with the correct message", () => {
+  const announceToScreenReader = jest.fn();
+  const wrapper = shallow(<PagingInfo {...props} start={41} end={80} />);
+
+  wrapper.find("ScreenReaderStatus").prop("render")(announceToScreenReader);
+  expect(announceToScreenReader).toHaveBeenCalledWith(
+    'Showing 41 to 80 results out of 1000, searching for "grok".'
+  );
+
+  // Should not call out search term if one isn't present
+  wrapper.setProps({ searchTerm: "" });
+  wrapper.find("ScreenReaderStatus").prop("render")(announceToScreenReader);
+  expect(announceToScreenReader).toHaveBeenCalledWith(
+    "Showing 41 to 80 results out of 1000"
+  );
 });

--- a/packages/react-search-ui-views/src/__tests__/__snapshots__/MultiCheckboxFacet.test.js.snap
+++ b/packages/react-search-ui-views/src/__tests__/__snapshots__/MultiCheckboxFacet.test.js.snap
@@ -67,14 +67,9 @@ exports[`renders 1`] = `
       </span>
     </label>
   </div>
-  <button
-    aria-label="Show more options"
-    className="sui-multi-checkbox-facet__view-more"
-    onClick={[MockFunction]}
-    type="button"
-  >
-    + More
-  </button>
+  <ScreenReaderStatus
+    render={[Function]}
+  />
 </fieldset>
 `;
 
@@ -145,13 +140,19 @@ exports[`renders range filters 1`] = `
       </span>
     </label>
   </div>
-  <button
-    aria-label="Show more options"
-    className="sui-multi-checkbox-facet__view-more"
-    onClick={[MockFunction]}
-    type="button"
-  >
-    + More
-  </button>
+  <ScreenReaderStatus
+    render={[Function]}
+  />
 </fieldset>
+`;
+
+exports[`'more' button behavior renders button if showMore param is true 1`] = `
+<button
+  aria-label="Show more options"
+  className="sui-multi-checkbox-facet__view-more"
+  onClick={[Function]}
+  type="button"
+>
+  + More
+</button>
 `;

--- a/packages/react-search-ui-views/src/__tests__/__snapshots__/PagingInfo.test.js.snap
+++ b/packages/react-search-ui-views/src/__tests__/__snapshots__/PagingInfo.test.js.snap
@@ -1,47 +1,57 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`does not render a higher end than the total # of results 1`] = `
-<div
-  className="sui-paging-info"
->
-  Showing
-   
-  <strong>
-    0
-     - 
-    15
-  </strong>
-   
-  out of 
-  <strong>
-    15
-  </strong>
-   for: 
-  <em>
-    grok
-  </em>
-</div>
+<Fragment>
+  <div
+    className="sui-paging-info"
+  >
+    Showing
+     
+    <strong>
+      0
+       - 
+      15
+    </strong>
+     
+    out of 
+    <strong>
+      15
+    </strong>
+     for: 
+    <em>
+      grok
+    </em>
+  </div>
+  <ScreenReaderStatus
+    render={[Function]}
+  />
+</Fragment>
 `;
 
 exports[`renders correctly 1`] = `
-<div
-  className="sui-paging-info"
->
-  Showing
-   
-  <strong>
-    0
-     - 
-    20
-  </strong>
-   
-  out of 
-  <strong>
-    1000
-  </strong>
-   for: 
-  <em>
-    grok
-  </em>
-</div>
+<Fragment>
+  <div
+    className="sui-paging-info"
+  >
+    Showing
+     
+    <strong>
+      0
+       - 
+      20
+    </strong>
+     
+    out of 
+    <strong>
+      1000
+    </strong>
+     for: 
+    <em>
+      grok
+    </em>
+  </div>
+  <ScreenReaderStatus
+    render={[Function]}
+  />
+</Fragment>
 `;

--- a/packages/react-search-ui-views/src/__tests__/view-helpers/screenReaderAnnouncements.ssr.test.js
+++ b/packages/react-search-ui-views/src/__tests__/view-helpers/screenReaderAnnouncements.ssr.test.js
@@ -1,0 +1,17 @@
+/**
+ * @jest-environment node
+ */
+import React from "react";
+import { shallow } from "enzyme";
+import { ScreenReaderStatus } from "../../view-helpers";
+
+it("does not crash or create errors in server-side rendered apps", () => {
+  shallow(
+    <ScreenReaderStatus
+      render={announceToScreenReader => {
+        announceToScreenReader("Test");
+        return null;
+      }}
+    />
+  );
+});

--- a/packages/react-search-ui-views/src/__tests__/view-helpers/screenReaderAnnouncements.test.js
+++ b/packages/react-search-ui-views/src/__tests__/view-helpers/screenReaderAnnouncements.test.js
@@ -1,0 +1,49 @@
+import React from "react";
+import { shallow } from "enzyme";
+import { ScreenReaderStatus } from "../../view-helpers";
+
+// Test helper
+const getLiveRegion = document =>
+  document.getElementById("search-ui-screen-reader-announcements");
+
+it("creates a live screen reader region", () => {
+  // Before init
+  expect(getLiveRegion(document)).toBeNull();
+
+  shallow(<ScreenReaderStatus render={() => null} />);
+
+  // After init
+  const region = getLiveRegion(document);
+  expect(region).not.toBeNull();
+  expect(region.getAttribute("role")).toEqual("status");
+  expect(region.getAttribute("aria-live")).toEqual("polite");
+  expect(region.style._values.overflow).toEqual("hidden");
+});
+
+it("renders children correctly", () => {
+  const wrapper = shallow(
+    <ScreenReaderStatus render={() => <div>Hello world</div>} />
+  );
+
+  expect(wrapper.text()).toEqual("Hello world");
+});
+
+it("updates the live region correctly via announceToScreenReader", () => {
+  const wrapper = shallow(
+    <ScreenReaderStatus
+      render={announceToScreenReader => (
+        <button onClick={() => announceToScreenReader("Hello world!")}>
+          Foo
+        </button>
+      )}
+    />
+  );
+
+  // Before update
+  expect(getLiveRegion(document).innerText).toBeUndefined();
+
+  wrapper.find("button").simulate("click");
+
+  // After update
+  expect(getLiveRegion(document).innerText).toEqual("Hello world!");
+});

--- a/packages/react-search-ui-views/src/view-helpers/index.js
+++ b/packages/react-search-ui-views/src/view-helpers/index.js
@@ -1,2 +1,3 @@
 export { default as getFilterValueDisplay } from "./getFilterValueDisplay";
 export { default as appendClassName } from "./appendClassName";
+export { default as ScreenReaderStatus } from "./screenReaderAnnouncements";

--- a/packages/react-search-ui-views/src/view-helpers/screenReaderAnnouncements.js
+++ b/packages/react-search-ui-views/src/view-helpers/screenReaderAnnouncements.js
@@ -41,6 +41,7 @@ const getLiveRegion = () => {
 const announceToScreenReader = announcement => {
   const region = getLiveRegion();
   region.innerText = announcement;
+  return null;
 };
 
 /**

--- a/packages/react-search-ui-views/src/view-helpers/screenReaderAnnouncements.js
+++ b/packages/react-search-ui-views/src/view-helpers/screenReaderAnnouncements.js
@@ -6,6 +6,7 @@
  * @see https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions
  */
 const regionId = "search-ui-screen-reader-announcements";
+const hasDOM = typeof document !== "undefined"; // Prevent errors in SSR apps
 
 const getLiveRegion = () => {
   let region = document.getElementById(regionId);
@@ -39,8 +40,10 @@ const getLiveRegion = () => {
 };
 
 const announceToScreenReader = announcement => {
-  const region = getLiveRegion();
-  region.innerText = announcement;
+  if (hasDOM) {
+    const region = getLiveRegion();
+    region.innerText = announcement;
+  }
   return null;
 };
 
@@ -51,7 +54,7 @@ const announceToScreenReader = announcement => {
  * back the announceToScreenReader function
  */
 const ScreenReaderStatus = ({ render }) => {
-  getLiveRegion();
+  if (hasDOM) getLiveRegion();
   return render(announceToScreenReader);
 };
 

--- a/packages/react-search-ui-views/src/view-helpers/screenReaderAnnouncements.js
+++ b/packages/react-search-ui-views/src/view-helpers/screenReaderAnnouncements.js
@@ -1,0 +1,57 @@
+/**
+ * This helper creates a live region that announces the results of certain
+ * actions (e.g. searching, paging, etc.), that are otherwise invisible
+ * to screen reader users.
+ *
+ * @see https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions
+ */
+const regionId = "search-ui-screen-reader-announcements";
+
+const getLiveRegion = () => {
+  let region = document.getElementById(regionId);
+  if (region) return region;
+
+  region = document.createElement("div");
+  region.id = regionId;
+  region.setAttribute("role", "status");
+  region.setAttribute("aria-live", "polite");
+
+  /**
+   * Visually-hidden CSS that's still available to screen readers.
+   * We're avoiding putting this in a stylesheet to ensure that this
+   * still works for users that opt for custom CSS instead of importing
+   * Search UI's styles. We're also opting to use CSSOM instead of
+   * inline styles to avoid Content Security Policy warnings.
+   *
+   * @see https://github.com/h5bp/html5-boilerplate/blob/v5.0.0/src/css/main.css#L126-L140
+   */
+  region.style.position = "absolute";
+  region.style.width = "1px";
+  region.style.height = "1px";
+  region.style.margin = "-1px";
+  region.style.padding = "0";
+  region.style.border = "0";
+  region.style.overflow = "hidden";
+  region.style.clip = "rect(0 0 0 0)";
+
+  document.body.appendChild(region);
+  return region;
+};
+
+const announceToScreenReader = announcement => {
+  const region = getLiveRegion();
+  region.innerText = announcement;
+};
+
+/**
+ * React render prop component
+ *
+ * Initializes the live region on load/mount, and sends
+ * back the announceToScreenReader function
+ */
+const ScreenReaderStatus = ({ render }) => {
+  getLiveRegion();
+  return render(announceToScreenReader);
+};
+
+export default ScreenReaderStatus;

--- a/packages/react-search-ui/src/containers/Facet.js
+++ b/packages/react-search-ui/src/containers/Facet.js
@@ -104,6 +104,7 @@ export class FacetContainer extends Component {
         addFilter(field, value, filterType);
       },
       options: options.slice(0, more),
+      optionsCount: options.length,
       showMore: options.length > more,
       values: selectedValues,
       showSearch: isFilterable,

--- a/packages/react-search-ui/src/containers/__tests__/__snapshots__/Facet.test.js.snap
+++ b/packages/react-search-ui/src/containers/__tests__/__snapshots__/Facet.test.js.snap
@@ -20,6 +20,7 @@ exports[`renders correctly 1`] = `
       },
     ]
   }
+  optionsCount={2}
   searchPlaceholder="Filter field1"
   showMore={false}
   showSearch={false}

--- a/packages/react-search-ui/src/containers/__tests__/__snapshots__/PagingInfo.test.js.snap
+++ b/packages/react-search-ui/src/containers/__tests__/__snapshots__/PagingInfo.test.js.snap
@@ -1,24 +1,29 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`renders when it doesn't have any results or a result search term 1`] = `
-<div
-  className="sui-paging-info"
->
-  Showing
-   
-  <strong>
-    1
-     - 
-    20
-  </strong>
-   
-  out of 
-  <strong>
-    100
-  </strong>
-   for: 
-  <em />
-</div>
+<Fragment>
+  <div
+    className="sui-paging-info"
+  >
+    Showing
+     
+    <strong>
+      1
+       - 
+      20
+    </strong>
+     
+    out of 
+    <strong>
+      100
+    </strong>
+     for: 
+    <em />
+  </div>
+  <ScreenReaderStatus
+    render={[Function]}
+  />
+</Fragment>
 `;
 
 exports[`supports a render prop 1`] = `


### PR DESCRIPTION
## Description

This is an an accessibility PR that provides more context and information to screen reader users. The goal is to announce the results/consequences of certain actions being taken to users, so that visually impaired users aren't left wondering what happened after pressing a button.

For example:
- After clicking the "+ More" button in the filters sidebar, a screen reader user should know how many total filters are now being shown. (This was originally spiked out [here](https://github.com/elastic/search-ui/pull/311#issuecomment-507883906)).
- After pressing the search button, a screen reader user should know how many results are being shown and how many total results were returned.
- After navigating to another page of results, a screen reader user should have the results/paging info read out to them (same as above)
- After changing how many results are being shown per-page, a screen reader user should have the results/paging info read out to them (same as above)

## Screencaps

`Search results announcements:`

<img width="632" alt="" src="https://user-images.githubusercontent.com/549407/60917191-378de500-a245-11e9-939a-e49087be33af.png">

![search-results-screencap](https://user-images.githubusercontent.com/549407/60917219-4b394b80-a245-11e9-8375-32751e4d53ef.gif)

`+ More Filters annoucements:`

![more-filters-screencap](https://user-images.githubusercontent.com/549407/60553178-019dad80-9ce7-11e9-9fb5-66534fcfb9b2.gif)


## List of changes

I recommend following along commit-by-commit if possible!

- Adds a new ScreenReaderStatus render prop helper
  - This creates a one-time live region in the app, and reads out any updates in that region to screen readers. This region can be used by multiple different components.
  - Note: Because this directly modifies the client DOM, a check needs to be added to this helper to ensure it doesn't crash for SSR React apps.
- Updates MultiCheckboxFacet's "+ More" button to announce shown filters to ScreenReaderStatus
- Updates PagingInfo to announce changes in results shown to ScreenReaderStatus

## QA

- [x] Tested on MacOS Voiceover

(Note - uncovered lines are same as before, and all coverage %s went up slightly)
<img width="872" alt="" src="https://user-images.githubusercontent.com/549407/60917688-62c50400-a246-11e9-9140-a11bb90df5b6.png">
<img width="859" alt="" src="https://user-images.githubusercontent.com/549407/60917873-bfc0ba00-a246-11e9-9cd9-047ee93fd530.png">
<img width="865" alt="Screen Shot 2019-07-09 at 12 38 10 PM" src="https://user-images.githubusercontent.com/549407/60917732-77a19780-a246-11e9-939b-2c7078049b12.png">


## Future

I'll continue to investigate other opportunities to use this new live region (the next likely being the SingleLinksFacet component), but for now I'd like to keep this PR fairly small and to the two lowest hanging fruit for screen reader announcements.