### PR TITLE
Removed babel polyfill

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -122,7 +122,7 @@ It can often be useful to publish a change and test it before doing a real live 
 option for this.
 
 1. Check out pr branch
-2. `npx lerna publish --canary` - Publishing with canary generates a unique new version number, publishes it to npm, then updates the `canary` tag in npm to point to that new version.
+2. `npx lerna publish --canary --preid canary` - Publishing with canary generates a unique new version number, publishes it to npm, then updates the `canary` tag in npm to point to that new version.
 3. In project you'll need to install all dependencies explicitly with the canary tag from npm:
 
    ```

--- a/examples/elasticsearch/package-lock.json
+++ b/examples/elasticsearch/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "elasticsearch-example",
-  "version": "0.12.1",
+  "version": "1.0.0-rc.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -930,21 +930,21 @@
       "integrity": "sha512-6It2EVfGskxZCQhuykrfnALg7oVeiI6KclWSmGDqB0AiInVrTGB9Jp9i4/Ad21u9Jde/voVQz6eFX/eSg/UsPA=="
     },
     "@elastic/react-search-ui": {
-      "version": "0.12.1",
-      "resolved": "https://registry.npmjs.org/@elastic/react-search-ui/-/react-search-ui-0.12.1.tgz",
-      "integrity": "sha512-JvH+2HG2HcXDLqrkI1Wb4XPkzOfQ4HVmCCbyvWQIm+/7uqF/Qtn+Zog8G+mf6v2uLW6DMuVSSYfP3LiC04BzcQ==",
+      "version": "1.0.0-rc.0",
+      "resolved": "https://registry.npmjs.org/@elastic/react-search-ui/-/react-search-ui-1.0.0-rc.0.tgz",
+      "integrity": "sha512-n/XZ08Lmuxmt8cVhj8Hm1tGK7Lg0qS/99WlPw/66UBNloNmdvV/jG0i3nUHGUrp2hKJDO8V3alSTUjrGD9/slQ==",
       "requires": {
         "@babel/polyfill": "^7.2.5",
-        "@elastic/react-search-ui-views": "0.12.1",
-        "@elastic/search-ui": "0.12.1",
+        "@elastic/react-search-ui-views": "1.0.0-rc.0",
+        "@elastic/search-ui": "1.0.0-rc.0",
         "core-js": "^2.6.9",
         "debounce-fn": "^1.0.0"
       }
     },
     "@elastic/react-search-ui-views": {
-      "version": "0.12.1",
-      "resolved": "https://registry.npmjs.org/@elastic/react-search-ui-views/-/react-search-ui-views-0.12.1.tgz",
-      "integrity": "sha512-qQpxasDgFbvAIku33K05sTFl4bNu7NeHFDUSFM/FDDfwBwv5ljMn1Z/43QxIXKYLXk7SFdcIV2KcSxiuFh8cCg==",
+      "version": "1.0.0-rc.0",
+      "resolved": "https://registry.npmjs.org/@elastic/react-search-ui-views/-/react-search-ui-views-1.0.0-rc.0.tgz",
+      "integrity": "sha512-huTG1KfkO0FBdvlHSASITT98pYiW/ZwhodcK/Uuqbgr0yIZDGINiQZdmuHwDHKFMV5jxmQMDbOvms2DWfwx22Q==",
       "requires": {
         "@babel/polyfill": "^7.2.5",
         "autoprefixer": "^9.4.7",
@@ -956,9 +956,9 @@
       }
     },
     "@elastic/search-ui": {
-      "version": "0.12.1",
-      "resolved": "https://registry.npmjs.org/@elastic/search-ui/-/search-ui-0.12.1.tgz",
-      "integrity": "sha512-4AZOQy0Wh4jwBIncmTbDP2895XOJItNrZByrTyXEubzD9jeKl2GUoSyk2Sf45c1kXFFbm41FpxYNxhaS2f9dkg==",
+      "version": "1.0.0-rc.0",
+      "resolved": "https://registry.npmjs.org/@elastic/search-ui/-/search-ui-1.0.0-rc.0.tgz",
+      "integrity": "sha512-nQNfkaA6jVIaVFWUe+AWufdTozM+gl07BpqO6lyj3Dx0NyCZU0jRmXrYY0rhcj1Ip2WNnyAqnKyzTgMIXmxNww==",
       "requires": {
         "@babel/polyfill": "^7.2.5",
         "core-js": "^2.6.9",
@@ -2877,8 +2877,7 @@
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -2896,13 +2895,11 @@
             },
             "balanced-match": {
               "version": "1.0.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -2915,18 +2912,15 @@
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "concat-map": {
               "version": "0.0.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -3029,8 +3023,7 @@
             },
             "inherits": {
               "version": "2.0.3",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "ini": {
               "version": "1.3.5",
@@ -3040,7 +3033,6 @@
             "is-fullwidth-code-point": {
               "version": "1.0.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -3053,20 +3045,17 @@
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
             },
             "minimist": {
               "version": "0.0.8",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -3083,7 +3072,6 @@
             "mkdirp": {
               "version": "0.5.1",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -3156,8 +3144,7 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -3167,7 +3154,6 @@
             "once": {
               "version": "1.4.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -3243,8 +3229,7 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -3274,7 +3259,6 @@
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -3292,7 +3276,6 @@
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -3331,13 +3314,11 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "yallist": {
               "version": "3.0.3",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             }
           }
         },
@@ -6826,8 +6807,7 @@
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -6845,13 +6825,11 @@
             },
             "balanced-match": {
               "version": "1.0.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -6864,18 +6842,15 @@
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "concat-map": {
               "version": "0.0.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -6978,8 +6953,7 @@
             },
             "inherits": {
               "version": "2.0.3",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "ini": {
               "version": "1.3.5",
@@ -6989,7 +6963,6 @@
             "is-fullwidth-code-point": {
               "version": "1.0.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -7002,20 +6975,17 @@
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
             },
             "minimist": {
               "version": "0.0.8",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -7032,7 +7002,6 @@
             "mkdirp": {
               "version": "0.5.1",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -7105,8 +7074,7 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -7116,7 +7084,6 @@
             "once": {
               "version": "1.4.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -7192,8 +7159,7 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -7223,7 +7189,6 @@
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -7241,7 +7206,6 @@
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -7280,13 +7244,11 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "yallist": {
               "version": "3.0.3",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             }
           }
         }
@@ -11874,9 +11836,9 @@
       "integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q="
     },
     "tiny-invariant": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.0.5.tgz",
-      "integrity": "sha512-BziszNEQNwtyMS9OVJia2LK9N9b6VJ35kBrvhDDDpr4hreLYqhCie15dB35uZMdqv9ZTQ55GHQtkz2FnleTHIA=="
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.0.6.tgz",
+      "integrity": "sha512-FOyLWWVjG+aC0UqG76V53yAWdXfH8bO6FNmyZOuUrzDzK8DI3/JRY25UD7+g49JWM1LXwymsKERB+DzI0dTEQA=="
     },
     "tiny-warning": {
       "version": "1.0.3",

--- a/examples/sandbox/package-lock.json
+++ b/examples/sandbox/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sandbox",
-  "version": "0.12.1",
+  "version": "1.0.0-rc.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -875,13 +875,13 @@
       "integrity": "sha512-5a6wqoJV/xEdbRNKVo6I4hO3VjyDq//8q2f9I6PBAvMesJHFauXDorcNCsr9RzvsZnaWi5NYCcfyqP1QeFHFbw=="
     },
     "@elastic/react-search-ui": {
-      "version": "0.12.1",
-      "resolved": "https://registry.npmjs.org/@elastic/react-search-ui/-/react-search-ui-0.12.1.tgz",
-      "integrity": "sha512-JvH+2HG2HcXDLqrkI1Wb4XPkzOfQ4HVmCCbyvWQIm+/7uqF/Qtn+Zog8G+mf6v2uLW6DMuVSSYfP3LiC04BzcQ==",
+      "version": "1.0.0-rc.0",
+      "resolved": "https://registry.npmjs.org/@elastic/react-search-ui/-/react-search-ui-1.0.0-rc.0.tgz",
+      "integrity": "sha512-n/XZ08Lmuxmt8cVhj8Hm1tGK7Lg0qS/99WlPw/66UBNloNmdvV/jG0i3nUHGUrp2hKJDO8V3alSTUjrGD9/slQ==",
       "requires": {
         "@babel/polyfill": "^7.2.5",
-        "@elastic/react-search-ui-views": "0.12.1",
-        "@elastic/search-ui": "0.12.1",
+        "@elastic/react-search-ui-views": "1.0.0-rc.0",
+        "@elastic/search-ui": "1.0.0-rc.0",
         "core-js": "^2.6.9",
         "debounce-fn": "^1.0.0"
       },
@@ -894,9 +894,9 @@
       }
     },
     "@elastic/react-search-ui-views": {
-      "version": "0.12.1",
-      "resolved": "https://registry.npmjs.org/@elastic/react-search-ui-views/-/react-search-ui-views-0.12.1.tgz",
-      "integrity": "sha512-qQpxasDgFbvAIku33K05sTFl4bNu7NeHFDUSFM/FDDfwBwv5ljMn1Z/43QxIXKYLXk7SFdcIV2KcSxiuFh8cCg==",
+      "version": "1.0.0-rc.0",
+      "resolved": "https://registry.npmjs.org/@elastic/react-search-ui-views/-/react-search-ui-views-1.0.0-rc.0.tgz",
+      "integrity": "sha512-huTG1KfkO0FBdvlHSASITT98pYiW/ZwhodcK/Uuqbgr0yIZDGINiQZdmuHwDHKFMV5jxmQMDbOvms2DWfwx22Q==",
       "requires": {
         "@babel/polyfill": "^7.2.5",
         "autoprefixer": "^9.4.7",
@@ -915,9 +915,9 @@
       }
     },
     "@elastic/search-ui": {
-      "version": "0.12.1",
-      "resolved": "https://registry.npmjs.org/@elastic/search-ui/-/search-ui-0.12.1.tgz",
-      "integrity": "sha512-4AZOQy0Wh4jwBIncmTbDP2895XOJItNrZByrTyXEubzD9jeKl2GUoSyk2Sf45c1kXFFbm41FpxYNxhaS2f9dkg==",
+      "version": "1.0.0-rc.0",
+      "resolved": "https://registry.npmjs.org/@elastic/search-ui/-/search-ui-1.0.0-rc.0.tgz",
+      "integrity": "sha512-nQNfkaA6jVIaVFWUe+AWufdTozM+gl07BpqO6lyj3Dx0NyCZU0jRmXrYY0rhcj1Ip2WNnyAqnKyzTgMIXmxNww==",
       "requires": {
         "@babel/polyfill": "^7.2.5",
         "core-js": "^2.6.9",
@@ -936,9 +936,9 @@
       }
     },
     "@elastic/search-ui-app-search-connector": {
-      "version": "0.12.1",
-      "resolved": "https://registry.npmjs.org/@elastic/search-ui-app-search-connector/-/search-ui-app-search-connector-0.12.1.tgz",
-      "integrity": "sha512-pWr1IL2DT/k04qQ6Wmzqsoyxe1sfflyqeVQybhFkOvk2S8WYxjO8IyNXAyJw6plTL6rM+s6yqYXzFJ6r3aya3A==",
+      "version": "1.0.0-rc.0",
+      "resolved": "https://registry.npmjs.org/@elastic/search-ui-app-search-connector/-/search-ui-app-search-connector-1.0.0-rc.0.tgz",
+      "integrity": "sha512-X6U/21QZgzYf7W0rSDj09g9OcX4SB8TLmHHgpjDldSzRVzOCoZlvadZ/Dmp5I+neM2k9clM+AFFQz9PeH5OUDA==",
       "requires": {
         "@babel/polyfill": "^7.2.5",
         "core-js": "^2.6.9",
@@ -953,9 +953,9 @@
       }
     },
     "@elastic/search-ui-site-search-connector": {
-      "version": "0.12.1",
-      "resolved": "https://registry.npmjs.org/@elastic/search-ui-site-search-connector/-/search-ui-site-search-connector-0.12.1.tgz",
-      "integrity": "sha512-g/qnUol512S4NlHK8uG2VhykT1wNZybj952/tWkmb2zNnitXS7piybSD4EVmtxWIXpKoa3c8hNisIQQAEJ/MlQ==",
+      "version": "1.0.0-rc.0",
+      "resolved": "https://registry.npmjs.org/@elastic/search-ui-site-search-connector/-/search-ui-site-search-connector-1.0.0-rc.0.tgz",
+      "integrity": "sha512-qbS2Q0VNH39h0E77qV0IsEkshG98H6JNfucuOF9jbaTxdXer+EtrSXFcG52RrLC9+n7OjRYKTUt0akk70uGrUA==",
       "requires": {
         "@babel/polyfill": "^7.2.5",
         "core-js": "^2.6.9"
@@ -2991,8 +2991,7 @@
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -3010,13 +3009,11 @@
             },
             "balanced-match": {
               "version": "1.0.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -3029,18 +3026,15 @@
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "concat-map": {
               "version": "0.0.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -3143,8 +3137,7 @@
             },
             "inherits": {
               "version": "2.0.3",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "ini": {
               "version": "1.3.5",
@@ -3154,7 +3147,6 @@
             "is-fullwidth-code-point": {
               "version": "1.0.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -3167,20 +3159,17 @@
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
             },
             "minimist": {
               "version": "0.0.8",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -3197,7 +3186,6 @@
             "mkdirp": {
               "version": "0.5.1",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -3270,8 +3258,7 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -3281,7 +3268,6 @@
             "once": {
               "version": "1.4.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -3357,8 +3343,7 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -3388,7 +3373,6 @@
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -3406,7 +3390,6 @@
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -3445,13 +3428,11 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "yallist": {
               "version": "3.0.3",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             }
           }
         },
@@ -6498,8 +6479,7 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -6517,13 +6497,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -6536,18 +6514,15 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -6650,8 +6625,7 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
@@ -6661,7 +6635,6 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -6674,20 +6647,17 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -6704,7 +6674,6 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -6777,8 +6746,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -6788,7 +6756,6 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -6864,8 +6831,7 @@
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -6895,7 +6861,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -6913,7 +6878,6 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -6952,13 +6916,11 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "yallist": {
           "version": "3.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         }
       }
     },
@@ -15420,9 +15382,9 @@
       "integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q="
     },
     "tiny-invariant": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.0.5.tgz",
-      "integrity": "sha512-BziszNEQNwtyMS9OVJia2LK9N9b6VJ35kBrvhDDDpr4hreLYqhCie15dB35uZMdqv9ZTQ55GHQtkz2FnleTHIA=="
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.0.6.tgz",
+      "integrity": "sha512-FOyLWWVjG+aC0UqG76V53yAWdXfH8bO6FNmyZOuUrzDzK8DI3/JRY25UD7+g49JWM1LXwymsKERB+DzI0dTEQA=="
     },
     "tiny-warning": {
       "version": "1.0.3",

--- a/packages/package-lock.json
+++ b/packages/package-lock.json
@@ -598,6 +598,18 @@
         "regenerator-transform": "^0.13.3"
       }
     },
+    "@babel/plugin-transform-runtime": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.5.0.tgz",
+      "integrity": "sha512-LmPIZOAgTLl+86gR9KjLXex6P/lRz1fWEjTz6V6QZMmKie51ja3tvzdwORqhHc4RWR8TcZ5pClpRWs0mlaA2ng==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-imports": "^7.0.0",
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "resolve": "^1.8.1",
+        "semver": "^5.5.1"
+      }
+    },
     "@babel/plugin-transform-shorthand-properties": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.2.0.tgz",

--- a/packages/package-lock.json
+++ b/packages/package-lock.json
@@ -5958,12 +5958,6 @@
         "regenerate": "^1.4.0"
       }
     },
-    "regenerator-runtime": {
-      "version": "0.12.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
-      "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg==",
-      "dev": true
-    },
     "regenerator-transform": {
       "version": "0.13.3",
       "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.13.3.tgz",

--- a/packages/package.json
+++ b/packages/package.json
@@ -12,7 +12,6 @@
     "eslint-config-prettier": "^3.3.0",
     "eslint-plugin-jest": "^22.0.0",
     "eslint-plugin-react": "^7.11.1",
-    "jest": "^23.6.0",
-    "regenerator-runtime": "^0.12.1"
+    "jest": "^23.6.0"
   }
 }

--- a/packages/package.json
+++ b/packages/package.json
@@ -4,6 +4,7 @@
   "devDependencies": {
     "@babel/core": "^7.1.2",
     "@babel/plugin-proposal-class-properties": "^7.1.0",
+    "@babel/plugin-transform-runtime": "^7.5.0",
     "@babel/preset-env": "^7.1.0",
     "babel-core": "^7.0.0-bridge.0",
     "babel-eslint": "^10.0.1",

--- a/packages/react-search-ui-views/babel.config.js
+++ b/packages/react-search-ui-views/babel.config.js
@@ -16,5 +16,8 @@ const presets = [
 module.exports = {
   sourceMaps: "inline",
   presets,
-  plugins: ["@babel/plugin-proposal-class-properties"]
+  plugins: [
+    "@babel/plugin-proposal-class-properties",
+    ["@babel/plugin-transform-runtime", { regenerator: true }]
+  ]
 };

--- a/packages/react-search-ui-views/babel.config.js
+++ b/packages/react-search-ui-views/babel.config.js
@@ -2,13 +2,7 @@ const presets = [
   [
     "@babel/env",
     {
-      // Because we are using @babel/polyfill, because we have old browser
-      // targets set, this will optimize the polyfills that are actually
-      // imported.
-      useBuiltIns: "entry",
       targets: {
-        // Setting target browsers like this, if they span back far enough,
-        // requires adding @babel/polyfill
         browsers: ["last 2 versions", "> 5%"]
       },
       modules: process.env.BABEL_MODULES

--- a/packages/react-search-ui-views/package-lock.json
+++ b/packages/react-search-ui-views/package-lock.json
@@ -1022,11 +1022,18 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.1.5",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.1.5.tgz",
-      "integrity": "sha512-xKnPpXG/pvK1B90JkwwxSGii90rQGKtzcMt2gI5G6+M0REXaq6rOHsGC2ay6/d0Uje7zzvSzjEzfR3ENhFlrfA==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.5.4.tgz",
+      "integrity": "sha512-Na84uwyImZZc3FKf4aUF1tysApzwf3p2yuFBIyBfbzT5glzKTdvYI4KVW4kcgjrzoGUjC7w3YyCHcJKaRxsr2Q==",
       "requires": {
-        "regenerator-runtime": "^0.12.0"
+        "regenerator-runtime": "^0.13.2"
+      },
+      "dependencies": {
+        "regenerator-runtime": {
+          "version": "0.13.2",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
+          "integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA=="
+        }
       }
     },
     "@babel/template": {
@@ -11899,7 +11906,8 @@
     "regenerator-runtime": {
       "version": "0.12.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
-      "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg=="
+      "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg==",
+      "dev": true
     },
     "regenerator-transform": {
       "version": "0.13.3",

--- a/packages/react-search-ui-views/package-lock.json
+++ b/packages/react-search-ui-views/package-lock.json
@@ -939,15 +939,6 @@
         "regexpu-core": "^4.1.3"
       }
     },
-    "@babel/polyfill": {
-      "version": "7.2.5",
-      "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.2.5.tgz",
-      "integrity": "sha512-8Y/t3MWThtMLYr0YNC/Q76tqN1w30+b0uQMeFUYauG2UGTR19zyUtFrAzT23zNtBxPp+LbE5E/nwV/q/r3y6ug==",
-      "requires": {
-        "core-js": "^2.5.7",
-        "regenerator-runtime": "^0.12.0"
-      }
-    },
     "@babel/preset-env": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.2.0.tgz",

--- a/packages/react-search-ui-views/package.json
+++ b/packages/react-search-ui-views/package.json
@@ -70,9 +70,7 @@
     "rimraf": "^2.6.2"
   },
   "dependencies": {
-    "@babel/polyfill": "^7.2.5",
     "autoprefixer": "^9.4.7",
-    "core-js": "^2.6.9",
     "deep-equal": "^1.0.1",
     "downshift": "^3.2.7",
     "rc-pagination": "^1.17.3",

--- a/packages/react-search-ui-views/package.json
+++ b/packages/react-search-ui-views/package.json
@@ -70,6 +70,7 @@
     "rimraf": "^2.6.2"
   },
   "dependencies": {
+    "@babel/runtime": "^7.5.4",
     "autoprefixer": "^9.4.7",
     "deep-equal": "^1.0.1",
     "downshift": "^3.2.7",

--- a/packages/react-search-ui-views/src/index.js
+++ b/packages/react-search-ui-views/src/index.js
@@ -1,5 +1,3 @@
-import "@babel/polyfill";
-
 export { default as Autocomplete } from "./Autocomplete";
 export { default as ErrorBoundary } from "./ErrorBoundary";
 export { default as Facets } from "./Facets";

--- a/packages/react-search-ui/babel.config.js
+++ b/packages/react-search-ui/babel.config.js
@@ -16,5 +16,8 @@ const presets = [
 module.exports = {
   sourceMaps: "inline",
   presets,
-  plugins: ["@babel/plugin-proposal-class-properties"]
+  plugins: [
+    "@babel/plugin-proposal-class-properties",
+    ["@babel/plugin-transform-runtime", { regenerator: true }]
+  ]
 };

--- a/packages/react-search-ui/babel.config.js
+++ b/packages/react-search-ui/babel.config.js
@@ -2,13 +2,7 @@ const presets = [
   [
     "@babel/env",
     {
-      // Because we are using @babel/polyfill, because we have old browser
-      // targets set, this will optimize the polyfills that are actually
-      // imported.
-      useBuiltIns: "entry",
       targets: {
-        // Setting target browsers like this, if they span back far enough,
-        // requires adding @babel/polyfill
         browsers: ["last 2 versions", "> 5%"]
       },
       modules: process.env.BABEL_MODULES

--- a/packages/react-search-ui/package-lock.json
+++ b/packages/react-search-ui/package-lock.json
@@ -120,6 +120,14 @@
         "@babel/plugin-transform-react-jsx-source": "^7.0.0"
       }
     },
+    "@babel/runtime": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.5.4.tgz",
+      "integrity": "sha512-Na84uwyImZZc3FKf4aUF1tysApzwf3p2yuFBIyBfbzT5glzKTdvYI4KVW4kcgjrzoGUjC7w3YyCHcJKaRxsr2Q==",
+      "requires": {
+        "regenerator-runtime": "^0.13.2"
+      }
+    },
     "@babel/types": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.1.3.tgz",
@@ -5389,6 +5397,11 @@
       "requires": {
         "util.promisify": "^1.0.0"
       }
+    },
+    "regenerator-runtime": {
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
+      "integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA=="
     },
     "regex-cache": {
       "version": "0.4.4",

--- a/packages/react-search-ui/package-lock.json
+++ b/packages/react-search-ui/package-lock.json
@@ -107,15 +107,6 @@
         "@babel/plugin-syntax-jsx": "^7.0.0"
       }
     },
-    "@babel/polyfill": {
-      "version": "7.2.5",
-      "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.2.5.tgz",
-      "integrity": "sha512-8Y/t3MWThtMLYr0YNC/Q76tqN1w30+b0uQMeFUYauG2UGTR19zyUtFrAzT23zNtBxPp+LbE5E/nwV/q/r3y6ug==",
-      "requires": {
-        "core-js": "^2.5.7",
-        "regenerator-runtime": "^0.12.0"
-      }
-    },
     "@babel/preset-react": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.0.0.tgz",
@@ -1079,7 +1070,8 @@
     "core-js": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.9.tgz",
-      "integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A=="
+      "integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A==",
+      "dev": true
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -5397,11 +5389,6 @@
       "requires": {
         "util.promisify": "^1.0.0"
       }
-    },
-    "regenerator-runtime": {
-      "version": "0.12.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
-      "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg=="
     },
     "regex-cache": {
       "version": "0.4.4",

--- a/packages/react-search-ui/package.json
+++ b/packages/react-search-ui/package.json
@@ -33,6 +33,7 @@
     "url": "https://github.com/elastic/search-ui/issues"
   },
   "dependencies": {
+    "@babel/runtime": "^7.5.4",
     "@elastic/react-search-ui-views": "1.0.0-rc.0",
     "@elastic/search-ui": "1.0.0-rc.0",
     "debounce-fn": "^1.0.0"

--- a/packages/react-search-ui/package.json
+++ b/packages/react-search-ui/package.json
@@ -33,10 +33,8 @@
     "url": "https://github.com/elastic/search-ui/issues"
   },
   "dependencies": {
-    "@babel/polyfill": "^7.2.5",
     "@elastic/react-search-ui-views": "1.0.0-rc.0",
     "@elastic/search-ui": "1.0.0-rc.0",
-    "core-js": "^2.6.9",
     "debounce-fn": "^1.0.0"
   },
   "peerDependencies": {

--- a/packages/search-ui-app-search-connector/babel.config.js
+++ b/packages/search-ui-app-search-connector/babel.config.js
@@ -2,13 +2,7 @@ const presets = [
   [
     "@babel/env",
     {
-      // Because we are using @babel/polyfill, because we have old browser
-      // targets set, this will optimize the polyfills that are actually
-      // imported.
-      useBuiltIns: "entry",
       targets: {
-        // Setting target browsers like this, if they span back far enough,
-        // requires adding @babel/polyfill
         browsers: ["last 2 versions", "> 5%"]
       },
       modules: process.env.BABEL_MODULES

--- a/packages/search-ui-app-search-connector/babel.config.js
+++ b/packages/search-ui-app-search-connector/babel.config.js
@@ -15,5 +15,8 @@ const presets = [
 module.exports = {
   sourceMaps: "inline",
   presets,
-  plugins: ["@babel/plugin-proposal-class-properties"]
+  plugins: [
+    "@babel/plugin-proposal-class-properties",
+    ["@babel/plugin-transform-runtime", { regenerator: true }]
+  ]
 };

--- a/packages/search-ui-app-search-connector/package-lock.json
+++ b/packages/search-ui-app-search-connector/package-lock.json
@@ -42,15 +42,6 @@
         "js-tokens": "^4.0.0"
       }
     },
-    "@babel/polyfill": {
-      "version": "7.2.5",
-      "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.2.5.tgz",
-      "integrity": "sha512-8Y/t3MWThtMLYr0YNC/Q76tqN1w30+b0uQMeFUYauG2UGTR19zyUtFrAzT23zNtBxPp+LbE5E/nwV/q/r3y6ug==",
-      "requires": {
-        "core-js": "^2.5.7",
-        "regenerator-runtime": "^0.12.0"
-      }
-    },
     "abab": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.0.tgz",
@@ -936,7 +927,8 @@
     "core-js": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.9.tgz",
-      "integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A=="
+      "integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A==",
+      "dev": true
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -4844,11 +4836,6 @@
       "requires": {
         "util.promisify": "^1.0.0"
       }
-    },
-    "regenerator-runtime": {
-      "version": "0.12.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
-      "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg=="
     },
     "regex-cache": {
       "version": "0.4.4",

--- a/packages/search-ui-app-search-connector/package-lock.json
+++ b/packages/search-ui-app-search-connector/package-lock.json
@@ -42,6 +42,14 @@
         "js-tokens": "^4.0.0"
       }
     },
+    "@babel/runtime": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.5.4.tgz",
+      "integrity": "sha512-Na84uwyImZZc3FKf4aUF1tysApzwf3p2yuFBIyBfbzT5glzKTdvYI4KVW4kcgjrzoGUjC7w3YyCHcJKaRxsr2Q==",
+      "requires": {
+        "regenerator-runtime": "^0.13.2"
+      }
+    },
     "abab": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.0.tgz",
@@ -4836,6 +4844,11 @@
       "requires": {
         "util.promisify": "^1.0.0"
       }
+    },
+    "regenerator-runtime": {
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
+      "integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA=="
     },
     "regex-cache": {
       "version": "0.4.4",

--- a/packages/search-ui-app-search-connector/package.json
+++ b/packages/search-ui-app-search-connector/package.json
@@ -39,8 +39,6 @@
     "rimraf": "^2.6.2"
   },
   "dependencies": {
-    "@babel/polyfill": "^7.2.5",
-    "core-js": "^2.6.9",
     "swiftype-app-search-javascript": "^2.4.0"
   }
 }

--- a/packages/search-ui-app-search-connector/package.json
+++ b/packages/search-ui-app-search-connector/package.json
@@ -39,6 +39,7 @@
     "rimraf": "^2.6.2"
   },
   "dependencies": {
+    "@babel/runtime": "^7.5.4",
     "swiftype-app-search-javascript": "^2.4.0"
   }
 }

--- a/packages/search-ui-app-search-connector/src/index.js
+++ b/packages/search-ui-app-search-connector/src/index.js
@@ -1,3 +1,1 @@
-import "@babel/polyfill";
-
 export { default } from "./AppSearchAPIConnector";

--- a/packages/search-ui-site-search-connector/babel.config.js
+++ b/packages/search-ui-site-search-connector/babel.config.js
@@ -2,13 +2,7 @@ const presets = [
   [
     "@babel/env",
     {
-      // Because we are using @babel/polyfill, because we have old browser
-      // targets set, this will optimize the polyfills that are actually
-      // imported.
-      useBuiltIns: "entry",
       targets: {
-        // Setting target browsers like this, if they span back far enough,
-        // requires adding @babel/polyfill
         browsers: ["last 2 versions", "> 5%"]
       },
       modules: process.env.BABEL_MODULES

--- a/packages/search-ui-site-search-connector/babel.config.js
+++ b/packages/search-ui-site-search-connector/babel.config.js
@@ -15,5 +15,8 @@ const presets = [
 module.exports = {
   sourceMaps: "inline",
   presets,
-  plugins: ["@babel/plugin-proposal-class-properties"]
+  plugins: [
+    "@babel/plugin-proposal-class-properties",
+    ["@babel/plugin-transform-runtime", { regenerator: true }]
+  ]
 };

--- a/packages/search-ui-site-search-connector/package-lock.json
+++ b/packages/search-ui-site-search-connector/package-lock.json
@@ -42,15 +42,6 @@
         "js-tokens": "^4.0.0"
       }
     },
-    "@babel/polyfill": {
-      "version": "7.2.5",
-      "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.2.5.tgz",
-      "integrity": "sha512-8Y/t3MWThtMLYr0YNC/Q76tqN1w30+b0uQMeFUYauG2UGTR19zyUtFrAzT23zNtBxPp+LbE5E/nwV/q/r3y6ug==",
-      "requires": {
-        "core-js": "^2.5.7",
-        "regenerator-runtime": "^0.12.0"
-      }
-    },
     "abab": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.0.tgz",
@@ -936,7 +927,8 @@
     "core-js": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.9.tgz",
-      "integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A=="
+      "integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A==",
+      "dev": true
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -4839,11 +4831,6 @@
       "requires": {
         "util.promisify": "^1.0.0"
       }
-    },
-    "regenerator-runtime": {
-      "version": "0.12.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
-      "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg=="
     },
     "regex-cache": {
       "version": "0.4.4",

--- a/packages/search-ui-site-search-connector/package-lock.json
+++ b/packages/search-ui-site-search-connector/package-lock.json
@@ -42,6 +42,14 @@
         "js-tokens": "^4.0.0"
       }
     },
+    "@babel/runtime": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.5.4.tgz",
+      "integrity": "sha512-Na84uwyImZZc3FKf4aUF1tysApzwf3p2yuFBIyBfbzT5glzKTdvYI4KVW4kcgjrzoGUjC7w3YyCHcJKaRxsr2Q==",
+      "requires": {
+        "regenerator-runtime": "^0.13.2"
+      }
+    },
     "abab": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.0.tgz",
@@ -4831,6 +4839,11 @@
       "requires": {
         "util.promisify": "^1.0.0"
       }
+    },
+    "regenerator-runtime": {
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
+      "integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA=="
     },
     "regex-cache": {
       "version": "0.4.4",

--- a/packages/search-ui-site-search-connector/package.json
+++ b/packages/search-ui-site-search-connector/package.json
@@ -37,5 +37,8 @@
     "jest": "^23.6.0",
     "npm-run-all": "^4.1.5",
     "rimraf": "^2.6.2"
+  },
+  "dependencies": {
+    "@babel/runtime": "^7.5.4"
   }
 }

--- a/packages/search-ui-site-search-connector/package.json
+++ b/packages/search-ui-site-search-connector/package.json
@@ -37,9 +37,5 @@
     "jest": "^23.6.0",
     "npm-run-all": "^4.1.5",
     "rimraf": "^2.6.2"
-  },
-  "dependencies": {
-    "@babel/polyfill": "^7.2.5",
-    "core-js": "^2.6.9"
   }
 }

--- a/packages/search-ui-site-search-connector/src/index.js
+++ b/packages/search-ui-site-search-connector/src/index.js
@@ -1,3 +1,1 @@
-import "@babel/polyfill";
-
 export { default } from "./SiteSearchAPIConnector";

--- a/packages/search-ui/babel.config.js
+++ b/packages/search-ui/babel.config.js
@@ -2,13 +2,7 @@ const presets = [
   [
     "@babel/env",
     {
-      // Because we are using @babel/polyfill, because we have old browser
-      // targets set, this will optimize the polyfills that are actually
-      // imported.
-      useBuiltIns: "entry",
       targets: {
-        // Setting target browsers like this, if they span back far enough,
-        // requires adding @babel/polyfill
         browsers: ["last 2 versions", "> 5%"]
       },
       modules: process.env.BABEL_MODULES

--- a/packages/search-ui/babel.config.js
+++ b/packages/search-ui/babel.config.js
@@ -15,5 +15,8 @@ const presets = [
 module.exports = {
   sourceMaps: "inline",
   presets,
-  plugins: ["@babel/plugin-proposal-class-properties"]
+  plugins: [
+    "@babel/plugin-proposal-class-properties",
+    ["@babel/plugin-transform-runtime", { regenerator: true }]
+  ]
 };

--- a/packages/search-ui/package-lock.json
+++ b/packages/search-ui/package-lock.json
@@ -42,15 +42,6 @@
         "js-tokens": "^4.0.0"
       }
     },
-    "@babel/polyfill": {
-      "version": "7.2.5",
-      "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.2.5.tgz",
-      "integrity": "sha512-8Y/t3MWThtMLYr0YNC/Q76tqN1w30+b0uQMeFUYauG2UGTR19zyUtFrAzT23zNtBxPp+LbE5E/nwV/q/r3y6ug==",
-      "requires": {
-        "core-js": "^2.5.7",
-        "regenerator-runtime": "^0.12.0"
-      }
-    },
     "abab": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.0.tgz",
@@ -944,7 +935,8 @@
     "core-js": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.9.tgz",
-      "integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A=="
+      "integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A==",
+      "dev": true
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -4887,11 +4879,6 @@
       "requires": {
         "util.promisify": "^1.0.0"
       }
-    },
-    "regenerator-runtime": {
-      "version": "0.12.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
-      "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg=="
     },
     "regex-cache": {
       "version": "0.4.4",

--- a/packages/search-ui/package-lock.json
+++ b/packages/search-ui/package-lock.json
@@ -42,6 +42,14 @@
         "js-tokens": "^4.0.0"
       }
     },
+    "@babel/runtime": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.5.4.tgz",
+      "integrity": "sha512-Na84uwyImZZc3FKf4aUF1tysApzwf3p2yuFBIyBfbzT5glzKTdvYI4KVW4kcgjrzoGUjC7w3YyCHcJKaRxsr2Q==",
+      "requires": {
+        "regenerator-runtime": "^0.13.2"
+      }
+    },
     "abab": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.0.tgz",
@@ -4879,6 +4887,11 @@
       "requires": {
         "util.promisify": "^1.0.0"
       }
+    },
+    "regenerator-runtime": {
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
+      "integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA=="
     },
     "regex-cache": {
       "version": "0.4.4",

--- a/packages/search-ui/package.json
+++ b/packages/search-ui/package.json
@@ -39,6 +39,7 @@
     "rimraf": "^2.6.2"
   },
   "dependencies": {
+    "@babel/runtime": "^7.5.4",
     "date-fns": "^1.29.0",
     "debounce-fn": "^1.0.0",
     "deep-equal": "^1.0.1",

--- a/packages/search-ui/package.json
+++ b/packages/search-ui/package.json
@@ -39,8 +39,6 @@
     "rimraf": "^2.6.2"
   },
   "dependencies": {
-    "@babel/polyfill": "^7.2.5",
-    "core-js": "^2.6.9",
     "date-fns": "^1.29.0",
     "debounce-fn": "^1.0.0",
     "deep-equal": "^1.0.1",

--- a/packages/search-ui/src/index.js
+++ b/packages/search-ui/src/index.js
@@ -1,3 +1,1 @@
-import "@babel/polyfill";
-
 export { default as SearchDriver } from "./SearchDriver";


### PR DESCRIPTION
## Description

`@babel/polyfill` was a dependency in this project. This was a pretty crazy headache, as it was a runtime dependency (as opposed to a build time, dev dependencies) that actually goes out and Polyfills a number of global APIs, like `Promise`, `Map`, etc, which is very intrusive and there is a lot of potential for conflict there. It's especially bad since this is a library, and you would *not* expect a library to do that.

In Babel's docs, they actually outline two methods for handling these globals. The first is the Polyfill, which they advise against for the libraries. The second, is https://babeljs.io/docs/en/babel-plugin-transform-runtime, which they DO recommend for libraries.

The approach the plugin takes is to replace globals like "Promise.all" etc with helpers from the `babel-runtime` package. This is much safer for libraries as it's not actually shimming anything globally.

Initially, I attempted to remove `@babel/polyfill` and not replace it, but it is required since we use `async` functions, which require a regenerate runtime.

Long story short, I replaced `@babel/polyfill` with `@babel/plugin-transform-runtime`

## List of changes
- Removed `@babel/polyfill`
- Added `@babel/plugin-transform-runtime`

## Associated Github Issues
https://github.com/elastic/search-ui/issues/278
https://github.com/elastic/search-ui/issues/290
