### PR TITLE
Pass down downshift props to `InputView`

### DIFF
--- a/packages/react-search-ui-views/src/SearchBox.js
+++ b/packages/react-search-ui-views/src/SearchBox.js
@@ -107,6 +107,7 @@ function SearchBox(props) {
                     return null;
                   }
                 }}
+                {...downshiftProps}
               />
             </div>
           </form>

--- a/packages/react-search-ui-views/src/SearchBox.js
+++ b/packages/react-search-ui-views/src/SearchBox.js
@@ -71,6 +71,7 @@ function SearchBox(props) {
               }
             >
               <InputView
+                {...downshiftProps}
                 getInputProps={additionalProps => {
                   const { className, ...rest } = additionalProps || {};
                   return getInputProps({
@@ -107,7 +108,6 @@ function SearchBox(props) {
                     return null;
                   }
                 }}
-                {...downshiftProps}
               />
             </div>
           </form>

--- a/packages/react-search-ui-views/src/__tests__/SearchBox.test.js
+++ b/packages/react-search-ui-views/src/__tests__/SearchBox.test.js
@@ -29,11 +29,24 @@ it("applies 'focused' class when `isFocused` is true", () => {
   expect(input.hasClass("focus")).toBe(true);
 });
 
+it("passes through downshiftProps", () => {
+  const wrapper = shallow(
+    <SearchBox {...requiredProps} inputProps={{ placeholder: "test" }} />
+  );
+  const SearchInput = wrapper.dive("Downshift").find("SearchInput");
+  expect(SearchInput.props().clearSelection).toBeInstanceOf(Function);
+});
+
 it("passes through inputProps", () => {
   const wrapper = shallow(
     <SearchBox {...requiredProps} inputProps={{ placeholder: "test" }} />
   );
-  expect(wrapper).toMatchSnapshot();
+  const downshift = wrapper
+    .dive("Downshift")
+    .find("SearchInput")
+    .shallow();
+  const input = downshift.find(".sui-search-box__text-input");
+  expect(input.props().placeholder).toBe("test");
 });
 
 it("renders with className prop applied", () => {

--- a/packages/react-search-ui-views/src/__tests__/__snapshots__/SearchBox.test.js.snap
+++ b/packages/react-search-ui-views/src/__tests__/__snapshots__/SearchBox.test.js.snap
@@ -1,28 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`passes through inputProps 1`] = `
-<Downshift
-  defaultHighlightedIndex={null}
-  defaultIsOpen={false}
-  environment={[Window]}
-  getA11yStatusMessage={[Function]}
-  inputValue="test"
-  itemToString={[Function]}
-  onChange={[Function]}
-  onInputValueChange={[Function]}
-  onOuterClick={[Function]}
-  onSelect={[Function]}
-  onStateChange={[Function]}
-  onUserAction={[Function]}
-  scrollIntoView={[Function]}
-  selectedItemChanged={[Function]}
-  stateReducer={[Function]}
-  suppressRefError={false}
->
-  <Component />
-</Downshift>
-`;
-
 exports[`renders correctly 1`] = `
 <Downshift
   defaultHighlightedIndex={null}


### PR DESCRIPTION
## Description

This allows us to add a button in our custom `InputView` which calls `clearSelection`:

https://github.com/downshift-js/downshift#actions

## List of changes

Pass down `downshiftProps` to `InputView`.

## Associated Github Issues

None
