### PR TITLE
Remove max-height+scrolling on Result card body

### DIFF
--- a/packages/react-search-ui-views/src/styles/themes/reference-ui/components/_result.scss
+++ b/packages/react-search-ui-views/src/styles/themes/reference-ui/components/_result.scss
@@ -99,13 +99,8 @@
   }
 
   @include element('details') {
-    max-height: 300px;
-    position: relative;
-    overflow: hidden;
-    overflow-y: auto;
     padding: $sizeM;
     list-style: none;
-    background-color: transparent;
     padding: $sizeM $sizeL
   }
 }


### PR DESCRIPTION
## Description

While working on #334, I noticed the `max-height` being set on Result card bodies was resulting in content being sometimes misleadingly cut off on mobile devices. I propose removing this entirely and letting cards remain whatever height they're at.

### Before:

![before](https://user-images.githubusercontent.com/549407/61164348-2ce38200-a4c9-11e9-8c84-a8b52bfc90ea.gif)

### After:

<img width="339" alt="" src="https://user-images.githubusercontent.com/549407/61164360-45ec3300-a4c9-11e9-85de-ade704c92eb5.png">

## List of changes

- Removes max-height, overflow, and other associated/unnecessary CSS from `.sui-result__details`