### PR TITLE
Automatically bake in subfolder installs into `npm install`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,11 +34,5 @@ jobs:
             - node_modules
           key: v2-dependencies-{{ checksum "package.json" }}
 
-      # Install common deps
-      - run: (cd packages && npm install)
-
-      # Install deps in all packages
-      - run: npm run bootstrap
-
       # run tests!
       - run: npm run test-ci

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,18 +34,13 @@ cause the examples applications to error out from dependency version conflicts.
 
 ### Installing dependencies
 
-From the root level of this repository, run the following commands in order:
+From the root level of this repository:
 
 ```shell
-# Install top level depenedencies at the root of the project
 npm install
-
-# Install dependencies in the /packages directory
-(cd packages && npm install)
-
-# Install all dependencies for the individual packages
-npm run bootstrap
 ```
+
+Behind the scenes, this installs dependencies in the root folder, in the `packages` folder, and for each lerna package and example repo.
 
 ### Building
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "license": "Apache-2.0",
   "scripts": {
-    "bootstrap": "lerna bootstrap",
+    "postinstall": "cd packages && npm install && cd .. && lerna bootstrap",
     "test": "lerna run test --stream --no-private",
     "test-ci": "lerna run test-ci --stream --no-private",
     "watch": "lerna run watch --parallel",


### PR DESCRIPTION
## Description

I kept messing up dependency installs (documented [here](https://github.com/elastic/search-ui/blob/master/CONTRIBUTING.md#installing-dependencies)) and thought I'd make it more idiot-proof for future me 😄

Now instead of having to run 3 separate install commands, just running the default `npm install`/`yarn install` commands will also trigger installing `packages/package.json` and `lerna bootstrap`.

## List of changes

- Add a postinstall script that auto-installs subfolder dependencies
- Update CircleCI
- Update docs