### PR TITLE
Bugfix: Fix SS console warning when no tags

### DIFF
--- a/packages/search-ui-site-search-connector/src/SiteSearchAPIConnector.js
+++ b/packages/search-ui-site-search-connector/src/SiteSearchAPIConnector.js
@@ -65,7 +65,7 @@ class SiteSearchAPIConnector {
   }
 
   onResultClick({ query, documentId, tags }) {
-    if (tags) {
+    if (tags && tags.length > 0) {
       console.warn(
         "search-ui-site-search-connector: Site Search does not support tags on click"
       );


### PR DESCRIPTION
## Description

In the SiteSearchAPIConnector, we were warning users not to use tags
for click through tagging, even though it was not actually in use.

This was due to a simple truthy check. Since tags are an array, the
check was passing. We are now checking length.

## Associated Github Issues

Fixes #405
