### PR TITLE
More robust fix for PagingInfo showing a higher end than possible

### DIFF
--- a/packages/react-search-ui-views/src/PagingInfo.js
+++ b/packages/react-search-ui-views/src/PagingInfo.js
@@ -8,7 +8,7 @@ function PagingInfo({ className, end, searchTerm, start, totalResults }) {
     <div className={appendClassName("sui-paging-info", className)}>
       Showing{" "}
       <strong>
-        {start} - {Math.min(end, totalResults)}
+        {start} - {end}
       </strong>{" "}
       out of <strong>{totalResults}</strong> for: <em>{searchTerm}</em>
     </div>

--- a/packages/react-search-ui-views/src/__tests__/PagingInfo.test.js
+++ b/packages/react-search-ui-views/src/__tests__/PagingInfo.test.js
@@ -22,8 +22,3 @@ it("renders with className prop applied", () => {
   const { className } = wrapper.props();
   expect(className).toEqual("sui-paging-info test-class");
 });
-
-it("does not render a higher end than the total # of results", () => {
-  const wrapper = shallow(<PagingInfo {...props} totalResults={15} />);
-  expect(wrapper).toMatchSnapshot();
-});

--- a/packages/react-search-ui-views/src/__tests__/__snapshots__/PagingInfo.test.js.snap
+++ b/packages/react-search-ui-views/src/__tests__/__snapshots__/PagingInfo.test.js.snap
@@ -1,28 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`does not render a higher end than the total # of results 1`] = `
-<div
-  className="sui-paging-info"
->
-  Showing
-   
-  <strong>
-    0
-     - 
-    15
-  </strong>
-   
-  out of 
-  <strong>
-    15
-  </strong>
-   for: 
-  <em>
-    grok
-  </em>
-</div>
-`;
-
 exports[`renders correctly 1`] = `
 <div
   className="sui-paging-info"

--- a/packages/react-search-ui/src/containers/PagingInfo.js
+++ b/packages/react-search-ui/src/containers/PagingInfo.js
@@ -27,7 +27,7 @@ export class PagingInfoContainer extends Component {
     } = this.props;
     const start = totalResults === 0 ? 0 : (current - 1) * resultsPerPage + 1;
     const end =
-      totalResults <= resultsPerPage
+      totalResults <= start + resultsPerPage
         ? totalResults
         : start + resultsPerPage - 1;
 

--- a/packages/react-search-ui/src/containers/__tests__/PagingInfo.test.js
+++ b/packages/react-search-ui/src/containers/__tests__/PagingInfo.test.js
@@ -37,6 +37,20 @@ it("renders when it doesn't have any results or a result search term", () => {
   expect(wrapper).toMatchSnapshot();
 });
 
+it("does not render more than the total # of results", () => {
+  const wrapper = shallow(<PagingInfoContainer {...params} totalResults={5} />);
+  expect(wrapper.text()).toEqual("Showing 1 - 5 out of 5 for: test");
+
+  wrapper.setProps({ current: 3, resultsPerPage: 5, totalResults: 12 });
+  expect(wrapper.text()).toEqual("Showing 11 - 12 out of 12 for: test");
+
+  wrapper.setProps({ totalResults: 15 });
+  expect(wrapper.text()).toEqual("Showing 11 - 15 out of 15 for: test");
+
+  wrapper.setProps({ totalResults: 0 });
+  expect(wrapper.text()).toEqual("Showing 0 - 0 out of 0 for: test");
+});
+
 it("passes className through to the view", () => {
   let viewProps;
   const className = "test-class";


### PR DESCRIPTION
## Description

It's https://github.com/elastic/search-ui/pull/318 redux! 😅 When working in `react-search-ui`'s PagingInfo component, I finally got my mind out of "views" mode and realized that we need to fix the issue at the container level and not the view level - since we're still sending the incorrect "end" to users using custom views. Also, the a11y announcement (that I'm working on) needs the correct numbers as well.

## List of changes

- Removes old `Math.min()` code and moves the `totalResult` check logic to `PagingInfoContainer` instead
- Updates tests