### PR TITLE
Modifies the way empty string searches are displayed in the Pagination info

### DIFF
--- a/packages/react-search-ui-views/src/PagingInfo.js
+++ b/packages/react-search-ui-views/src/PagingInfo.js
@@ -3,14 +3,14 @@ import React from "react";
 
 import { appendClassName } from "./view-helpers";
 
-function PagingInfo({ className, end, start, totalResults }) {
+function PagingInfo({ className, end, searchTerm, start, totalResults }) {
   return (
     <div className={appendClassName("sui-paging-info", className)}>
       Showing{" "}
       <strong>
         {start} - {end}
       </strong>{" "}
-      out of <strong>{totalResults}</strong>
+      out of <strong>{totalResults}</strong>: <em>{searchTerm}</em>
     </div>
   );
 }

--- a/packages/react-search-ui-views/src/PagingInfo.js
+++ b/packages/react-search-ui-views/src/PagingInfo.js
@@ -10,7 +10,12 @@ function PagingInfo({ className, end, searchTerm, start, totalResults }) {
       <strong>
         {start} - {end}
       </strong>{" "}
-      out of <strong>{totalResults}</strong>: <em>{searchTerm}</em>
+      out of <strong>{totalResults}</strong>{" "}
+      {searchTerm && (
+        <React.Fragment>
+          for: <em>{searchTerm}</em>
+        </React.Fragment>
+      )}
     </div>
   );
 }

--- a/packages/react-search-ui-views/src/PagingInfo.js
+++ b/packages/react-search-ui-views/src/PagingInfo.js
@@ -10,9 +10,10 @@ function PagingInfo({ className, end, searchTerm, start, totalResults }) {
       <strong>
         {start} - {end}
       </strong>{" "}
-      out of <strong>{totalResults}</strong>{" "}
+      out of <strong>{totalResults}</strong>
       {searchTerm && (
         <>
+          {" "}
           for: <em>{searchTerm}</em>
         </>
       )}

--- a/packages/react-search-ui-views/src/PagingInfo.js
+++ b/packages/react-search-ui-views/src/PagingInfo.js
@@ -3,14 +3,14 @@ import React from "react";
 
 import { appendClassName } from "./view-helpers";
 
-function PagingInfo({ className, end, searchTerm, start, totalResults }) {
+function PagingInfo({ className, end, start, totalResults }) {
   return (
     <div className={appendClassName("sui-paging-info", className)}>
       Showing{" "}
       <strong>
         {start} - {end}
       </strong>{" "}
-      out of <strong>{totalResults}</strong> for: <em>{searchTerm}</em>
+      out of <strong>{totalResults}</strong>
     </div>
   );
 }

--- a/packages/react-search-ui-views/src/PagingInfo.js
+++ b/packages/react-search-ui-views/src/PagingInfo.js
@@ -12,9 +12,9 @@ function PagingInfo({ className, end, searchTerm, start, totalResults }) {
       </strong>{" "}
       out of <strong>{totalResults}</strong>{" "}
       {searchTerm && (
-        <React.Fragment>
+        <>
           for: <em>{searchTerm}</em>
-        </React.Fragment>
+        </>
       )}
     </div>
   );

--- a/packages/react-search-ui-views/src/__tests__/__snapshots__/PagingInfo.test.js.snap
+++ b/packages/react-search-ui-views/src/__tests__/__snapshots__/PagingInfo.test.js.snap
@@ -16,7 +16,7 @@ exports[`renders correctly 1`] = `
   <strong>
     1000
   </strong>
-   for: 
+  : 
   <em>
     grok
   </em>

--- a/packages/react-search-ui-views/src/__tests__/__snapshots__/PagingInfo.test.js.snap
+++ b/packages/react-search-ui-views/src/__tests__/__snapshots__/PagingInfo.test.js.snap
@@ -17,11 +17,9 @@ exports[`renders correctly 1`] = `
     1000
   </strong>
    
-  <span>
-    for: 
-    <em>
-      grok
-    </em>
-  </span>
+  for: 
+  <em>
+    grok
+  </em>
 </div>
 `;

--- a/packages/react-search-ui-views/src/__tests__/__snapshots__/PagingInfo.test.js.snap
+++ b/packages/react-search-ui-views/src/__tests__/__snapshots__/PagingInfo.test.js.snap
@@ -16,9 +16,12 @@ exports[`renders correctly 1`] = `
   <strong>
     1000
   </strong>
-  : 
-  <em>
-    grok
-  </em>
+   
+  <span>
+    for: 
+    <em>
+      grok
+    </em>
+  </span>
 </div>
 `;

--- a/packages/react-search-ui/src/containers/__tests__/PagingInfo.test.js
+++ b/packages/react-search-ui/src/containers/__tests__/PagingInfo.test.js
@@ -39,16 +39,16 @@ it("renders when it doesn't have any results or a result search term", () => {
 
 it("does not render more than the total # of results", () => {
   const wrapper = shallow(<PagingInfoContainer {...params} totalResults={5} />);
-  expect(wrapper.text()).toEqual("Showing 1 - 5 out of 5 for: test");
+  expect(wrapper.text()).toEqual("Showing 1 - 5 out of 5: test");
 
   wrapper.setProps({ current: 3, resultsPerPage: 5, totalResults: 12 });
-  expect(wrapper.text()).toEqual("Showing 11 - 12 out of 12 for: test");
+  expect(wrapper.text()).toEqual("Showing 11 - 12 out of 12: test");
 
   wrapper.setProps({ totalResults: 15 });
-  expect(wrapper.text()).toEqual("Showing 11 - 15 out of 15 for: test");
+  expect(wrapper.text()).toEqual("Showing 11 - 15 out of 15: test");
 
   wrapper.setProps({ totalResults: 0 });
-  expect(wrapper.text()).toEqual("Showing 0 - 0 out of 0 for: test");
+  expect(wrapper.text()).toEqual("Showing 0 - 0 out of 0: test");
 });
 
 it("passes className through to the view", () => {

--- a/packages/react-search-ui/src/containers/__tests__/PagingInfo.test.js
+++ b/packages/react-search-ui/src/containers/__tests__/PagingInfo.test.js
@@ -39,16 +39,16 @@ it("renders when it doesn't have any results or a result search term", () => {
 
 it("does not render more than the total # of results", () => {
   const wrapper = shallow(<PagingInfoContainer {...params} totalResults={5} />);
-  expect(wrapper.text()).toEqual("Showing 1 - 5 out of 5: test");
+  expect(wrapper.text()).toEqual("Showing 1 - 5 out of 5 for: test");
 
   wrapper.setProps({ current: 3, resultsPerPage: 5, totalResults: 12 });
-  expect(wrapper.text()).toEqual("Showing 11 - 12 out of 12: test");
+  expect(wrapper.text()).toEqual("Showing 11 - 12 out of 12 for: test");
 
   wrapper.setProps({ totalResults: 15 });
-  expect(wrapper.text()).toEqual("Showing 11 - 15 out of 15: test");
+  expect(wrapper.text()).toEqual("Showing 11 - 15 out of 15 for: test");
 
   wrapper.setProps({ totalResults: 0 });
-  expect(wrapper.text()).toEqual("Showing 0 - 0 out of 0: test");
+  expect(wrapper.text()).toEqual("Showing 0 - 0 out of 0 for: test");
 });
 
 it("passes className through to the view", () => {

--- a/packages/react-search-ui/src/containers/__tests__/__snapshots__/PagingInfo.test.js.snap
+++ b/packages/react-search-ui/src/containers/__tests__/__snapshots__/PagingInfo.test.js.snap
@@ -16,8 +16,7 @@ exports[`renders when it doesn't have any results or a result search term 1`] = 
   <strong>
     100
   </strong>
-  : 
-  <em />
+   
 </div>
 `;
 

--- a/packages/react-search-ui/src/containers/__tests__/__snapshots__/PagingInfo.test.js.snap
+++ b/packages/react-search-ui/src/containers/__tests__/__snapshots__/PagingInfo.test.js.snap
@@ -16,7 +16,7 @@ exports[`renders when it doesn't have any results or a result search term 1`] = 
   <strong>
     100
   </strong>
-   for: 
+  : 
   <em />
 </div>
 `;

--- a/packages/react-search-ui/src/containers/__tests__/__snapshots__/PagingInfo.test.js.snap
+++ b/packages/react-search-ui/src/containers/__tests__/__snapshots__/PagingInfo.test.js.snap
@@ -16,7 +16,6 @@ exports[`renders when it doesn't have any results or a result search term 1`] = 
   <strong>
     100
   </strong>
-   
 </div>
 `;
 


### PR DESCRIPTION

## Description

When a user searches for an empty string, the UI showing the pagination information looks a little odd. It looks much better when we remove the text "for". 

## List of changes
* Removes "for" from the text displaying the pagination information. 

## Associated Github Issues
#337 
