### PR TITLE
Fix ResultsPerPage vertical alignment on mobile

### DIFF
--- a/packages/react-search-ui-views/src/styles/themes/reference-ui/components/_results-per-page.scss
+++ b/packages/react-search-ui-views/src/styles/themes/reference-ui/components/_results-per-page.scss
@@ -9,4 +9,12 @@
   @include element('label') {
     margin-right: $sizeS;
   }
+
+  .sui-select__control {
+    align-items: center;
+
+    input {
+      position: absolute;
+    }
+  }
 }


### PR DESCRIPTION
## Description

I noticed this when working on #334 and thought I'd push out a separate fix for this (to keep the PRs clean/atomic).

When PagingInfo is on a small enough screen or has a long enough Search Term to span multiple lines, the vertical alignment on ResultsPerPage's dropdown gets all wonky (see below screenshot).

## Screenshot

**Before (left) vs. After (right):**

![screenshot](https://user-images.githubusercontent.com/549407/61164467-446f3a80-a4ca-11e9-807b-4baf8fcefee5.png)

## List of changes

- Adds CSS fixing vertical alignment on ResultsPerPage's react-select dropdown

## QA

- [x] Test in Chrome, Safari, Opera
- [x] Test in Firefox
- [x] Test in Edge
- [x] Test in iOS Safari
- [x] Test in Android Chrome
