### PR TITLE
Added a command for installing all dependencies

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,14 +37,8 @@ cause the examples applications to error out from dependency version conflicts.
 From the root level of this repository, run the following commands in order:
 
 ```shell
-# Install top level depenedencies at the root of the project
-npm install
-
-# Install dependencies in the /packages directory
-(cd packages && npm install)
-
-# Install all dependencies for the individual packages
-npm run bootstrap
+# Install all dependencies
+npm run install-all
 ```
 
 ### Building

--- a/bin/install
+++ b/bin/install
@@ -1,0 +1,5 @@
+npm install
+cd packages
+npm install
+cd ..
+lerna bootstrap

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "license": "Apache-2.0",
   "scripts": {
-    "bootstrap": "lerna bootstrap",
+    "install-all": "./bin/install",
     "test": "lerna run test --stream --no-private",
     "test-ci": "lerna run test-ci --stream --no-private",
     "watch": "lerna run watch --parallel",


### PR DESCRIPTION
## Description

Previously, to re-install all dependencies you had to run 3
different commands separately. This change creates on command
at the top level which will run all 3.

## List of changes

- Add an `install-all` command

## Associated Github Issues
