### PR TITLE
Fixed "no true options" case for BooleanFacet

### DIFF
--- a/packages/react-search-ui-views/src/BooleanFacet.js
+++ b/packages/react-search-ui-views/src/BooleanFacet.js
@@ -12,7 +12,8 @@ function BooleanFacet({
   onRemove,
   values
 }) {
-  const trueCount = options.find(option => option.value === "true").count;
+  const trueOptions = options.find(option => option.value === "true");
+  if (!trueOptions) return null;
   const isSelected = values.includes("true");
 
   const apply = () => onChange("true");
@@ -35,7 +36,9 @@ function BooleanFacet({
               />
               <span className="sui-boolean-facet__input-text">{label}</span>
             </div>
-            <span className="sui-boolean-facet__option-count">{trueCount}</span>
+            <span className="sui-boolean-facet__option-count">
+              {trueOptions.count}
+            </span>
           </label>
         </div>
       </div>

--- a/packages/react-search-ui-views/src/__tests__/BooleanFacet.test.js
+++ b/packages/react-search-ui-views/src/__tests__/BooleanFacet.test.js
@@ -37,9 +37,21 @@ it("onChange is called on click", () => {
 });
 
 it("onRemove is called on click", () => {
-  params.values = ["true"];
-  const wrapper = mount(<BooleanFacet {...params} />);
+  const wrapper = mount(
+    <BooleanFacet
+      {...{
+        ...params,
+        values: ["true"]
+      }}
+    />
+  );
 
   wrapper.find("input").simulate("change");
   expect(params.onRemove).toHaveBeenCalledTimes(1);
+});
+
+it("will not render when there are no true options", () => {
+  params.options = [];
+  const wrapper = shallow(<BooleanFacet {...params} />);
+  expect(wrapper).toMatchSnapshot();
 });

--- a/packages/react-search-ui-views/src/__tests__/__snapshots__/BooleanFacet.test.js.snap
+++ b/packages/react-search-ui-views/src/__tests__/__snapshots__/BooleanFacet.test.js.snap
@@ -42,3 +42,5 @@ exports[`renders 1`] = `
   </div>
 </fieldset>
 `;
+
+exports[`will not render when there are no true options 1`] = `""`;


### PR DESCRIPTION
If a user filters the results to the point where there are no
"true" values in a facet, then the BooleanFacet should hide itself.
Instead, the component was currently erroring out.

Relates to: https://github.com/elastic/search-ui/pull/383