### PR TITLE
Fix non-working mockSearchResponse in SearchDriver test

### DIFF
--- a/packages/search-ui/src/__tests__/SearchDriver.test.js
+++ b/packages/search-ui/src/__tests__/SearchDriver.test.js
@@ -68,12 +68,13 @@ it("will default facets to {} in state if facets is missing from the response", 
     mockSearchResponse: {
       totalResults: 1000,
       totalPages: 100,
-      requestId: "12345",
+      requestId: "67890",
       results: [{}, {}]
     }
   });
 
   expect(doesStateHaveResponseData(stateAfterCreation)).toBe(true);
+  expect(stateAfterCreation.requestId).toEqual("67890");
   expect(stateAfterCreation.facets).toEqual({});
 });
 

--- a/packages/search-ui/src/test/helpers.js
+++ b/packages/search-ui/src/test/helpers.js
@@ -50,6 +50,12 @@ export function setupDriver({
 } = {}) {
   const mockApiConnector = getMockApiConnector();
 
+  if (mockSearchResponse) {
+    mockApiConnector.onSearch = jest.fn().mockReturnValue({
+      then: cb => cb(mockSearchResponse)
+    });
+  }
+
   trackUrlState =
     trackUrlState === false || trackUrlState === true ? trackUrlState : true;
 
@@ -61,12 +67,6 @@ export function setupDriver({
     // pushes happen synchronously
     urlPushDebounceLength: 0
   });
-
-  if (mockSearchResponse) {
-    mockApiConnector.search = jest.fn().mockReturnValue({
-      then: cb => cb(mockSearchResponse)
-    });
-  }
 
   const updatedStateAfterAction = {};
   driver.subscribeToStateChanges(newState => {


### PR DESCRIPTION
## Description

I found this issue while writing tests for the upcoming a11y SearchDriver work.

### Reproducing issue: 

1. In [SearchDriver.test.js, line 71](https://github.com/constancecchen/search-ui/blob/fd4add80ab82fcc4a688b3e1b7ea2ff0cbdb5dd3/packages/search-ui/src/__tests__/SearchDriver.test.js#L71), change `requestId` to `67890` (or any other string)
2. Add `console.log(stateAfterCreation)` to the end of this test
3. Notice that the test now fails and the console log returns the [default `resultId: "12345"`](https://github.com/constancecchen/search-ui/blob/fd4add80ab82fcc4a688b3e1b7ea2ff0cbdb5dd3/packages/search-ui/src/test/helpers.js#L20) searchResponse still

<img width="457" alt="" src="https://user-images.githubusercontent.com/549407/61561890-ec35bc80-aa24-11e9-9cd4-b16d7ee02338.png">

### Reproducing fix:

1. Pull down this branch.
2. Add `console.log(stateAfterCreation)` to the end of [this test](https://github.com/constancecchen/search-ui/blob/fd4add80ab82fcc4a688b3e1b7ea2ff0cbdb5dd3/packages/search-ui/src/__tests__/SearchDriver.test.js#L61-L79)
3. Notice the test now passes and the console log returns `resultId: "67890"` (as expected)

<img width="458" alt="" src="https://user-images.githubusercontent.com/549407/61561979-1dae8800-aa25-11e9-9e93-adaee2b27647.png">

## List of changes

- Change `mockApiConnector.search = ` to `mockApiConnector.onSearch =` (there's no such key as `search` in mock)

https://github.com/elastic/search-ui/blob/fd4add80ab82fcc4a688b3e1b7ea2ff0cbdb5dd3/packages/search-ui/src/test/helpers.js#L32-L42

- Move the if check/override earlier on the page to [_before_ `new SearchDriver()` is initialized](https://github.com/constancecchen/search-ui/blob/fd4add80ab82fcc4a688b3e1b7ea2ff0cbdb5dd3/packages/search-ui/src/test/helpers.js#L62-L63)