### PR TITLE
Fix misc. Edge cross-browser styling issues

### DIFF
--- a/packages/react-search-ui-views/src/styles/themes/reference-ui/components/_multi-checkbox-facet.scss
+++ b/packages/react-search-ui-views/src/styles/themes/reference-ui/components/_multi-checkbox-facet.scss
@@ -55,6 +55,7 @@
     height: 100%;
     padding: 6px;
     margin: 0;
+    font-family: inherit;
     border: 1px solid #cccccc;
     border-radius: 4px;
     outline: none;

--- a/packages/react-search-ui-views/src/styles/themes/reference-ui/components/_search-box.scss
+++ b/packages/react-search-ui-views/src/styles/themes/reference-ui/components/_search-box.scss
@@ -6,6 +6,7 @@
   font-family: $fontFamily;
 
   @include element("submit") {
+    font-family: inherit;
     font-size: 14px;
     padding: 16px;
     margin-left: 10px;
@@ -48,6 +49,7 @@
     padding: 16px;
     outline: none;
     position: relative;
+    font-family: inherit;
     font-size: 14px;
     width: 100%;
 

--- a/packages/react-search-ui-views/src/styles/themes/reference-ui/components/_search-box.scss
+++ b/packages/react-search-ui-views/src/styles/themes/reference-ui/components/_search-box.scss
@@ -6,6 +6,7 @@
   font-family: $fontFamily;
 
   @include element("submit") {
+    flex-shrink: 0;
     font-family: inherit;
     font-size: 14px;
     padding: 16px;


### PR DESCRIPTION
## Description

This fixes some very minor cross-browser Edge CSS issues that I noticed while testing Search UI's sandbox example in Browserstack.

### Screenshots

**Before (left) vs. After (right):**

(Weird squashing/padding on right appeared to be due to flexbox & shrinking)
<img width="1153" alt="" src="https://user-images.githubusercontent.com/549407/61240633-8b417800-a6f6-11e9-91ec-0b37bcfe5d77.png">

(Very subtle sans-serif vs. Segoe font in "Filter states")
<img width="435" alt="" src="https://user-images.githubusercontent.com/549407/61240636-8d0b3b80-a6f6-11e9-8f7e-b21fc0dfe1c0.png">

## List of changes

- Fixes font family on SearchBox's text/button input not inheriting correctly on Edge
- Fix SearchBox's "Search" button being squashed on Edge
- Fixes font family on Search Filters input not inheriting correctly on Edge