### PR TITLE
Updated to the latest App Search API client

### DIFF
--- a/packages/search-ui-app-search-connector/package.json
+++ b/packages/search-ui-app-search-connector/package.json
@@ -40,6 +40,6 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.5.4",
-    "swiftype-app-search-javascript": "^2.4.0"
+    "@elastic/app-search-javascript": "^7.3.0"
   }
 }

--- a/packages/search-ui-app-search-connector/src/AppSearchAPIConnector.js
+++ b/packages/search-ui-app-search-connector/src/AppSearchAPIConnector.js
@@ -1,4 +1,4 @@
-import * as SwiftypeAppSearch from "swiftype-app-search-javascript";
+import * as ElasticAppSearch from "@elastic/app-search-javascript";
 import { version } from "../package.json";
 
 import { adaptResponse } from "./responseAdapter";
@@ -61,7 +61,7 @@ class AppSearchAPIConnector {
       );
     }
 
-    this.client = SwiftypeAppSearch.createClient({
+    this.client = ElasticAppSearch.createClient({
       ...(endpointBase && { endpointBase }), //Add property on condition
       ...(hostIdentifier && { hostIdentifier: hostIdentifier }),
       apiKey: searchKey,

--- a/packages/search-ui-app-search-connector/src/__tests__/AppSearchAPIConnector.test.js
+++ b/packages/search-ui-app-search-connector/src/__tests__/AppSearchAPIConnector.test.js
@@ -1,7 +1,7 @@
-import * as SwiftypeAppSearch from "swiftype-app-search-javascript";
+import * as ElasticAppSearch from "@elastic/app-search-javascript";
 import AppSearchAPIConnector from "..";
 
-jest.mock("swiftype-app-search-javascript");
+jest.mock("@elastic/app-search-javascript");
 
 const resultsSuggestions = {
   results: {
@@ -43,7 +43,7 @@ const mockClient = {
   click: jest.fn().mockReturnValue(Promise.resolve())
 };
 
-SwiftypeAppSearch.createClient.mockReturnValue(mockClient);
+ElasticAppSearch.createClient.mockReturnValue(mockClient);
 
 const resultState = {
   facets: {},


### PR DESCRIPTION
## Description

This PR updates the App Search connector to the latest App Search API client, which is now published under @elastic/app-search-javascript

Closes https://github.com/elastic/search-ui/issues/385