### PR TITLE
Add contributing clarification for Windows developers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,8 +6,9 @@ How to build and contribute to Search UI.
 
 ### Requirements
 
-Node: 10.16
-NPM: 6.9
+- Node: 10.16
+- NPM: 6.9
+- OS: Unix/Linux or Windows Subsystem for Linux
 
 ### Mono-repo explanation
 


### PR DESCRIPTION
## Description

This PR comes as a result of [a conversation in Gitter](https://gitter.im/elastic-search-ui/community?at=5d336ebfec5abe7bbc1bb4c0) originally reported by @compuroad.

> ⚠️ **NOTE**:
> None of this applies to developers who are **using** and not **developing** search-ui. This error does not come up when simply installing the search-ui package via npm. This only applies to developers who clone the repo and are attempting to develop search-ui locally.

When I attempted to [reproduce the issue](https://gitter.im/elastic-search-ui/community?at=5d35d6ff35e05c0993806f98) locally on my Windows 10 machine, I found that the issue was not after all with either `cd` or `&&` on PowerShell, but with our `bin/` unix executables (located in all lerna packages). Here's a copy of the full error:

```console
> @elastic/react-search-ui-views@1.0.0 prepare C:\Users\Constance\Documents\master\search-ui\packages\react-search-ui-views
> npm run build


> @elastic/react-search-ui-views@1.0.0 build C:\Users\Constance\Documents\master\search-ui\packages\react-search-ui-views
> run-s clean build-css build-js


> @elastic/react-search-ui-views@1.0.0 clean C:\Users\Constance\Documents\master\search-ui\packages\react-search-ui-views
> rimraf es lib


> @elastic/react-search-ui-views@1.0.0 build-css C:\Users\Constance\Documents\master\search-ui\packages\react-search-ui-views
> ./bin/build-css

'.' is not recognized as an internal or external command,
operable program or batch file.
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! @elastic/react-search-ui-views@1.0.0 build-css: `./bin/build-css`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the @elastic/react-search-ui-views@1.0.0 build-css script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     C:\Users\Constance\AppData\Roaming\npm-cache\_logs\2019-07-22T15_31_04_545Z-debug.log
ERROR: "build-css" exited with 1.
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! @elastic/react-search-ui-views@1.0.0 build: `run-s clean build-css build-js`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the @elastic/react-search-ui-views@1.0.0 build script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     C:\Users\Constance\AppData\Roaming\npm-cache\_logs\2019-07-22T15_31_04_750Z-debug.log
lerna info lifecycle @elastic/react-search-ui-views@1.0.0~prepare: Failed to exec prepare script

> @elastic/search-ui-app-search-connector@1.0.0 prepare C:\Users\Constance\Documents\master\search-ui\packages\search-ui-app-search-connector
> npm run build

npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! root@ postinstall: `cd packages && npm install && cd .. && lerna bootstrap`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the root@ postinstall script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     C:\Users\Constance\AppData\Roaming\npm-cache\_logs\2019-07-22T15_31_05_135Z-debug.log
PS C:\Users\Constance\Documents\master\search-ui>
```

After inspecting our `bin` folders, it does indeed make sense that a Windows machine would be unable to run a Unix executable:

<img width="192" alt="" src="https://user-images.githubusercontent.com/549407/61651495-d6b1d400-ac6a-11e9-9a78-cc2aa0d7bfa7.png">

## Workarounds

- Windows developers should in all likelihood be using [Windows Subsystem for Linux + Windows Bash Shell](https://docs.microsoft.com/en-us/windows/wsl/faq).
- There are more options listed in [this StackOverflow answer](https://superuser.com/a/1361053) (including recompiling the executables) if people are looking for alternatives.

BTW -  I tried using Git Bash (included in git for windows), but no dice there, since this is straight up unix executables and not bash/shell scripts (see [this StackOverflow discussion](https://stackoverflow.com/questions/23243353/how-to-set-shell-for-npm-run-scripts-in-windows) for more info). Switching to `.sh` scripts _may_ be an option if we want to consider that, since it's a tad more likely that Windows developers will have bash (required for git for windows) vs the entire windows subsystem enabled.