### PR TITLE
Add basic/MVP mobile UX for layout sidebar

### DIFF
--- a/packages/react-search-ui-views/src/__tests__/layouts/LayoutSidebar.test.js
+++ b/packages/react-search-ui-views/src/__tests__/layouts/LayoutSidebar.test.js
@@ -1,0 +1,55 @@
+import React from "react";
+import { shallow } from "enzyme";
+
+import LayoutSidebar from "../../layouts/LayoutSidebar";
+
+beforeEach(() => {
+  // This polyfill is required because enzyme/jsdom doesn't render innerText
+  // @see https://github.com/jsdom/jsdom/issues/1245
+  Object.defineProperty(global.Element.prototype, "innerText", {
+    get() {
+      return this.textContent;
+    },
+    configurable: true
+  });
+});
+
+it("renders correctly", () => {
+  const wrapper = shallow(
+    <LayoutSidebar className="sui-layout-sidebar">Hello world!</LayoutSidebar>
+  );
+  expect(wrapper).toMatchSnapshot();
+});
+
+it("renders toggled class based on state", () => {
+  const wrapper = shallow(
+    <LayoutSidebar className="sui-layout-sidebar">Hello world!</LayoutSidebar>
+  );
+  wrapper.setState({ isSidebarToggled: true });
+
+  expect(wrapper.find(".sui-layout-sidebar--toggled")).toHaveLength(1);
+});
+
+it("updates isSidebarToggled state on button click", () => {
+  const wrapper = shallow(
+    <LayoutSidebar className="sui-layout-sidebar">Hello world!</LayoutSidebar>
+  );
+  expect(wrapper.state("isSidebarToggled")).toEqual(false);
+  const buttons = wrapper.find(".sui-layout-sidebar-toggle");
+
+  buttons.first().simulate("click");
+  expect(wrapper.state("isSidebarToggled")).toEqual(true);
+
+  buttons.last().simulate("click");
+  expect(wrapper.state("isSidebarToggled")).toEqual(false);
+});
+
+it("does not show the toggle buttons if there is no sidebar content", () => {
+  // Completely empty sidebar
+  const wrapper = shallow(<LayoutSidebar className="sui-layout-sidebar" />);
+  expect(wrapper.find(".sui-layout-sidebar-toggle")).toHaveLength(0);
+
+  // Effectively empty sidebar
+  wrapper.setProps({ children: <span /> });
+  expect(wrapper.find(".sui-layout-sidebar-toggle")).toHaveLength(0);
+});

--- a/packages/react-search-ui-views/src/__tests__/layouts/__snapshots__/Layout.test.js.snap
+++ b/packages/react-search-ui-views/src/__tests__/layouts/__snapshots__/Layout.test.js.snap
@@ -21,7 +21,7 @@ exports[`renders correctly 1`] = `
     <div
       className="sui-layout-body__inner"
     >
-      <div
+      <LayoutSidebar
         className="sui-layout-sidebar"
       >
         <div>
@@ -29,7 +29,7 @@ exports[`renders correctly 1`] = `
             Side Content
           </div>
         </div>
-      </div>
+      </LayoutSidebar>
       <div
         className="sui-layout-main"
       >
@@ -85,7 +85,7 @@ exports[`will accept children instead of bodyContent 1`] = `
     <div
       className="sui-layout-body__inner"
     >
-      <div
+      <LayoutSidebar
         className="sui-layout-sidebar"
       >
         <div>
@@ -93,7 +93,7 @@ exports[`will accept children instead of bodyContent 1`] = `
             Side Content
           </div>
         </div>
-      </div>
+      </LayoutSidebar>
       <div
         className="sui-layout-main"
       >

--- a/packages/react-search-ui-views/src/__tests__/layouts/__snapshots__/LayoutSidebar.test.js.snap
+++ b/packages/react-search-ui-views/src/__tests__/layouts/__snapshots__/LayoutSidebar.test.js.snap
@@ -1,0 +1,27 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders correctly 1`] = `
+<Fragment>
+  <button
+    className="sui-layout-sidebar-toggle"
+    hidden={true}
+    onClick={[Function]}
+    type="button"
+  >
+    Show Filters
+  </button>
+  <div
+    className="sui-layout-sidebar"
+  >
+    <button
+      className="sui-layout-sidebar-toggle"
+      hidden={true}
+      onClick={[Function]}
+      type="button"
+    >
+      Done Filtering
+    </button>
+    Hello world!
+  </div>
+</Fragment>
+`;

--- a/packages/react-search-ui-views/src/__tests__/layouts/__snapshots__/LayoutSidebar.test.js.snap
+++ b/packages/react-search-ui-views/src/__tests__/layouts/__snapshots__/LayoutSidebar.test.js.snap
@@ -19,7 +19,7 @@ exports[`renders correctly 1`] = `
       onClick={[Function]}
       type="button"
     >
-      Done Filtering
+      Save Filters
     </button>
     Hello world!
   </div>

--- a/packages/react-search-ui-views/src/layouts/Layout.js
+++ b/packages/react-search-ui-views/src/layouts/Layout.js
@@ -1,6 +1,7 @@
 import PropTypes from "prop-types";
 import React from "react";
 
+import SidebarToggle from "./SidebarToggle";
 import { appendClassName } from "../view-helpers";
 
 function Layout({
@@ -54,40 +55,5 @@ Layout.propTypes = {
   bodyHeader: PropTypes.node,
   sideContent: PropTypes.node
 };
-
-class SidebarToggle extends React.Component {
-  static propTypes = { children: PropTypes.func };
-
-  state = { isSidebarToggled: false };
-
-  toggleSidebar = () => {
-    this.setState(({ isSidebarToggled }) => ({
-      isSidebarToggled: !isSidebarToggled
-    }));
-  };
-
-  render() {
-    const { isSidebarToggled } = this.state;
-
-    const renderToggleButton = label => (
-      <button
-        hidden
-        type="button"
-        className="sui-layout-sidebar-toggle"
-        onClick={this.toggleSidebar}
-      >
-        {label}
-      </button>
-    );
-
-    const renderToggleClass = className =>
-      appendClassName(
-        className,
-        isSidebarToggled ? `${className}--toggled` : null
-      );
-
-    return this.props.children({ renderToggleButton, renderToggleClass });
-  }
-}
 
 export default Layout;

--- a/packages/react-search-ui-views/src/layouts/Layout.js
+++ b/packages/react-search-ui-views/src/layouts/Layout.js
@@ -1,7 +1,7 @@
 import PropTypes from "prop-types";
 import React from "react";
 
-import SidebarToggle from "./SidebarToggle";
+import LayoutSidebar from "./LayoutSidebar";
 import { appendClassName } from "../view-helpers";
 
 function Layout({
@@ -20,17 +20,9 @@ function Layout({
       </div>
       <div className="sui-layout-body">
         <div className="sui-layout-body__inner">
-          <SidebarToggle content={sideContent}>
-            {({ renderToggleButton, renderToggleClass }) => (
-              <>
-                {renderToggleButton("Show Filters")}
-                <div className={renderToggleClass("sui-layout-sidebar")}>
-                  {renderToggleButton("Done Filtering")}
-                  {sideContent}
-                </div>
-              </>
-            )}
-          </SidebarToggle>
+          <LayoutSidebar className="sui-layout-sidebar">
+            {sideContent}
+          </LayoutSidebar>
           <div className="sui-layout-main">
             <div className="sui-layout-main-header">
               <div className="sui-layout-main-header__inner">{bodyHeader}</div>

--- a/packages/react-search-ui-views/src/layouts/Layout.js
+++ b/packages/react-search-ui-views/src/layouts/Layout.js
@@ -19,7 +19,17 @@ function Layout({
       </div>
       <div className="sui-layout-body">
         <div className="sui-layout-body__inner">
-          <div className="sui-layout-sidebar">{sideContent}</div>
+          <SidebarToggle>
+            {({ renderToggleButton, renderToggleClass }) => (
+              <>
+                {renderToggleButton("Show Filters")}
+                <div className={renderToggleClass("sui-layout-sidebar")}>
+                  {renderToggleButton("Done Filtering")}
+                  {sideContent}
+                </div>
+              </>
+            )}
+          </SidebarToggle>
           <div className="sui-layout-main">
             <div className="sui-layout-main-header">
               <div className="sui-layout-main-header__inner">{bodyHeader}</div>
@@ -44,5 +54,40 @@ Layout.propTypes = {
   bodyHeader: PropTypes.node,
   sideContent: PropTypes.node
 };
+
+class SidebarToggle extends React.Component {
+  static propTypes = { children: PropTypes.func };
+
+  state = { isSidebarToggled: false };
+
+  toggleSidebar = () => {
+    this.setState(({ isSidebarToggled }) => ({
+      isSidebarToggled: !isSidebarToggled
+    }));
+  };
+
+  render() {
+    const { isSidebarToggled } = this.state;
+
+    const renderToggleButton = label => (
+      <button
+        hidden
+        type="button"
+        className="sui-layout-sidebar-toggle"
+        onClick={this.toggleSidebar}
+      >
+        {label}
+      </button>
+    );
+
+    const renderToggleClass = className =>
+      appendClassName(
+        className,
+        isSidebarToggled ? `${className}--toggled` : null
+      );
+
+    return this.props.children({ renderToggleButton, renderToggleClass });
+  }
+}
 
 export default Layout;

--- a/packages/react-search-ui-views/src/layouts/Layout.js
+++ b/packages/react-search-ui-views/src/layouts/Layout.js
@@ -20,7 +20,7 @@ function Layout({
       </div>
       <div className="sui-layout-body">
         <div className="sui-layout-body__inner">
-          <SidebarToggle>
+          <SidebarToggle content={sideContent}>
             {({ renderToggleButton, renderToggleClass }) => (
               <>
                 {renderToggleButton("Show Filters")}

--- a/packages/react-search-ui-views/src/layouts/LayoutSidebar.js
+++ b/packages/react-search-ui-views/src/layouts/LayoutSidebar.js
@@ -4,10 +4,10 @@ import ReactDOM from "react-dom";
 
 import { appendClassName } from "../view-helpers";
 
-class SidebarToggle extends React.Component {
+class LayoutSidebar extends React.Component {
   static propTypes = {
-    children: PropTypes.func,
-    content: PropTypes.node
+    className: PropTypes.string,
+    children: PropTypes.node
   };
 
   constructor(props) {
@@ -22,17 +22,15 @@ class SidebarToggle extends React.Component {
     }));
   };
 
-  render() {
-    const { content } = this.props;
-    if (!content) return null;
+  renderToggleButton = label => {
+    const { children } = this.props;
+    if (!children) return null;
 
-    ReactDOM.render(content, this.checkContent);
+    ReactDOM.render(children, this.checkContent);
     const hasSidebarContent = Boolean(this.checkContent.innerText);
     if (!hasSidebarContent) return null;
 
-    const { isSidebarToggled } = this.state;
-
-    const renderToggleButton = label => (
+    return (
       <button
         hidden
         type="button"
@@ -42,15 +40,27 @@ class SidebarToggle extends React.Component {
         {label}
       </button>
     );
+  };
 
-    const renderToggleClass = className =>
-      appendClassName(
-        className,
-        isSidebarToggled ? `${className}--toggled` : null
-      );
+  render() {
+    const { className, children } = this.props;
+    const { isSidebarToggled } = this.state;
 
-    return this.props.children({ renderToggleButton, renderToggleClass });
+    const classes = appendClassName(
+      className,
+      isSidebarToggled ? `${className}--toggled` : null
+    );
+
+    return (
+      <>
+        {this.renderToggleButton("Show Filters")}
+        <div className={classes}>
+          {this.renderToggleButton("Done Filtering")}
+          {children}
+        </div>
+      </>
+    );
   }
 }
 
-export default SidebarToggle;
+export default LayoutSidebar;

--- a/packages/react-search-ui-views/src/layouts/LayoutSidebar.js
+++ b/packages/react-search-ui-views/src/layouts/LayoutSidebar.js
@@ -55,7 +55,7 @@ class LayoutSidebar extends React.Component {
       <>
         {this.renderToggleButton("Show Filters")}
         <div className={classes}>
-          {this.renderToggleButton("Done Filtering")}
+          {this.renderToggleButton("Save Filters")}
           {children}
         </div>
       </>

--- a/packages/react-search-ui-views/src/layouts/SidebarToggle.js
+++ b/packages/react-search-ui-views/src/layouts/SidebarToggle.js
@@ -1,0 +1,41 @@
+import PropTypes from "prop-types";
+import React from "react";
+
+import { appendClassName } from "../view-helpers";
+
+class SidebarToggle extends React.Component {
+  static propTypes = { children: PropTypes.func };
+
+  state = { isSidebarToggled: false };
+
+  toggleSidebar = () => {
+    this.setState(({ isSidebarToggled }) => ({
+      isSidebarToggled: !isSidebarToggled
+    }));
+  };
+
+  render() {
+    const { isSidebarToggled } = this.state;
+
+    const renderToggleButton = label => (
+      <button
+        hidden
+        type="button"
+        className="sui-layout-sidebar-toggle"
+        onClick={this.toggleSidebar}
+      >
+        {label}
+      </button>
+    );
+
+    const renderToggleClass = className =>
+      appendClassName(
+        className,
+        isSidebarToggled ? `${className}--toggled` : null
+      );
+
+    return this.props.children({ renderToggleButton, renderToggleClass });
+  }
+}
+
+export default SidebarToggle;

--- a/packages/react-search-ui-views/src/layouts/SidebarToggle.js
+++ b/packages/react-search-ui-views/src/layouts/SidebarToggle.js
@@ -1,12 +1,20 @@
 import PropTypes from "prop-types";
 import React from "react";
+import ReactDOM from "react-dom";
 
 import { appendClassName } from "../view-helpers";
 
 class SidebarToggle extends React.Component {
-  static propTypes = { children: PropTypes.func };
+  static propTypes = {
+    children: PropTypes.func,
+    content: PropTypes.node
+  };
 
-  state = { isSidebarToggled: false };
+  constructor(props) {
+    super(props);
+    this.state = { isSidebarToggled: false };
+    this.checkContent = document.createElement("div");
+  }
 
   toggleSidebar = () => {
     this.setState(({ isSidebarToggled }) => ({
@@ -15,6 +23,13 @@ class SidebarToggle extends React.Component {
   };
 
   render() {
+    const { content } = this.props;
+    if (!content) return null;
+
+    ReactDOM.render(content, this.checkContent);
+    const hasSidebarContent = Boolean(this.checkContent.innerText);
+    if (!hasSidebarContent) return null;
+
     const { isSidebarToggled } = this.state;
 
     const renderToggleButton = label => (

--- a/packages/react-search-ui-views/src/styles/themes/reference-ui/layouts/_layout.scss
+++ b/packages/react-search-ui-views/src/styles/themes/reference-ui/layouts/_layout.scss
@@ -45,6 +45,9 @@
       margin: 32px 0;
       padding-right: 32px;
 
+      @media (max-width: $sidebarBreakpoint + $offset) {
+        padding-right: 0;
+      }
       @media (max-width: $sidebarBreakpoint) {
         z-index: 99;
         display: none;

--- a/packages/react-search-ui-views/src/styles/themes/reference-ui/layouts/_layout.scss
+++ b/packages/react-search-ui-views/src/styles/themes/reference-ui/layouts/_layout.scss
@@ -97,6 +97,7 @@
     width: 100%;
     margin: 20px auto;
     padding: 10px;
+    font-family: inherit;
     font-size: 14px;
     font-weight: 700;
     color: $linkColor;

--- a/packages/react-search-ui-views/src/styles/themes/reference-ui/layouts/_layout.scss
+++ b/packages/react-search-ui-views/src/styles/themes/reference-ui/layouts/_layout.scss
@@ -2,121 +2,57 @@
   width: 100%;
   display: flex;
   flex-direction: column;
+}
 
-  @include block("layout-header") {
-    padding: 32px 24px;
-    border-bottom: 1px solid #eeeeee;
+/**
+ * Header / Searchbox
+ */
+
+@include block("layout-header") {
+  padding: 32px 24px;
+  border-bottom: 1px solid #eeeeee;
+}
+
+/**
+ * Body
+ */
+
+@include block("layout-body") {
+  background: #fcfcfc;
+
+  &:after {
+    content: "";
+    height: 80px;
+    width: 100%;
+    display: block;
+    position: relative;
+    background: -moz-linear-gradient(top, #fcfcfc 0%, #ffffff 100%);
+    background: -webkit-linear-gradient(top, #fcfcfc 0%, #ffffff 100%);
+    background: linear-gradient(to bottom, #fcfcfc 0%, #ffffff 100%);
+    filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#fcfcfc', endColorstr='#ffffff',GradientType=0 );
+
+    @media (max-width: $sidebarBreakpoint) {
+      display: none;
+    }
   }
 
-  @include block("layout-body") {
-    background: #fcfcfc;
+  @include element("inner") {
+    max-width: 1300px;
+    margin-left: auto;
+    margin-right: auto;
+    display: flex;
+    padding: 0 24px;
 
-    &:after {
-      content: '';
-      height: 80px;
-      width: 100%;
+    @media (max-width: $sidebarBreakpoint) {
       display: block;
-      position: relative;
-      background: -moz-linear-gradient(top, #fcfcfc 0%, #ffffff 100%);
-      background: -webkit-linear-gradient(top, #fcfcfc 0%,#ffffff 100%);
-      background: linear-gradient(to bottom, #fcfcfc 0%,#ffffff 100%);
-      filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#fcfcfc', endColorstr='#ffffff',GradientType=0 );
-
-      @media (max-width: $sidebarBreakpoint) {
-        display: none;
-      }
-    }
-
-    @include element("inner") {
-      max-width: 1300px;
-      margin-left: auto;
-      margin-right: auto;
-      display: flex;
-      padding: 0 24px;
-
-      @media (max-width: $sidebarBreakpoint) {
-        display: block;
-        padding: 0 15px;
-      }
-    }
-
-    @include block("layout-sidebar") {
-      width: 24%;
-      margin: 32px 0;
-      padding-right: 32px;
-
-      @media (max-width: $sidebarBreakpoint + $offset) {
-        padding-right: 0;
-      }
-      @media (max-width: $sidebarBreakpoint) {
-        z-index: 99;
-        display: none;
-        position: fixed;
-        top: 0;
-        left: 0;
-        height: 100%;
-        width: 100%;
-        margin: 0;
-        padding: 0 15px 30px 15px;
-        background-color: $resultBackgroundColor;
-        overflow: auto;
-      }
-
-      @include modifier("toggled") {
-        display: block;
-        animation: fadein 0.2s ease-out;
-      }
-    }
-
-    @include block("layout-sidebar-toggle") {
-      @media (max-width: $sidebarBreakpoint) {
-        display: block;
-        width: 100%;
-        margin: 20px auto;
-        padding: 10px;
-        font-size: 14px;
-        font-weight: 700;
-        color: $linkColor;
-        background-color: $white;
-        border: 1px solid $linkColor;
-        border-radius: $borderRadius;
-      }
-    }
-
-    @include block("layout-main") {
-      width: 76%;
-      margin: 32px 0;
-      padding-left: 32px;
-
-      @media (max-width: $sidebarBreakpoint) {
-        width: 100%;
-        padding-left: 0;
-      }
-
-      @include block("layout-main-header") {
-        display: flex;
-        width: 100%;
-        justify-content: space-between;
-        align-items: center;
-
-        @include element("inner") {
-          font-size: 12px;
-          color: #4a4b4b;
-          display: flex;
-          justify-content: space-between;
-          align-items: center;
-          width: 100%;
-        }
-      }
-
-      @include block("layout-main-footer") {
-        display: flex;
-        align-items: center;
-        justify-content: space-around;
-      }
+      padding: 0 15px;
     }
   }
 }
+
+/**
+ * Sidebar / Filters
+ */
 
 @keyframes fadein {
   0% {
@@ -125,4 +61,84 @@
   100% {
     opacity: 1;
   }
+}
+
+@include block("layout-sidebar") {
+  width: 24%;
+  margin: 32px 0;
+  padding-right: 32px;
+
+  @media (max-width: $sidebarBreakpoint + $offset) {
+    padding-right: 0;
+  }
+  @media (max-width: $sidebarBreakpoint) {
+    z-index: 99;
+    display: none;
+    position: fixed;
+    top: 0;
+    left: 0;
+    height: 100%;
+    width: 100%;
+    margin: 0;
+    padding: 0 15px 30px 15px;
+    background-color: $resultBackgroundColor;
+    overflow: auto;
+  }
+
+  @include modifier("toggled") {
+    display: block;
+    animation: fadein 0.2s ease-out;
+  }
+}
+
+@include block("layout-sidebar-toggle") {
+  @media (max-width: $sidebarBreakpoint) {
+    display: block;
+    width: 100%;
+    margin: 20px auto;
+    padding: 10px;
+    font-size: 14px;
+    font-weight: 700;
+    color: $linkColor;
+    background-color: $white;
+    border: 1px solid $linkColor;
+    border-radius: $borderRadius;
+  }
+}
+
+/**
+ * Main / Results
+ */
+
+@include block("layout-main") {
+  width: 76%;
+  margin: 32px 0;
+  padding-left: 32px;
+
+  @media (max-width: $sidebarBreakpoint) {
+    width: 100%;
+    padding-left: 0;
+  }
+}
+
+@include block("layout-main-header") {
+  display: flex;
+  width: 100%;
+  justify-content: space-between;
+  align-items: center;
+
+  @include element("inner") {
+    font-size: 12px;
+    color: #4a4b4b;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    width: 100%;
+  }
+}
+
+@include block("layout-main-footer") {
+  display: flex;
+  align-items: center;
+  justify-content: space-around;
 }

--- a/packages/react-search-ui-views/src/styles/themes/reference-ui/layouts/_layout.scss
+++ b/packages/react-search-ui-views/src/styles/themes/reference-ui/layouts/_layout.scss
@@ -21,6 +21,10 @@
       background: -webkit-linear-gradient(top, #fcfcfc 0%,#ffffff 100%);
       background: linear-gradient(to bottom, #fcfcfc 0%,#ffffff 100%);
       filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#fcfcfc', endColorstr='#ffffff',GradientType=0 );
+
+      @media (max-width: $sidebarBreakpoint) {
+        display: none;
+      }
     }
 
     @include element("inner") {
@@ -29,18 +33,61 @@
       margin-right: auto;
       display: flex;
       padding: 0 24px;
+
+      @media (max-width: $sidebarBreakpoint) {
+        display: block;
+        padding: 0 15px;
+      }
     }
 
     @include block("layout-sidebar") {
       width: 24%;
-      padding: 32px 32px 0 0;
+      margin: 32px 0;
+      padding-right: 32px;
+
+      @media (max-width: $sidebarBreakpoint) {
+        z-index: 99;
+        display: none;
+        position: fixed;
+        top: 0;
+        left: 0;
+        height: 100%;
+        width: 100%;
+        margin: 0;
+        padding: 0 15px 30px 15px;
+        background-color: $resultBackgroundColor;
+        overflow: auto;
+      }
+
+      @include modifier("toggled") {
+        display: block;
+      }
+    }
+
+    @include block("layout-sidebar-toggle") {
+      @media (max-width: $sidebarBreakpoint) {
+        display: block;
+        width: 100%;
+        margin: 20px auto;
+        padding: 10px;
+        font-size: 14px;
+        font-weight: 700;
+        color: $linkColor;
+        background-color: $white;
+        border: 1px solid $linkColor;
+        border-radius: $borderRadius;
+      }
     }
 
     @include block("layout-main") {
       width: 76%;
-      padding: 2rem 0;
-      padding: 32px 0 32px 32px;
-      border-left: none;
+      margin: 32px 0;
+      padding-left: 32px;
+
+      @media (max-width: $sidebarBreakpoint) {
+        width: 100%;
+        padding-left: 0;
+      }
 
       @include block("layout-main-header") {
         display: flex;

--- a/packages/react-search-ui-views/src/styles/themes/reference-ui/layouts/_layout.scss
+++ b/packages/react-search-ui-views/src/styles/themes/reference-ui/layouts/_layout.scss
@@ -61,6 +61,7 @@
 
       @include modifier("toggled") {
         display: block;
+        animation: fadein 0.2s ease-out;
       }
     }
 
@@ -111,5 +112,14 @@
         justify-content: space-around;
       }
     }
+  }
+}
+
+@keyframes fadein {
+  0% {
+    opacity: 0;
+  }
+  100% {
+    opacity: 1;
   }
 }

--- a/packages/react-search-ui-views/src/styles/themes/reference-ui/modules/_variables.scss
+++ b/packages/react-search-ui-views/src/styles/themes/reference-ui/modules/_variables.scss
@@ -45,6 +45,7 @@ $sizeL: 24px !default;
 $sizeXL: 32px !default;
 $sizeXXL: 48px !default;
 
+$sidebarBreakpoint: 800px !default;
 $maxWidth: 1300px !default;
 $offset: 175px !default;
 


### PR DESCRIPTION
## Description

From our Slack discussion:

> I thought it'd be a shame to ship 1.0 without very basic mobile functionality - so I spiked out a quick attempt at a mobile toggle for our sidebar/filters. I'm hoping that it's a good enough start for the upcoming release and that we can continue to iterate on it for 2.0+

## Screenshots

![screencap](https://user-images.githubusercontent.com/549407/61163633-11c24380-a4c4-11e9-88fc-ad2980ce107c.gif)

## List of changes

1. Adds a new internal [LayoutSidebar](https://github.com/elastic/search-ui/pull/334/files#diff-0433fdec156966cc8e783042c78eff6c) component + styling which:
  - handles conditionally rendering show/hide toggle buttons
  - makes the filter sidebar a scrollable sticky flyout on mobile
  - does not display toggle buttons if there is no content in the sidebar

Note that for developers that utilize `<Layout>` but are completely rolling their own styles - they will not inherit this mobile UX as a result, but the toggle buttons also should not show up or otherwise mess up their styling.

At some point the goal is to separate layout vs presentational CSS so that users can have both completely custom styling while still having OOTB working mobile UX.

2. Additionally, I also proposed a minor cleanup/refactor in 7cfcd4a which unflattens all our nested classes in `_layouts.scss` - which should make overriding existing styles much more pleasant for developers (`.sui-layout .sui-layout-body .sui-layout-sidebar` becomes just `.sui-layout-sidebar`, for example).

<img width="656" alt="" src="https://user-images.githubusercontent.com/549407/61164018-b3e32b00-a4c6-11e9-8c82-191bbc9b020c.png">

## QA

<img width="835" alt="" src="https://user-images.githubusercontent.com/549407/61164086-11777780-a4c7-11e9-9824-6509146f1625.png">

- [x] Test in Chrome, Safari, Opera
- [x] Test in Firefox
- [x] Test in Edge
- [x] Test in iOS Safari
- [x] Test in Android Chrome

## Associated Github Issues

#214 - although note that this PR does not close/resolve the issue - it's just a v1 and I wouldn't consider this a finished/polished feature by any means.