### PR TITLE
Initial search

### DIFF
--- a/ADVANCED.md
+++ b/ADVANCED.md
@@ -1082,7 +1082,8 @@ const configurationOptions = {
   a11yNotificationMessages: {
     searchResults: ({ start, end, totalResults, searchTerm }) =>
       `Searching for "${searchTerm}". Showing ${start} to ${end} results out of ${totalResults}.`
-  }
+  },
+  alwaysSearchOnInitialLoad: true
 };
 
 return (
@@ -1118,6 +1119,8 @@ return (
 | `urlPushDebounceLength`     | Integer                                                                 | optional  | 500     | The amount of time in milliseconds to debounce/delay updating the browser url after the UI update. This, for example, prevents excessive history entries while a user is still typing in a live search box.                  |
 | `hasA11yNotifications`      | Boolean                                                                 | optional  | false   | Search UI will create a visually hidden live region to announce search results & other actions to screen reader users. This accessibility feature will be turned on by default in our 2.0 release.                           |
 | `a11yNotificationMessages`  | Object                                                                  | optional  | {}      | You can override our default screen reader [messages](packages/search-ui/src/A11yNotifications.js#L49) (e.g. for localization), or create your own custom notification, by passing in your own key and message function(s).  |
+| `alwaysSearchOnInitialLoad`  | Boolean                                                                | optional  | false   | If true, Search UI will always do an initial search, even when no inital Request State is set.
+
 
 ## Query Config
 

--- a/packages/search-ui/src/SearchDriver.js
+++ b/packages/search-ui/src/SearchDriver.js
@@ -92,7 +92,8 @@ export default class SearchDriver {
     trackUrlState = true,
     urlPushDebounceLength = 500,
     hasA11yNotifications = false,
-    a11yNotificationMessages = {}
+    a11yNotificationMessages = {},
+    alwaysSearchOnInitialLoad = false
   }) {
     this.actions = Object.entries(actions).reduce(
       (acc, [actionName, action]) => {
@@ -121,6 +122,7 @@ export default class SearchDriver {
     this.subscriptions = [];
     this.trackUrlState = trackUrlState;
     this.urlPushDebounceLength = urlPushDebounceLength;
+    this.alwaysSearchOnInitialLoad = alwaysSearchOnInitialLoad;
 
     let urlState;
     if (trackUrlState) {
@@ -170,9 +172,13 @@ export default class SearchDriver {
     };
 
     // We'll trigger an initial search if initial parameters contain
-    // a search term or filters, otherwise, we'll just save their selections
-    // in state as initial values.
-    if (searchParameters.searchTerm || searchParameters.filters.length > 0) {
+    // a search term or filters, or if alwaysSearchOnInitialLoad is set.
+    // Otherwise, we'll just save their selections in state as initial values.
+    if (
+      searchParameters.searchTerm ||
+      searchParameters.filters.length > 0 ||
+      this.alwaysSearchOnInitialLoad
+    ) {
       this._updateSearchResults(searchParameters);
     }
   }

--- a/packages/search-ui/src/__tests__/SearchDriver.test.js
+++ b/packages/search-ui/src/__tests__/SearchDriver.test.js
@@ -94,14 +94,20 @@ it("will default facets to {} in state if facets is missing from the response", 
   expect(stateAfterCreation.facets).toEqual({});
 });
 
-it("will trigger a search if searchTerm or filters are provided in initial state", () => {
-  const initialState = {
-    filters: [{ field: "initial", values: ["value"], type: "all" }],
-    searchTerm: "test"
-  };
+it("does not do an initial search when alwaysSearchOnInitialLoad is not set", () => {
+  const initialState = {};
+
+  const { stateAfterCreation } = setupDriver({ initialState });
+
+  expect(doesStateHaveResponseData(stateAfterCreation)).toBe(0);
+});
+
+it("will trigger a search if alwaysSearchOnInitialLoad are set", () => {
+  const initialState = {};
 
   const { stateAfterCreation } = setupDriver({
-    initialState
+    initialState,
+    alwaysSearchOnInitialLoad: true
   });
 
   expect(doesStateHaveResponseData(stateAfterCreation)).toBe(true);

--- a/packages/search-ui/src/__tests__/SearchDriver.test.js
+++ b/packages/search-ui/src/__tests__/SearchDriver.test.js
@@ -94,6 +94,19 @@ it("will default facets to {} in state if facets is missing from the response", 
   expect(stateAfterCreation.facets).toEqual({});
 });
 
+it("will trigger a search if searchTerm or filters are provided in initial state", () => {
+  const initialState = {
+    filters: [{ field: "initial", values: ["value"], type: "all" }],
+    searchTerm: "test"
+  };
+
+  const { stateAfterCreation } = setupDriver({
+    initialState
+  });
+
+  expect(doesStateHaveResponseData(stateAfterCreation)).toBe(true);
+});
+
 it("does not do an initial search when alwaysSearchOnInitialLoad is not set", () => {
   const initialState = {};
 

--- a/packages/search-ui/src/__tests__/SearchDriver.test.js
+++ b/packages/search-ui/src/__tests__/SearchDriver.test.js
@@ -115,7 +115,7 @@ it("does not do an initial search when alwaysSearchOnInitialLoad is not set", ()
   expect(doesStateHaveResponseData(stateAfterCreation)).toBe(0);
 });
 
-it("will trigger a search if alwaysSearchOnInitialLoad are set", () => {
+it("does do an initial search when alwaysSearchOnInitialLoad is set", () => {
   const initialState = {};
 
   const { stateAfterCreation } = setupDriver({

--- a/packages/search-ui/src/__tests__/actions/trackClickThrough.test.js
+++ b/packages/search-ui/src/__tests__/actions/trackClickThrough.test.js
@@ -1,15 +1,8 @@
 import { getClickCalls, setupDriver } from "../../test/helpers";
 
 describe("#trackClickThrough", () => {
-  function subject(
-    { initialState, alwaysSearchOnInitialLoad } = {},
-    documentId,
-    tags
-  ) {
-    const { driver, mockApiConnector } = setupDriver({
-      initialState,
-      alwaysSearchOnInitialLoad
-    });
+  function subject({ initialState } = {}, documentId, tags) {
+    const { driver, mockApiConnector } = setupDriver({ initialState });
     driver.trackClickThrough(documentId, tags);
     return { driver, mockApiConnector };
   }
@@ -21,10 +14,7 @@ describe("#trackClickThrough", () => {
 
   it("Calls Connector 'click' with correct parameters", () => {
     const { mockApiConnector } = subject(
-      {
-        initialState: { searchTerm: "search terms" },
-        alwaysSearchOnInitialLoad: true
-      },
+      { initialState: { searchTerm: "search terms" } },
       1,
       ["test"]
     );

--- a/packages/search-ui/src/__tests__/actions/trackClickThrough.test.js
+++ b/packages/search-ui/src/__tests__/actions/trackClickThrough.test.js
@@ -1,8 +1,15 @@
 import { getClickCalls, setupDriver } from "../../test/helpers";
 
 describe("#trackClickThrough", () => {
-  function subject({ initialState } = {}, documentId, tags) {
-    const { driver, mockApiConnector } = setupDriver({ initialState });
+  function subject(
+    { initialState, alwaysSearchOnInitialLoad } = {},
+    documentId,
+    tags
+  ) {
+    const { driver, mockApiConnector } = setupDriver({
+      initialState,
+      alwaysSearchOnInitialLoad
+    });
     driver.trackClickThrough(documentId, tags);
     return { driver, mockApiConnector };
   }
@@ -14,7 +21,10 @@ describe("#trackClickThrough", () => {
 
   it("Calls Connector 'click' with correct parameters", () => {
     const { mockApiConnector } = subject(
-      { initialState: { searchTerm: "search terms" } },
+      {
+        initialState: { searchTerm: "search terms" },
+        alwaysSearchOnInitialLoad: true
+      },
       1,
       ["test"]
     );


### PR DESCRIPTION
## Description
When `alwaysSearchOnInitialLoad` is set to `true`, the `SearchDriver` will do an initial search, even if `searchTerm` and/or `filters` is empty.

## List of changes
- Added `alwaysSearchOnInitialLoad` to the config options of `SearchDriver` that defaults to false
- Added a check to the constructor of `SearchDriver`. The check is at the same place as the original `should we do an initial search is` (`SearchDriver.js` line 180)
- Added two tests to verify that `alwaysSearchOnInitialLoad` behaves as expected
- Added documentation for the option `alwaysSearchOnInitialLoad` to `ADVANCED.md`

## Associated Github Issues
#194 