### PR TITLE
Facet fix

### DIFF
--- a/packages/react-search-ui-views/package.json
+++ b/packages/react-search-ui-views/package.json
@@ -74,7 +74,6 @@
   "dependencies": {
     "@babel/runtime": "^7.5.4",
     "autoprefixer": "^9.6.1",
-    "deep-equal": "^1.0.1",
     "downshift": "^3.2.10",
     "rc-pagination": "^1.20.1",
     "react-select": "^2.4.4"

--- a/packages/react-search-ui-views/src/MultiCheckboxFacet.js
+++ b/packages/react-search-ui-views/src/MultiCheckboxFacet.js
@@ -1,26 +1,17 @@
 import PropTypes from "prop-types";
 import React from "react";
 
-import { FacetValue, FilterValue } from "./types";
+import { FacetValue } from "./types";
 import { appendClassName, getFilterValueDisplay } from "./view-helpers";
-
-function getIsChecked(doFilterValuesMatch, values, option) {
-  const foundValue = values.find(value =>
-    doFilterValuesMatch(option.value, value)
-  );
-  return typeof foundValue !== "undefined" && foundValue !== null;
-}
 
 function MultiCheckboxFacet({
   className,
-  doFilterValuesMatch,
   label,
   onMoreClick,
   onRemove,
   onSelect,
   options,
   showMore,
-  values,
   showSearch,
   onSearch,
   searchPlaceholder
@@ -45,7 +36,7 @@ function MultiCheckboxFacet({
       <div className="sui-multi-checkbox-facet">
         {options.length < 1 && <div>No matching options</div>}
         {options.map(option => {
-          const checked = getIsChecked(doFilterValuesMatch, values, option);
+          const checked = option.selected;
           return (
             <label
               key={`${getFilterValueDisplay(option.value)}`}
@@ -93,7 +84,6 @@ function MultiCheckboxFacet({
 }
 
 MultiCheckboxFacet.propTypes = {
-  doFilterValuesMatch: PropTypes.func.isRequired,
   label: PropTypes.string.isRequired,
   onMoreClick: PropTypes.func.isRequired,
   onRemove: PropTypes.func.isRequired,
@@ -101,7 +91,6 @@ MultiCheckboxFacet.propTypes = {
   onSearch: PropTypes.func.isRequired,
   options: PropTypes.arrayOf(FacetValue).isRequired,
   showMore: PropTypes.bool.isRequired,
-  values: PropTypes.arrayOf(FilterValue).isRequired,
   className: PropTypes.string,
   showSearch: PropTypes.bool,
   searchPlaceholder: PropTypes.string

--- a/packages/react-search-ui-views/src/MultiCheckboxFacet.js
+++ b/packages/react-search-ui-views/src/MultiCheckboxFacet.js
@@ -5,6 +5,14 @@ import deepEqual from "deep-equal";
 import { FacetValue, FilterValue } from "./types";
 import { appendClassName, getFilterValueDisplay } from "./view-helpers";
 
+function getIsChecked(values, option) {
+  const foundValue = values.find(value => {
+    if (value && value.name && option.value.name === value.name) return true;
+    return deepEqual(option.value, value, { strict: true });
+  });
+  return typeof foundValue !== "undefined" && foundValue !== null;
+}
+
 function MultiCheckboxFacet({
   className,
   label,
@@ -38,12 +46,7 @@ function MultiCheckboxFacet({
       <div className="sui-multi-checkbox-facet">
         {options.length < 1 && <div>No matching options</div>}
         {options.map(option => {
-          const checked = !!values.find(value => {
-            if (value && value.name && option.value.name === value.name)
-              return true;
-            if (deepEqual(option.value, value)) return true;
-            return false;
-          });
+          const checked = getIsChecked(values, option);
           return (
             <label
               key={`${getFilterValueDisplay(option.value)}`}

--- a/packages/react-search-ui-views/src/MultiCheckboxFacet.js
+++ b/packages/react-search-ui-views/src/MultiCheckboxFacet.js
@@ -1,20 +1,19 @@
 import PropTypes from "prop-types";
 import React from "react";
-import deepEqual from "deep-equal";
 
 import { FacetValue, FilterValue } from "./types";
 import { appendClassName, getFilterValueDisplay } from "./view-helpers";
 
-function getIsChecked(values, option) {
-  const foundValue = values.find(value => {
-    if (value && value.name && option.value.name === value.name) return true;
-    return deepEqual(option.value, value, { strict: true });
-  });
+function getIsChecked(doFilterValuesMatch, values, option) {
+  const foundValue = values.find(value =>
+    doFilterValuesMatch(option.value, value)
+  );
   return typeof foundValue !== "undefined" && foundValue !== null;
 }
 
 function MultiCheckboxFacet({
   className,
+  doFilterValuesMatch,
   label,
   onMoreClick,
   onRemove,
@@ -46,7 +45,7 @@ function MultiCheckboxFacet({
       <div className="sui-multi-checkbox-facet">
         {options.length < 1 && <div>No matching options</div>}
         {options.map(option => {
-          const checked = getIsChecked(values, option);
+          const checked = getIsChecked(doFilterValuesMatch, values, option);
           return (
             <label
               key={`${getFilterValueDisplay(option.value)}`}
@@ -94,6 +93,7 @@ function MultiCheckboxFacet({
 }
 
 MultiCheckboxFacet.propTypes = {
+  doFilterValuesMatch: PropTypes.func.isRequired,
   label: PropTypes.string.isRequired,
   onMoreClick: PropTypes.func.isRequired,
   onRemove: PropTypes.func.isRequired,

--- a/packages/react-search-ui-views/src/SingleLinksFacet.js
+++ b/packages/react-search-ui-views/src/SingleLinksFacet.js
@@ -1,19 +1,12 @@
 import PropTypes from "prop-types";
 import React from "react";
 
-import { FacetValue, FilterValue } from "./types";
+import { FacetValue } from "./types";
 import { getFilterValueDisplay } from "./view-helpers";
 import { appendClassName } from "./view-helpers";
 
-function SingleLinksFacet({
-  className,
-  label,
-  onRemove,
-  onSelect,
-  options,
-  values = []
-}) {
-  const value = values[0];
+function SingleLinksFacet({ className, label, onRemove, onSelect, options }) {
+  const value = options.filter(o => o.selected).map(o => o.value)[0];
   return (
     <div className={appendClassName("sui-facet", className)}>
       <div>
@@ -67,7 +60,6 @@ SingleLinksFacet.propTypes = {
   onRemove: PropTypes.func.isRequired,
   onSelect: PropTypes.func.isRequired,
   options: PropTypes.arrayOf(FacetValue).isRequired,
-  values: PropTypes.arrayOf(FilterValue).isRequired,
   className: PropTypes.string
 };
 

--- a/packages/react-search-ui-views/src/SingleSelectFacet.js
+++ b/packages/react-search-ui-views/src/SingleSelectFacet.js
@@ -1,7 +1,6 @@
 import PropTypes from "prop-types";
 import React from "react";
 import Select, { components } from "react-select";
-import deepEqual from "deep-equal";
 
 import { FacetValue, FilterValue } from "./types";
 import { getFilterValueDisplay } from "./view-helpers";
@@ -37,18 +36,18 @@ const setDefaultStyle = {
   indicatorSeparator: () => ({})
 };
 
-function SingleSelectFacet({ className, label, onChange, options, values }) {
+function SingleSelectFacet({
+  className,
+  doFilterValuesMatch,
+  label,
+  onChange,
+  options,
+  values
+}) {
   const selectOptions = options.map(toSelectOption);
   const selectedFilterValue = values[0];
   const selectedOption = selectOptions.find(option => {
-    if (
-      selectedFilterValue &&
-      selectedFilterValue.name &&
-      option.value.name === selectedFilterValue.name
-    )
-      return true;
-    if (deepEqual(option.value, selectedFilterValue)) return true;
-    return false;
+    return doFilterValuesMatch(option.value, selectedFilterValue);
   });
 
   return (
@@ -69,6 +68,7 @@ function SingleSelectFacet({ className, label, onChange, options, values }) {
 }
 
 SingleSelectFacet.propTypes = {
+  doFilterValuesMatch: PropTypes.func.isRequired,
   label: PropTypes.string.isRequired,
   onChange: PropTypes.func.isRequired,
   options: PropTypes.arrayOf(FacetValue).isRequired,

--- a/packages/react-search-ui-views/src/SingleSelectFacet.js
+++ b/packages/react-search-ui-views/src/SingleSelectFacet.js
@@ -21,7 +21,7 @@ Option.propTypes = {
   data: PropTypes.object.isRequired
 };
 
-function toSelectOption(filterValue) {
+function toSelectBoxOption(filterValue) {
   return {
     value: filterValue.value,
     label: getFilterValueDisplay(filterValue.value),
@@ -37,18 +37,18 @@ const setDefaultStyle = {
 };
 
 function SingleSelectFacet({ className, label, onChange, options }) {
-  let selectedOption;
-  let selectOptionSet = false;
+  let selectedSelectBoxOption;
+  let isSelectedSelectBoxOptionSet = false;
 
-  const selectOptions = options.map(option => {
-    const selectOption = toSelectOption(option);
+  const selectBoxOptions = options.map(option => {
+    const selectBoxOption = toSelectBoxOption(option);
     // There should never be multiple filters set for this facet because it is single select,
     // but if there is, we use the first value.
-    if (option.selected && !selectOptionSet) {
-      selectedOption = selectOption;
-      selectOptionSet = true;
+    if (option.selected && !isSelectedSelectBoxOptionSet) {
+      selectedSelectBoxOption = selectBoxOption;
+      isSelectedSelectBoxOptionSet = true;
     }
-    return selectOption;
+    return selectBoxOption;
   });
 
   return (
@@ -58,9 +58,9 @@ function SingleSelectFacet({ className, label, onChange, options }) {
         className="sui-select"
         classNamePrefix="sui-select"
         components={{ Option }}
-        value={selectedOption}
+        value={selectedSelectBoxOption}
         onChange={o => onChange(o.value)}
-        options={selectOptions}
+        options={selectBoxOptions}
         isSearchable={false}
         styles={setDefaultStyle}
       />

--- a/packages/react-search-ui-views/src/SingleSelectFacet.js
+++ b/packages/react-search-ui-views/src/SingleSelectFacet.js
@@ -2,7 +2,7 @@ import PropTypes from "prop-types";
 import React from "react";
 import Select, { components } from "react-select";
 
-import { FacetValue, FilterValue } from "./types";
+import { FacetValue } from "./types";
 import { getFilterValueDisplay } from "./view-helpers";
 import { appendClassName } from "./view-helpers";
 
@@ -36,18 +36,19 @@ const setDefaultStyle = {
   indicatorSeparator: () => ({})
 };
 
-function SingleSelectFacet({
-  className,
-  doFilterValuesMatch,
-  label,
-  onChange,
-  options,
-  values
-}) {
-  const selectOptions = options.map(toSelectOption);
-  const selectedFilterValue = values[0];
-  const selectedOption = selectOptions.find(option => {
-    return doFilterValuesMatch(option.value, selectedFilterValue);
+function SingleSelectFacet({ className, label, onChange, options }) {
+  let selectedOption;
+  let selectOptionSet = false;
+
+  const selectOptions = options.map(option => {
+    const selectOption = toSelectOption(option);
+    // There should never be multiple filters set for this facet because it is single select,
+    // but if there is, we use the first value.
+    if (option.selected && !selectOptionSet) {
+      selectedOption = selectOption;
+      selectOptionSet = true;
+    }
+    return selectOption;
   });
 
   return (
@@ -68,11 +69,9 @@ function SingleSelectFacet({
 }
 
 SingleSelectFacet.propTypes = {
-  doFilterValuesMatch: PropTypes.func.isRequired,
   label: PropTypes.string.isRequired,
   onChange: PropTypes.func.isRequired,
   options: PropTypes.arrayOf(FacetValue).isRequired,
-  values: PropTypes.arrayOf(FilterValue).isRequired,
   className: PropTypes.string
 };
 

--- a/packages/react-search-ui-views/src/__tests__/MultiCheckboxFacet.test.js
+++ b/packages/react-search-ui-views/src/__tests__/MultiCheckboxFacet.test.js
@@ -2,31 +2,26 @@ import React from "react";
 import MultiCheckboxFacet from "../MultiCheckboxFacet";
 import { shallow } from "enzyme";
 
-function getParams() {
-  return {
-    label: "A Facet",
-    doFilterValuesMatch: jest
-      .fn()
-      .mockReturnValueOnce(false)
-      .mockReturnValueOnce(true),
-    onMoreClick: jest.fn(),
-    onRemove: jest.fn(),
-    onSelect: jest.fn(),
-    onSearch: jest.fn(),
-    options: [
-      {
-        value: "fieldValue1",
-        count: 10
-      },
-      {
-        value: "fieldValue2",
-        count: 5
-      }
-    ],
-    showMore: true,
-    values: ["fieldValue2"]
-  };
-}
+const params = {
+  label: "A Facet",
+  onMoreClick: jest.fn(),
+  onRemove: jest.fn(),
+  onSelect: jest.fn(),
+  onSearch: jest.fn(),
+  options: [
+    {
+      value: "fieldValue1",
+      count: 10,
+      selected: false
+    },
+    {
+      value: "fieldValue2",
+      count: 5,
+      selected: true
+    }
+  ],
+  showMore: true
+};
 
 const rangeOptions = [
   {
@@ -48,13 +43,13 @@ const rangeOptions = [
 ];
 
 it("renders", () => {
-  const wrapper = shallow(<MultiCheckboxFacet {...getParams()} />);
+  const wrapper = shallow(<MultiCheckboxFacet {...params} />);
   expect(wrapper).toMatchSnapshot();
 });
 
 it("renders range filters", () => {
   const wrapper = shallow(
-    <MultiCheckboxFacet {...getParams()} option={rangeOptions} />
+    <MultiCheckboxFacet {...params} option={rangeOptions} />
   );
   expect(wrapper).toMatchSnapshot();
 });
@@ -63,7 +58,7 @@ it("will render 'more' button if more param is true", () => {
   const wrapper = shallow(
     <MultiCheckboxFacet
       {...{
-        ...getParams(),
+        ...params,
         showMore: true
       }}
     />
@@ -75,7 +70,7 @@ it("will render a no results message is no options are available", () => {
   const wrapper = shallow(
     <MultiCheckboxFacet
       {...{
-        ...getParams(),
+        ...params,
         options: []
       }}
     />
@@ -89,7 +84,7 @@ it("won't render 'more' button if more param is false", () => {
   const wrapper = shallow(
     <MultiCheckboxFacet
       {...{
-        ...getParams(),
+        ...params,
         showMore: false
       }}
     />
@@ -97,9 +92,9 @@ it("won't render 'more' button if more param is false", () => {
   expect(wrapper.find(".sui-multi-checkbox-facet__view-more")).toHaveLength(0);
 });
 
-describe("determining selected option from values", () => {
-  it("will correctly determine which of the options is selected based on the provided value", () => {
-    const wrapper = shallow(<MultiCheckboxFacet {...getParams()} />);
+describe("determining selected option", () => {
+  it("will correctly determine which of the options is selected", () => {
+    const wrapper = shallow(<MultiCheckboxFacet {...params} />);
     expect(
       wrapper
         .find("input")
@@ -119,7 +114,7 @@ describe("determining selected option from values", () => {
 it("renders with className prop applied", () => {
   const customClassName = "test-class";
   const wrapper = shallow(
-    <MultiCheckboxFacet className={customClassName} {...getParams()} />
+    <MultiCheckboxFacet className={customClassName} {...params} />
   );
   const { className } = wrapper.props();
   expect(className).toEqual("sui-facet test-class");
@@ -129,7 +124,7 @@ it("will render search input if `showSearch` param is true", () => {
   const wrapper = shallow(
     <MultiCheckboxFacet
       {...{
-        ...getParams(),
+        ...params,
         showSearch: true
       }}
     />
@@ -142,7 +137,7 @@ it("won't render search input if `showSearch` param is false", () => {
   const wrapper = shallow(
     <MultiCheckboxFacet
       {...{
-        ...getParams(),
+        ...params,
         showSearch: false
       }}
     />
@@ -156,7 +151,7 @@ it("should use the `searchPlaceholder` param as a search input placeholder", () 
   const wrapper = shallow(
     <MultiCheckboxFacet
       {...{
-        ...getParams(),
+        ...params,
         showSearch: true,
         searchPlaceholder
       }}

--- a/packages/react-search-ui-views/src/__tests__/MultiCheckboxFacet.test.js
+++ b/packages/react-search-ui-views/src/__tests__/MultiCheckboxFacet.test.js
@@ -2,25 +2,31 @@ import React from "react";
 import MultiCheckboxFacet from "../MultiCheckboxFacet";
 import { shallow } from "enzyme";
 
-const params = {
-  label: "A Facet",
-  onMoreClick: jest.fn(),
-  onRemove: jest.fn(),
-  onSelect: jest.fn(),
-  onSearch: jest.fn(),
-  options: [
-    {
-      value: "fieldValue1",
-      count: 10
-    },
-    {
-      value: "fieldValue2",
-      count: 5
-    }
-  ],
-  showMore: true,
-  values: ["fieldValue2"]
-};
+function getParams() {
+  return {
+    label: "A Facet",
+    doFilterValuesMatch: jest
+      .fn()
+      .mockReturnValueOnce(false)
+      .mockReturnValueOnce(true),
+    onMoreClick: jest.fn(),
+    onRemove: jest.fn(),
+    onSelect: jest.fn(),
+    onSearch: jest.fn(),
+    options: [
+      {
+        value: "fieldValue1",
+        count: 10
+      },
+      {
+        value: "fieldValue2",
+        count: 5
+      }
+    ],
+    showMore: true,
+    values: ["fieldValue2"]
+  };
+}
 
 const rangeOptions = [
   {
@@ -41,31 +47,14 @@ const rangeOptions = [
   }
 ];
 
-const rangeOptionsTimeBased = [
-  {
-    count: 1,
-    value: {
-      from: new Date().getTime() - 1000,
-      name: "1000 ms ago"
-    }
-  },
-  {
-    count: 11,
-    value: {
-      from: new Date().getTime() - 10000,
-      name: "10000 ms ago"
-    }
-  }
-];
-
 it("renders", () => {
-  const wrapper = shallow(<MultiCheckboxFacet {...params} />);
+  const wrapper = shallow(<MultiCheckboxFacet {...getParams()} />);
   expect(wrapper).toMatchSnapshot();
 });
 
 it("renders range filters", () => {
   const wrapper = shallow(
-    <MultiCheckboxFacet {...params} option={rangeOptions} />
+    <MultiCheckboxFacet {...getParams()} option={rangeOptions} />
   );
   expect(wrapper).toMatchSnapshot();
 });
@@ -74,7 +63,7 @@ it("will render 'more' button if more param is true", () => {
   const wrapper = shallow(
     <MultiCheckboxFacet
       {...{
-        ...params,
+        ...getParams(),
         showMore: true
       }}
     />
@@ -86,7 +75,7 @@ it("will render a no results message is no options are available", () => {
   const wrapper = shallow(
     <MultiCheckboxFacet
       {...{
-        ...params,
+        ...getParams(),
         options: []
       }}
     />
@@ -100,7 +89,7 @@ it("won't render 'more' button if more param is false", () => {
   const wrapper = shallow(
     <MultiCheckboxFacet
       {...{
-        ...params,
+        ...getParams(),
         showMore: false
       }}
     />
@@ -110,7 +99,7 @@ it("won't render 'more' button if more param is false", () => {
 
 describe("determining selected option from values", () => {
   it("will correctly determine which of the options is selected based on the provided value", () => {
-    const wrapper = shallow(<MultiCheckboxFacet {...params} />);
+    const wrapper = shallow(<MultiCheckboxFacet {...getParams()} />);
     expect(
       wrapper
         .find("input")
@@ -124,185 +113,13 @@ describe("determining selected option from values", () => {
         .at(1)
         .prop("checked")
     ).toBe(true);
-  });
-
-  it("will correctly determine which of the options when the provided value is an empty string", () => {
-    const updatedParams = {
-      ...params,
-      options: [
-        {
-          value: "fieldValue1",
-          count: 10
-        },
-        {
-          value: "",
-          count: 5
-        }
-      ],
-      values: [""]
-    };
-    const wrapper = shallow(<MultiCheckboxFacet {...updatedParams} />);
-    expect(
-      wrapper
-        .find("input")
-        .at(0)
-        .prop("checked")
-    ).toBe(false);
-
-    expect(
-      wrapper
-        .find("input")
-        .at(1)
-        .prop("checked")
-    ).toBe(true);
-  });
-
-  it("will correctly determine which of the options when the provided value is 0", () => {
-    const updatedParams = {
-      ...params,
-      options: [
-        {
-          value: "fieldValue1",
-          count: 10
-        },
-        {
-          value: 0,
-          count: 5
-        }
-      ],
-      values: [0]
-    };
-    const wrapper = shallow(<MultiCheckboxFacet {...updatedParams} />);
-    expect(
-      wrapper
-        .find("input")
-        .at(0)
-        .prop("checked")
-    ).toBe(false);
-
-    expect(
-      wrapper
-        .find("input")
-        .at(1)
-        .prop("checked")
-    ).toBe(true);
-  });
-
-  it("will correctly determine when no value is selected", () => {
-    const wrapper = shallow(<MultiCheckboxFacet {...params} values={[]} />);
-
-    expect(
-      wrapper
-        .find("input")
-        .at(0)
-        .prop("checked")
-    ).toBe(false);
-
-    expect(
-      wrapper
-        .find("input")
-        .at(1)
-        .prop("checked")
-    ).toBe(false);
-  });
-
-  it("will correctly determine which of the options is selected when using range filters", () => {
-    const wrapper = shallow(
-      <MultiCheckboxFacet
-        {...params}
-        options={rangeOptions}
-        values={[
-          {
-            from: 1,
-            to: 10,
-            name: "The first option"
-          }
-        ]}
-      />
-    );
-
-    expect(
-      wrapper
-        .find("input")
-        .at(0)
-        .prop("checked")
-    ).toBe(true);
-
-    expect(
-      wrapper
-        .find("input")
-        .at(1)
-        .prop("checked")
-    ).toBe(false);
-  });
-
-  it("will correctly determine which of the options is selected when using range filters and only the name matches", () => {
-    const wrapper = shallow(
-      <MultiCheckboxFacet
-        {...params}
-        options={rangeOptionsTimeBased}
-        values={[
-          {
-            // A time range filter that was applied based on the current time 20 seconds ago, will not have
-            // the same "from" value as a facet that is calculated at the current time. However, we can still
-            // make a match based on the "name" of the values.
-            from: new Date().getTime() - 1000,
-            name: "1000 ms ago"
-          }
-        ]}
-      />
-    );
-
-    expect(
-      wrapper
-        .find("input")
-        .at(0)
-        .prop("checked")
-    ).toBe(true);
-
-    expect(
-      wrapper
-        .find("input")
-        .at(1)
-        .prop("checked")
-    ).toBe(false);
-  });
-
-  it("will correctly determine which of the options is selected even if the provided value has differently ordered props", () => {
-    const wrapper = shallow(
-      <MultiCheckboxFacet
-        {...params}
-        options={rangeOptions}
-        values={[
-          {
-            to: 10, // Reversed
-            from: 1, // Reversed
-            name: "The first option"
-          }
-        ]}
-      />
-    );
-
-    expect(
-      wrapper
-        .find("input")
-        .at(0)
-        .prop("checked")
-    ).toBe(true);
-
-    expect(
-      wrapper
-        .find("input")
-        .at(1)
-        .prop("checked")
-    ).toBe(false);
   });
 });
 
 it("renders with className prop applied", () => {
   const customClassName = "test-class";
   const wrapper = shallow(
-    <MultiCheckboxFacet className={customClassName} {...params} />
+    <MultiCheckboxFacet className={customClassName} {...getParams()} />
   );
   const { className } = wrapper.props();
   expect(className).toEqual("sui-facet test-class");
@@ -312,7 +129,7 @@ it("will render search input if `showSearch` param is true", () => {
   const wrapper = shallow(
     <MultiCheckboxFacet
       {...{
-        ...params,
+        ...getParams(),
         showSearch: true
       }}
     />
@@ -325,7 +142,7 @@ it("won't render search input if `showSearch` param is false", () => {
   const wrapper = shallow(
     <MultiCheckboxFacet
       {...{
-        ...params,
+        ...getParams(),
         showSearch: false
       }}
     />
@@ -339,7 +156,7 @@ it("should use the `searchPlaceholder` param as a search input placeholder", () 
   const wrapper = shallow(
     <MultiCheckboxFacet
       {...{
-        ...params,
+        ...getParams(),
         showSearch: true,
         searchPlaceholder
       }}

--- a/packages/react-search-ui-views/src/__tests__/MultiCheckboxFacet.test.js
+++ b/packages/react-search-ui-views/src/__tests__/MultiCheckboxFacet.test.js
@@ -126,6 +126,68 @@ describe("determining selected option from values", () => {
     ).toBe(true);
   });
 
+  it("will correctly determine which of the options when the provided value is an empty string", () => {
+    const updatedParams = {
+      ...params,
+      options: [
+        {
+          value: "fieldValue1",
+          count: 10
+        },
+        {
+          value: "",
+          count: 5
+        }
+      ],
+      values: [""]
+    };
+    const wrapper = shallow(<MultiCheckboxFacet {...updatedParams} />);
+    expect(
+      wrapper
+        .find("input")
+        .at(0)
+        .prop("checked")
+    ).toBe(false);
+
+    expect(
+      wrapper
+        .find("input")
+        .at(1)
+        .prop("checked")
+    ).toBe(true);
+  });
+
+  it("will correctly determine which of the options when the provided value is 0", () => {
+    const updatedParams = {
+      ...params,
+      options: [
+        {
+          value: "fieldValue1",
+          count: 10
+        },
+        {
+          value: 0,
+          count: 5
+        }
+      ],
+      values: [0]
+    };
+    const wrapper = shallow(<MultiCheckboxFacet {...updatedParams} />);
+    expect(
+      wrapper
+        .find("input")
+        .at(0)
+        .prop("checked")
+    ).toBe(false);
+
+    expect(
+      wrapper
+        .find("input")
+        .at(1)
+        .prop("checked")
+    ).toBe(true);
+  });
+
   it("will correctly determine when no value is selected", () => {
     const wrapper = shallow(<MultiCheckboxFacet {...params} values={[]} />);
 

--- a/packages/react-search-ui-views/src/__tests__/SingleLinksFacet.test.js
+++ b/packages/react-search-ui-views/src/__tests__/SingleLinksFacet.test.js
@@ -6,80 +6,58 @@ const params = {
   label: "Facet",
   onRemove: () => {},
   onSelect: () => {},
-  options: [{ value: "1", count: 1 }, { value: "2", count: 1 }],
-  values: []
+  options: [
+    { value: "1", count: 1, selected: false },
+    { value: "2", count: 1, selected: false }
+  ]
 };
-
-const rangeOptions = [
-  {
-    count: 1,
-    value: {
-      from: 1,
-      to: 10,
-      name: "The first option"
-    }
-  },
-  {
-    count: 11,
-    value: {
-      from: 11,
-      to: 20,
-      name: "The second option"
-    }
-  }
-];
 
 it("renders correctly", () => {
   const wrapper = shallow(<SingleLinksFacet {...params} />);
   expect(wrapper).toMatchSnapshot();
 });
 
-describe("determining selected option from values", () => {
-  it("will correctly determine which of the options is selected based on the provided value", () => {
-    const wrapper = shallow(<SingleLinksFacet {...params} values={["1"]} />);
+describe("determining selected option", () => {
+  it("will correctly determine which of the options is selected", () => {
+    const wrapper = shallow(
+      <SingleLinksFacet
+        {...params}
+        options={[
+          { value: "1", count: 1, selected: true },
+          { value: "2", count: 1, selected: false }
+        ]}
+      />
+    );
+    expect(wrapper.find("li").length).toBe(1);
+    expect(wrapper.find("li").text()).toBe("1 (Remove)");
+  });
+
+  // This shouldn't ever happen, but if it does, it should use the first selected value
+  it("will used the first selected option when multiple options are selected", () => {
+    const wrapper = shallow(
+      <SingleLinksFacet
+        {...params}
+        options={[
+          { value: "1", count: 1, selected: true },
+          { value: "2", count: 1, selected: true }
+        ]}
+      />
+    );
     expect(wrapper.find("li").length).toBe(1);
     expect(wrapper.find("li").text()).toBe("1 (Remove)");
   });
 
   it("will correctly determine when no value is selected", () => {
-    const wrapper = shallow(<SingleLinksFacet {...params} />);
+    const wrapper = shallow(
+      <SingleLinksFacet
+        {...params}
+        options={[
+          { value: "1", count: 1, selected: false },
+          { value: "2", count: 1, selected: false }
+        ]}
+      />
+    );
     expect(wrapper.find("li").length).toBe(2);
-  });
-
-  it("will correctly determine which of the options is selected when using range filters", () => {
-    const wrapper = shallow(
-      <SingleLinksFacet
-        {...params}
-        options={rangeOptions}
-        values={[
-          {
-            from: 1,
-            to: 10,
-            name: "The first option"
-          }
-        ]}
-      />
-    );
-    expect(wrapper.find("li").length).toBe(1);
-    expect(wrapper.find("li").text()).toBe("The first option (Remove)");
-  });
-
-  it("will correctly determine which of the options is selected even if the provided value has differently ordered props", () => {
-    const wrapper = shallow(
-      <SingleLinksFacet
-        {...params}
-        options={rangeOptions}
-        values={[
-          {
-            to: 10, // Reversed
-            from: 1, // Reversed
-            name: "The first option"
-          }
-        ]}
-      />
-    );
-    expect(wrapper.find("li").length).toBe(1);
-    expect(wrapper.find("li").text()).toBe("The first option (Remove)");
   });
 });
 

--- a/packages/react-search-ui-views/src/__tests__/SingleSelectFacet.test.js
+++ b/packages/react-search-ui-views/src/__tests__/SingleSelectFacet.test.js
@@ -13,121 +13,70 @@ const valueFacetOptions = [
   }
 ];
 
-const params = {
-  label: "A Facet",
-  onChange: jest.fn(),
-  options: [
-    {
-      count: 20,
-      value: {
+function getParams() {
+  return {
+    label: "A Facet",
+    doFilterValuesMatch: jest
+      .fn()
+      .mockReturnValueOnce(false)
+      .mockReturnValueOnce(true),
+    onChange: jest.fn(),
+    options: [
+      {
+        count: 20,
+        value: {
+          from: 1,
+          to: 10,
+          name: "Range 1"
+        }
+      },
+      {
+        count: 10,
+        value: {
+          to: 20,
+          from: 11,
+          name: "Range 2"
+        }
+      }
+    ],
+    values: [
+      {
         from: 1,
         to: 10,
-        name: "Range 1"
-      }
-    },
-    {
-      count: 10,
-      value: {
-        to: 20,
-        from: 11,
         name: "Range 2"
       }
-    }
-  ],
-  values: [
-    {
-      from: 1,
-      to: 10,
-      name: "Range 1"
-    }
-  ]
-};
+    ]
+  };
+}
 
 it("renders", () => {
-  const wrapper = shallow(<SingleSelectFacet {...params} />);
+  const wrapper = shallow(<SingleSelectFacet {...getParams()} />);
   expect(wrapper).toMatchSnapshot();
 });
 
 describe("determining selected option from values", () => {
   it("will correctly determine which of the options is selected based on the provided value", () => {
-    const wrapper = render(<SingleSelectFacet {...params} />);
-    expect(wrapper.find(".sui-select__single-value").text()).toEqual("Range 1");
-  });
-
-  it("will correctly determine which of the options is selected even if the provided value has differently ordered props", () => {
-    const wrapper = render(
-      <SingleSelectFacet
-        {...params}
-        values={[
-          {
-            to: 10, // Reversed
-            from: 1, // Reversed
-            name: "Range 1"
-          }
-        ]}
-      />
-    );
-    expect(wrapper.find(".sui-select__single-value").text()).toEqual("Range 1");
-  });
-
-  it("will correctly determine which of the options is selected when using value filters", () => {
-    const wrapper = render(
-      <SingleSelectFacet
-        {...params}
-        options={valueFacetOptions}
-        values={["Pennsylvania"]}
-      />
-    );
-    expect(wrapper.find(".sui-select__single-value").text()).toEqual(
-      "Pennsylvania"
-    );
+    const wrapper = render(<SingleSelectFacet {...getParams()} />);
+    expect(wrapper.find(".sui-select__single-value").text()).toEqual("Range 2");
   });
 
   it("will correctly determine when no value is selected", () => {
     const wrapper = render(
-      <SingleSelectFacet {...params} options={valueFacetOptions} values={[]} />
-    );
-    expect(wrapper.find(".sui-select__single-value").text()).toEqual("");
-  });
-
-  it("will correctly determine when when using range filters and only the name matches", () => {
-    const wrapper = render(
       <SingleSelectFacet
-        {...params}
-        options={[
-          {
-            count: 1,
-            value: {
-              from: new Date().getTime() - 1000,
-              name: "1000 ms ago"
-            }
-          },
-          {
-            count: 11,
-            value: {
-              from: new Date().getTime() - 10000,
-              name: "10000 ms ago"
-            }
-          }
-        ]}
-        values={[
-          {
-            from: new Date().getTime() - 1000,
-            name: "1000 ms ago"
-          }
-        ]}
+        {...getParams()}
+        doFilterValuesMatch={jest.fn().mockReturnValue(false)}
+        options={valueFacetOptions}
+        values={[]}
       />
     );
-    expect(wrapper.find(".sui-select__single-value").text()).toEqual(
-      "1000 ms ago"
-    );
+    expect(wrapper.find(".sui-select__single-value").text()).toEqual("");
   });
 });
 
 it("renders with className prop applied", () => {
   const customClassName = "test-class";
   const wrapper = shallow(
-    <SingleSelectFacet {...params} className={customClassName} />
+    <SingleSelectFacet {...getParams()} className={customClassName} />
   );
   const { className } = wrapper.props();
   expect(className).toEqual("sui-facet test-class");

--- a/packages/react-search-ui-views/src/__tests__/SingleSelectFacet.test.js
+++ b/packages/react-search-ui-views/src/__tests__/SingleSelectFacet.test.js
@@ -2,71 +2,58 @@ import React from "react";
 import SingleSelectFacet from "../SingleSelectFacet";
 import { shallow, render } from "enzyme";
 
-const valueFacetOptions = [
-  {
-    count: 1,
-    value: "Pennsylvania"
-  },
-  {
-    count: 1,
-    value: "Georgia"
-  }
-];
-
-function getParams() {
-  return {
-    label: "A Facet",
-    doFilterValuesMatch: jest
-      .fn()
-      .mockReturnValueOnce(false)
-      .mockReturnValueOnce(true),
-    onChange: jest.fn(),
-    options: [
-      {
-        count: 20,
-        value: {
-          from: 1,
-          to: 10,
-          name: "Range 1"
-        }
-      },
-      {
-        count: 10,
-        value: {
-          to: 20,
-          from: 11,
-          name: "Range 2"
-        }
-      }
-    ],
-    values: [
-      {
+const params = {
+  label: "A Facet",
+  onChange: jest.fn(),
+  options: [
+    {
+      count: 20,
+      value: {
         from: 1,
         to: 10,
+        name: "Range 1"
+      },
+      selected: false
+    },
+    {
+      count: 10,
+      value: {
+        to: 20,
+        from: 11,
         name: "Range 2"
-      }
-    ]
-  };
-}
+      },
+      selected: true
+    }
+  ]
+};
 
 it("renders", () => {
-  const wrapper = shallow(<SingleSelectFacet {...getParams()} />);
+  const wrapper = shallow(<SingleSelectFacet {...params} />);
   expect(wrapper).toMatchSnapshot();
 });
 
-describe("determining selected option from values", () => {
-  it("will correctly determine which of the options is selected based on the provided value", () => {
-    const wrapper = render(<SingleSelectFacet {...getParams()} />);
+describe("determining selected option", () => {
+  it("will correctly determine which of the options is selected", () => {
+    const wrapper = render(<SingleSelectFacet {...params} />);
     expect(wrapper.find(".sui-select__single-value").text()).toEqual("Range 2");
+  });
+
+  // This shouldn't ever happen, but if it does, it should use the first selected value
+  it("will used the first selected option when multiple options are selected", () => {
+    const wrapper = render(
+      <SingleSelectFacet
+        {...params}
+        options={params.options.map(o => ({ ...o, selected: true }))}
+      />
+    );
+    expect(wrapper.find(".sui-select__single-value").text()).toEqual("Range 1");
   });
 
   it("will correctly determine when no value is selected", () => {
     const wrapper = render(
       <SingleSelectFacet
-        {...getParams()}
-        doFilterValuesMatch={jest.fn().mockReturnValue(false)}
-        options={valueFacetOptions}
-        values={[]}
+        {...params}
+        options={params.options.map(o => ({ ...o, selected: false }))}
       />
     );
     expect(wrapper.find(".sui-select__single-value").text()).toEqual("");
@@ -76,7 +63,7 @@ describe("determining selected option from values", () => {
 it("renders with className prop applied", () => {
   const customClassName = "test-class";
   const wrapper = shallow(
-    <SingleSelectFacet {...getParams()} className={customClassName} />
+    <SingleSelectFacet {...params} className={customClassName} />
   );
   const { className } = wrapper.props();
   expect(className).toEqual("sui-facet test-class");

--- a/packages/react-search-ui-views/src/__tests__/SingleSelectFacet.test.js
+++ b/packages/react-search-ui-views/src/__tests__/SingleSelectFacet.test.js
@@ -13,7 +13,7 @@ const params = {
         to: 10,
         name: "Range 1"
       },
-      selected: false
+      selected: true
     },
     {
       count: 10,
@@ -22,7 +22,7 @@ const params = {
         from: 11,
         name: "Range 2"
       },
-      selected: true
+      selected: false
     }
   ]
 };
@@ -35,7 +35,7 @@ it("renders", () => {
 describe("determining selected option", () => {
   it("will correctly determine which of the options is selected", () => {
     const wrapper = render(<SingleSelectFacet {...params} />);
-    expect(wrapper.find(".sui-select__single-value").text()).toEqual("Range 2");
+    expect(wrapper.find(".sui-select__single-value").text()).toEqual("Range 1");
   });
 
   // This shouldn't ever happen, but if it does, it should use the first selected value

--- a/packages/react-search-ui-views/src/__tests__/__snapshots__/SingleSelectFacet.test.js.snap
+++ b/packages/react-search-ui-views/src/__tests__/__snapshots__/SingleSelectFacet.test.js.snap
@@ -54,12 +54,12 @@ exports[`renders 1`] = `
     }
     value={
       Object {
-        "count": 10,
-        "label": "Range 2",
+        "count": 20,
+        "label": "Range 1",
         "value": Object {
-          "from": 11,
-          "name": "Range 2",
-          "to": 20,
+          "from": 1,
+          "name": "Range 1",
+          "to": 10,
         },
       }
     }

--- a/packages/react-search-ui-views/src/__tests__/__snapshots__/SingleSelectFacet.test.js.snap
+++ b/packages/react-search-ui-views/src/__tests__/__snapshots__/SingleSelectFacet.test.js.snap
@@ -54,12 +54,12 @@ exports[`renders 1`] = `
     }
     value={
       Object {
-        "count": 20,
-        "label": "Range 1",
+        "count": 10,
+        "label": "Range 2",
         "value": Object {
-          "from": 1,
-          "name": "Range 1",
-          "to": 10,
+          "from": 11,
+          "name": "Range 2",
+          "to": 20,
         },
       }
     }

--- a/packages/react-search-ui-views/src/types/FacetValue.js
+++ b/packages/react-search-ui-views/src/types/FacetValue.js
@@ -2,6 +2,10 @@ import PropTypes from "prop-types";
 import FilterValue from "./FilterValue";
 
 export default PropTypes.shape({
+  // Number of results for this filter
   count: PropTypes.number.isRequired,
-  value: FilterValue.isRequired
+  // Filter to apply if selected
+  value: FilterValue.isRequired,
+  // Whether or not this facet value is selected
+  selected: PropTypes.bool
 });

--- a/packages/react-search-ui-views/stories/FacetsContainer.stories.js
+++ b/packages/react-search-ui-views/stories/FacetsContainer.stories.js
@@ -10,6 +10,7 @@ import { SingleLinksFacet } from "../src";
 
 const multiValueProps = {
   label: "The Label",
+  doFilterValuesMatch: () => false,
   onMoreClick: action("Clicked More"),
   onRemove: action("Removed"),
   onSelect: action("Selected"),
@@ -32,6 +33,7 @@ const multiValueProps = {
 
 const rangeFacetProps = {
   onChange: action("changed"),
+  doFilterValuesMatch: () => false,
   label: "The label",
   options: [
     {
@@ -60,6 +62,7 @@ const rangeFacetProps = {
 };
 
 const singleValueLinksProps = {
+  doFilterValuesMatch: () => false,
   onChange: action("changed"),
   onSelect: action("selected"),
   onRemove: action("removed"),

--- a/packages/react-search-ui-views/stories/FacetsContainer.stories.js
+++ b/packages/react-search-ui-views/stories/FacetsContainer.stories.js
@@ -10,7 +10,6 @@ import { SingleLinksFacet } from "../src";
 
 const multiValueProps = {
   label: "The Label",
-  doFilterValuesMatch: () => false,
   onMoreClick: action("Clicked More"),
   onRemove: action("Removed"),
   onSelect: action("Selected"),
@@ -33,7 +32,6 @@ const multiValueProps = {
 
 const rangeFacetProps = {
   onChange: action("changed"),
-  doFilterValuesMatch: () => false,
   label: "The label",
   options: [
     {
@@ -62,7 +60,6 @@ const rangeFacetProps = {
 };
 
 const singleValueLinksProps = {
-  doFilterValuesMatch: () => false,
   onChange: action("changed"),
   onSelect: action("selected"),
   onRemove: action("removed"),

--- a/packages/react-search-ui-views/stories/MultiCheckboxFacet.stories.js
+++ b/packages/react-search-ui-views/stories/MultiCheckboxFacet.stories.js
@@ -7,7 +7,6 @@ import { MultiCheckboxFacet } from "../src";
 
 const baseProps = {
   label: "The Label",
-  doFilterValuesMatch: () => false,
   onMoreClick: action("Clicked More"),
   onRemove: action("Removed"),
   onSelect: action("Selected"),
@@ -15,18 +14,20 @@ const baseProps = {
   options: [
     {
       value: "value",
-      count: 10
+      count: 10,
+      selected: false
     },
     {
       value: "two",
-      count: 20
+      count: 20,
+      selected: false
     },
     {
       value: "three",
-      count: 30
+      count: 30,
+      selected: false
     }
-  ],
-  values: ["two", "three"]
+  ]
 };
 
 const rangeOptions = [
@@ -54,18 +55,25 @@ storiesOf("Facets/MultiCheckboxFacet", module)
   ))
   .add("with Value Facets selected", () => (
     <MultiCheckboxFacet
-      {...{ ...baseProps, doFilterValuesMatch: () => true }}
+      {...{
+        ...baseProps,
+        options: baseProps.options.map(o => ({ ...o, selected: true }))
+      }}
     />
   ))
   .add("with Range Facets not selected", () => (
-    <MultiCheckboxFacet {...{ ...baseProps, options: rangeOptions }} />
+    <MultiCheckboxFacet
+      {...{
+        ...baseProps,
+        options: rangeOptions
+      }}
+    />
   ))
   .add("with Range Facets selected", () => (
     <MultiCheckboxFacet
       {...{
         ...baseProps,
-        doFilterValuesMatch: () => true,
-        options: rangeOptions
+        options: rangeOptions.map(o => ({ ...o, selected: true }))
       }}
     />
   ))
@@ -79,7 +87,6 @@ storiesOf("Facets/MultiCheckboxFacet", module)
     <MultiCheckboxFacet
       {...{
         ...baseProps,
-        values: [],
         showSearch: true,
         searchPlaceholder: "Search..."
       }}

--- a/packages/react-search-ui-views/stories/MultiCheckboxFacet.stories.js
+++ b/packages/react-search-ui-views/stories/MultiCheckboxFacet.stories.js
@@ -7,6 +7,7 @@ import { MultiCheckboxFacet } from "../src";
 
 const baseProps = {
   label: "The Label",
+  doFilterValuesMatch: () => false,
   onMoreClick: action("Clicked More"),
   onRemove: action("Removed"),
   onSelect: action("Selected"),
@@ -49,27 +50,21 @@ const rangeOptions = [
 
 storiesOf("Facets/MultiCheckboxFacet", module)
   .add("with Value Facets not selected", () => (
-    <MultiCheckboxFacet {...{ ...baseProps, values: [] }} />
-  ))
-  .add("with Value Facets selected", () => (
     <MultiCheckboxFacet {...{ ...baseProps }} />
   ))
-  .add("with Range Facets not selected", () => (
+  .add("with Value Facets selected", () => (
     <MultiCheckboxFacet
-      {...{ ...baseProps, values: [], options: rangeOptions }}
+      {...{ ...baseProps, doFilterValuesMatch: () => true }}
     />
+  ))
+  .add("with Range Facets not selected", () => (
+    <MultiCheckboxFacet {...{ ...baseProps, options: rangeOptions }} />
   ))
   .add("with Range Facets selected", () => (
     <MultiCheckboxFacet
       {...{
         ...baseProps,
-        values: [
-          {
-            from: 11,
-            to: 20,
-            name: "The second option"
-          }
-        ],
+        doFilterValuesMatch: () => true,
         options: rangeOptions
       }}
     />
@@ -81,5 +76,12 @@ storiesOf("Facets/MultiCheckboxFacet", module)
     <MultiCheckboxFacet {...{ ...baseProps, showMore: true, values: [] }} />
   ))
   .add("with Search", () => (
-    <MultiCheckboxFacet {...{ ...baseProps, values: [], showSearch: true, searchPlaceholder: "Search..." }} />
+    <MultiCheckboxFacet
+      {...{
+        ...baseProps,
+        values: [],
+        showSearch: true,
+        searchPlaceholder: "Search..."
+      }}
+    />
   ));

--- a/packages/react-search-ui-views/stories/SingleLinksFacet.stories.js
+++ b/packages/react-search-ui-views/stories/SingleLinksFacet.stories.js
@@ -10,27 +10,31 @@ const baseProps = {
   onSelect: action("selected"),
   onRemove: action("removed"),
   label: "The label",
-  values: [],
   options: [
     {
       count: 100,
-      value: "Compact Cars"
+      value: "Compact Cars",
+      selected: false
     },
     {
       count: 150,
-      value: "Subcompact Cars"
+      value: "Subcompact Cars",
+      selected: false
     },
     {
       count: 300,
-      value: "Mini Compact Cars"
+      value: "Mini Compact Cars",
+      selected: false
     },
     {
       count: 120,
-      value: "Hatchback"
+      value: "Hatchback",
+      selected: false
     },
     {
       count: 80,
-      value: "Sport Utility Vehicles"
+      value: "Sport Utility Vehicles",
+      selected: false
     }
   ]
 };
@@ -59,7 +63,14 @@ storiesOf("Facets/SingleLinksFacet", module)
     <SingleLinksFacet {...{ ...baseProps }} />
   ))
   .add("with Value Facets selected", () => (
-    <SingleLinksFacet {...{ ...baseProps, values: ["Compact Cars"] }} />
+    <SingleLinksFacet
+      {...{
+        ...baseProps,
+        options: baseProps.options.map(o =>
+          o.value === "Compact Cars" ? { ...o, selected: true } : o
+        )
+      }}
+    />
   ))
   .add("with Range Facets not selected", () => (
     <SingleLinksFacet {...{ ...baseProps, options: rangeOptions }} />
@@ -68,14 +79,9 @@ storiesOf("Facets/SingleLinksFacet", module)
     <SingleLinksFacet
       {...{
         ...baseProps,
-        options: rangeOptions,
-        values: [
-          {
-            from: 11,
-            to: 20,
-            name: "The second option"
-          }
-        ]
+        options: rangeOptions.map(o =>
+          o.value.name === "The second option" ? { ...o, selected: true } : o
+        )
       }}
     />
   ));

--- a/packages/react-search-ui-views/stories/SingleSelectFacet.stories.js
+++ b/packages/react-search-ui-views/stories/SingleSelectFacet.stories.js
@@ -15,7 +15,8 @@ const baseProps = {
         from: 1,
         to: 10,
         name: "The first option"
-      }
+      },
+      selected: false
     },
     {
       count: 11,
@@ -23,14 +24,8 @@ const baseProps = {
         from: 11,
         to: 20,
         name: "The second option"
-      }
-    }
-  ],
-  values: [
-    {
-      from: 11,
-      to: 20,
-      name: "The second option"
+      },
+      selected: false
     }
   ]
 };
@@ -47,18 +42,24 @@ const valueFacetOptions = [
 ];
 
 storiesOf("Facets/SingleSelectFacet", module)
-  .add("no options selected", () => (
-    <SingleSelectFacet {...{ ...baseProps, values: [] }} />
-  ))
+  .add("no options selected", () => <SingleSelectFacet {...{ ...baseProps }} />)
   .add("with Range Facets selected", () => (
-    <SingleSelectFacet {...{ ...baseProps }} />
+    <SingleSelectFacet
+      {...{
+        ...baseProps,
+        options: baseProps.options.map(o =>
+          o.value.name === "The second option" ? { ...o, selected: true } : o
+        )
+      }}
+    />
   ))
   .add("with Value Facets selected", () => (
     <SingleSelectFacet
       {...{
         ...baseProps,
-        options: valueFacetOptions,
-        values: ["Pennsylvania"]
+        options: valueFacetOptions.map(o =>
+          o.value === "Pennsylvania" ? { ...o, selected: true } : o
+        )
       }}
     />
   ));

--- a/packages/react-search-ui/src/containers/Facet.js
+++ b/packages/react-search-ui/src/containers/Facet.js
@@ -5,14 +5,9 @@ import { helpers } from "@elastic/search-ui";
 
 import { Facet, Filter, FilterType } from "../types";
 import { accentFold } from "../helpers";
-
 import { withSearch } from "..";
 
-function findFacetValueInFilters(name, filters, filterType) {
-  const filter = filters.find(f => f.field === name && f.type === filterType);
-  if (!filter) return;
-  return filter.values;
-}
+const { markSelectedFacetValuesFromFilters } = helpers;
 
 export class FacetContainer extends Component {
   static propTypes = {
@@ -81,18 +76,29 @@ export class FacetContainer extends Component {
       a11yNotify,
       ...rest
     } = this.props;
-    const facetValues = facets[field];
+    const facetsForField = facets[field];
 
-    if (!facetValues) return null;
+    if (!facetsForField) return null;
 
-    let options = facetValues[0].data;
-    const selectedValues =
-      findFacetValueInFilters(field, filters, filterType) || [];
+    // By using `[0]`, we are currently assuming only 1 facet per field. This will likely be enforced
+    // in future version, so instead of an array, there will only be one facet allowed per field.
+    const facet = facetsForField[0];
 
-    if (!options.length && !selectedValues.length) return null;
+    let facetValues = markSelectedFacetValuesFromFilters(
+      facet,
+      filters,
+      field,
+      filterType
+    ).data;
+
+    const selectedValues = facetValues
+      .filter(fv => fv.selected)
+      .map(fv => fv.value);
+
+    if (!facetValues.length && !selectedValues.length) return null;
 
     if (searchTerm.trim()) {
-      options = options.filter(option =>
+      facetValues = facetValues.filter(option =>
         accentFold(option.value)
           .toLowerCase()
           .includes(accentFold(searchTerm).toLowerCase())
@@ -104,8 +110,7 @@ export class FacetContainer extends Component {
     return View({
       className,
       label: label,
-      doFilterValuesMatch: helpers.doFilterValuesMatch,
-      onMoreClick: this.handleClickMore.bind(this, options.length),
+      onMoreClick: this.handleClickMore.bind(this, facetValues.length),
       onRemove: value => {
         removeFilter(field, value, filterType);
       },
@@ -115,8 +120,8 @@ export class FacetContainer extends Component {
       onSelect: value => {
         addFilter(field, value, filterType);
       },
-      options: options.slice(0, more),
-      showMore: options.length > more,
+      options: facetValues.slice(0, more),
+      showMore: facetValues.length > more,
       values: selectedValues,
       showSearch: isFilterable,
       onSearch: value => {

--- a/packages/react-search-ui/src/containers/Facet.js
+++ b/packages/react-search-ui/src/containers/Facet.js
@@ -1,6 +1,7 @@
 import PropTypes from "prop-types";
 import { Component } from "react";
 import { MultiCheckboxFacet } from "@elastic/react-search-ui-views";
+import { helpers } from "@elastic/search-ui";
 
 import { Facet, Filter, FilterType } from "../types";
 import { accentFold } from "../helpers";
@@ -103,6 +104,7 @@ export class FacetContainer extends Component {
     return View({
       className,
       label: label,
+      doFilterValuesMatch: helpers.doFilterValuesMatch,
       onMoreClick: this.handleClickMore.bind(this, options.length),
       onRemove: value => {
         removeFilter(field, value, filterType);

--- a/packages/react-search-ui/src/containers/__tests__/__snapshots__/Facet.test.js.snap
+++ b/packages/react-search-ui/src/containers/__tests__/__snapshots__/Facet.test.js.snap
@@ -12,10 +12,12 @@ exports[`renders correctly 1`] = `
     Array [
       Object {
         "count": 20,
+        "selected": true,
         "value": "field1value1",
       },
       Object {
         "count": 10,
+        "selected": false,
         "value": "field1value2",
       },
     ]

--- a/packages/react-search-ui/src/types/FacetValue.js
+++ b/packages/react-search-ui/src/types/FacetValue.js
@@ -5,5 +5,7 @@ export default PropTypes.shape({
   // Number of results for this filter
   count: PropTypes.number.isRequired,
   // Filter to apply if selected
-  value: FilterValue.isRequired
+  value: FilterValue.isRequired,
+  // Whether or not this facet value is selected
+  selected: PropTypes.bool
 });

--- a/packages/search-ui-app-search-connector/src/__tests__/responseAdapter.test.js
+++ b/packages/search-ui-app-search-connector/src/__tests__/responseAdapter.test.js
@@ -98,6 +98,32 @@ const responseWithEmptyFacetValue = {
   }
 };
 
+const responseWithZeroFacetValue = {
+  rawResults: [],
+  info: {
+    facets: {
+      states: [
+        {
+          type: "value",
+          data: [
+            {
+              value: 0,
+              count: 5
+            }
+          ]
+        }
+      ]
+    },
+    meta: {
+      request_id: "1234",
+      page: {
+        total_results: 100,
+        total_pages: 10
+      }
+    }
+  }
+};
+
 const adaptedResponse = {
   results: [],
   totalPages: 10,
@@ -189,6 +215,27 @@ const adaptedResponseWithEmptyFacetValue = {
   }
 };
 
+const adaptedResponseWithZeroFacetValue = {
+  results: [],
+  totalPages: 10,
+  totalResults: 100,
+  requestId: "1234",
+  facets: {
+    states: [
+      {
+        type: "value",
+        field: "states",
+        data: [
+          {
+            value: 0,
+            count: 5
+          }
+        ]
+      }
+    ]
+  }
+};
+
 const geoOptions = {
   additionalFacetValueFields: {
     location: {
@@ -210,6 +257,12 @@ describe("adaptResponse", () => {
   it("adapts facets with empty values", () => {
     expect(adaptResponse(responseWithEmptyFacetValue)).toEqual(
       adaptedResponseWithEmptyFacetValue
+    );
+  });
+
+  it("adapts facets with zero values", () => {
+    expect(adaptResponse(responseWithZeroFacetValue)).toEqual(
+      adaptedResponseWithZeroFacetValue
     );
   });
 

--- a/packages/search-ui-app-search-connector/src/__tests__/responseAdapter.test.js
+++ b/packages/search-ui-app-search-connector/src/__tests__/responseAdapter.test.js
@@ -72,6 +72,32 @@ const emptyResponse = {
   }
 };
 
+const responseWithEmptyFacetValue = {
+  rawResults: [],
+  info: {
+    facets: {
+      states: [
+        {
+          type: "value",
+          data: [
+            {
+              value: "",
+              count: 5
+            }
+          ]
+        }
+      ]
+    },
+    meta: {
+      request_id: "1234",
+      page: {
+        total_results: 100,
+        total_pages: 10
+      }
+    }
+  }
+};
+
 const adaptedResponse = {
   results: [],
   totalPages: 10,
@@ -142,6 +168,27 @@ const adaptedResponse = {
 
 const adaptedEmptyResponse = { requestId: "1234", results: [] };
 
+const adaptedResponseWithEmptyFacetValue = {
+  results: [],
+  totalPages: 10,
+  totalResults: 100,
+  requestId: "1234",
+  facets: {
+    states: [
+      {
+        type: "value",
+        field: "states",
+        data: [
+          {
+            value: "",
+            count: 5
+          }
+        ]
+      }
+    ]
+  }
+};
+
 const geoOptions = {
   additionalFacetValueFields: {
     location: {
@@ -158,6 +205,12 @@ describe("adaptResponse", () => {
 
   it("adapts empty response", () => {
     expect(adaptResponse(emptyResponse)).toEqual(adaptedEmptyResponse);
+  });
+
+  it("adapts facets with empty values", () => {
+    expect(adaptResponse(responseWithEmptyFacetValue)).toEqual(
+      adaptedResponseWithEmptyFacetValue
+    );
   });
 
   it("will accept additional facet value fields to inject into response", () => {

--- a/packages/search-ui-app-search-connector/src/responseAdapter.js
+++ b/packages/search-ui-app-search-connector/src/responseAdapter.js
@@ -2,10 +2,11 @@ function adaptation1AdaptFacetValue(
   facetValue,
   additionalFacetValueFieldsForField = {}
 ) {
+  const hasValue = facetValue.hasOwnProperty("value");
   const { count, value, ...rest } = facetValue;
   return {
     count,
-    value: value
+    value: hasValue
       ? value
       : {
           ...rest,

--- a/packages/search-ui/src/__tests__/helpers.test.js
+++ b/packages/search-ui/src/__tests__/helpers.test.js
@@ -1,5 +1,7 @@
 import { helpers } from "..";
 const doFilterValuesMatch = helpers.doFilterValuesMatch;
+const markSelectedFacetValuesFromFilters =
+  helpers.markSelectedFacetValuesFromFilters;
 
 describe("doFilterValuesMatch", () => {
   describe("when matching simple values", () => {
@@ -67,6 +69,12 @@ describe("doFilterValuesMatch", () => {
       expect(doFilterValuesMatch(filterValue1, filterValue2)).toBe(false);
     });
 
+    it("will match objects with differently ordered props", () => {
+      const filterValue1 = { to: 10, from: 1 };
+      const filterValue2 = { from: 1, to: 10 };
+      expect(doFilterValuesMatch(filterValue1, filterValue2)).toBe(true);
+    });
+
     it("will do a short-circuit match if 'name' matches", () => {
       const filterValue1 = { name: "The first option" };
       const filterValue2 = { from: 1, to: 10, name: "The first option" };
@@ -95,6 +103,84 @@ describe("doFilterValuesMatch", () => {
       const filterValue1 = {};
       const filterValue2 = {};
       expect(doFilterValuesMatch(filterValue1, filterValue2)).toBe(true);
+    });
+  });
+});
+
+describe("markSelectedFacetValuesFromFilters", () => {
+  const facet = {
+    field: "states",
+    type: "value",
+    data: [
+      {
+        count: 9,
+        value: "California"
+      },
+      {
+        count: 8,
+        value: "Alaska"
+      },
+      {
+        count: 1,
+        value: "South Carolina"
+      },
+      {
+        count: 1,
+        value: "Tennessee"
+      }
+    ]
+  };
+
+  let filters = [
+    {
+      field: "states",
+      values: ["California", "South Carolina"],
+      type: "any"
+    },
+    {
+      field: "states",
+      values: ["Alaska"],
+      type: "all"
+    },
+    {
+      field: "world_heritage_site",
+      values: ["true"],
+      type: "all"
+    }
+  ];
+
+  it("will mark selected facets as selected based on current filters, field name, and filter type", () => {
+    const marked = markSelectedFacetValuesFromFilters(
+      facet,
+      filters,
+      "states",
+      "any"
+    );
+    expect(marked).toEqual({
+      field: "states",
+      type: "value",
+      data: [
+        {
+          count: 9,
+          value: "California",
+          selected: true
+        },
+        {
+          count: 8,
+          value: "Alaska",
+          selected: false
+        },
+        {
+          count: 1,
+          value: "South Carolina",
+          selected: true
+        },
+        {
+          count: 1,
+          value: "Tennessee",
+          selected: false
+        }
+      ]
     });
   });
 });

--- a/packages/search-ui/src/__tests__/helpers.test.js
+++ b/packages/search-ui/src/__tests__/helpers.test.js
@@ -1,0 +1,100 @@
+import { helpers } from "..";
+const doFilterValuesMatch = helpers.doFilterValuesMatch;
+
+describe("doFilterValuesMatch", () => {
+  describe("when matching simple values", () => {
+    it("will match string", () => {
+      expect(doFilterValuesMatch("filterValue", "filterValue")).toBe(true);
+    });
+
+    it("will not match different string", () => {
+      expect(doFilterValuesMatch("filterValue", "filterValue1")).toBe(false);
+    });
+
+    it("will match number", () => {
+      expect(doFilterValuesMatch(1, 1)).toBe(true);
+    });
+
+    it("will match different number", () => {
+      expect(doFilterValuesMatch(1, 2)).toBe(false);
+    });
+  });
+
+  describe("when matching falsey values", () => {
+    it("will match empty string", () => {
+      expect(doFilterValuesMatch("", "")).toBe(true);
+    });
+
+    it("will match 0", () => {
+      expect(doFilterValuesMatch(0, 0)).toBe(true);
+    });
+
+    it("will match null", () => {
+      expect(doFilterValuesMatch(null, null)).toBe(true);
+    });
+
+    it("will match undefined", () => {
+      expect(doFilterValuesMatch(undefined, undefined)).toBe(true);
+    });
+
+    it("will not match different falsey values - 0 and ''", () => {
+      expect(doFilterValuesMatch(0, "")).toBe(false);
+    });
+  });
+
+  describe("when matching object based filter values", () => {
+    it("will match objects", () => {
+      const filterValue1 = { from: 1, to: 10 };
+      const filterValue2 = { from: 1, to: 10 };
+      expect(doFilterValuesMatch(filterValue1, filterValue2)).toBe(true);
+    });
+
+    it("will not match objects if they are different", () => {
+      const filterValue1 = { from: 1, to: 10 };
+      const filterValue2 = { from: 1, to: 12 };
+      expect(doFilterValuesMatch(filterValue1, filterValue2)).toBe(false);
+    });
+
+    it("will not match objects if leafs are falsey matches", () => {
+      const filterValue1 = { from: 1, to: 0 };
+      const filterValue2 = { from: 1, to: "" };
+      expect(doFilterValuesMatch(filterValue1, filterValue2)).toBe(false);
+    });
+
+    it("will not match objects through coercion", () => {
+      const filterValue1 = { from: 1, to: 0 };
+      const filterValue2 = { from: 1, to: "0" };
+      expect(doFilterValuesMatch(filterValue1, filterValue2)).toBe(false);
+    });
+
+    it("will do a short-circuit match if 'name' matches", () => {
+      const filterValue1 = { name: "The first option" };
+      const filterValue2 = { from: 1, to: 10, name: "The first option" };
+      expect(doFilterValuesMatch(filterValue1, filterValue2)).toBe(true);
+    });
+
+    it("will do a short-circuit match if 'name' matches as well as attributes", () => {
+      const filterValue1 = { from: 1, to: 10, name: "The first option" };
+      const filterValue2 = { from: 1, to: 10, name: "The first option" };
+      expect(doFilterValuesMatch(filterValue1, filterValue2)).toBe(true);
+    });
+
+    it("will not do a short-circuit match if 'name' doesn't matches", () => {
+      const filterValue1 = { name: "The first option" };
+      const filterValue2 = { from: 1, to: 10, name: "The second option" };
+      expect(doFilterValuesMatch(filterValue1, filterValue2)).toBe(false);
+    });
+
+    it("will not do a short-circuit match if 'name' isn't present", () => {
+      const filterValue1 = { from: 1 };
+      const filterValue2 = { from: 1, to: 10 };
+      expect(doFilterValuesMatch(filterValue1, filterValue2)).toBe(false);
+    });
+
+    it("will match empty objects", () => {
+      const filterValue1 = {};
+      const filterValue2 = {};
+      expect(doFilterValuesMatch(filterValue1, filterValue2)).toBe(true);
+    });
+  });
+});

--- a/packages/search-ui/src/__tests__/helpers.test.js
+++ b/packages/search-ui/src/__tests__/helpers.test.js
@@ -17,7 +17,7 @@ describe("doFilterValuesMatch", () => {
       expect(doFilterValuesMatch(1, 1)).toBe(true);
     });
 
-    it("will match different number", () => {
+    it("will not match different number", () => {
       expect(doFilterValuesMatch(1, 2)).toBe(false);
     });
   });

--- a/packages/search-ui/src/actions/addFilter.js
+++ b/packages/search-ui/src/actions/addFilter.js
@@ -1,4 +1,4 @@
-import { matchFilter } from "../helpers";
+import { doFilterValuesMatch } from "../helpers";
 
 /**
  * Filter results - Adds to current filter value
@@ -22,7 +22,7 @@ export default function addFilter(name, value, type = "all") {
   const existingFilterValues = existingFilter.values || [];
 
   const newFilterValues = existingFilterValues.find(existing =>
-    matchFilter(existing, value)
+    doFilterValuesMatch(existing, value)
   )
     ? existingFilterValues
     : existingFilterValues.concat(value);

--- a/packages/search-ui/src/helpers.js
+++ b/packages/search-ui/src/helpers.js
@@ -5,7 +5,7 @@ export function removeSingleFilterValue(filters, name, value, filterType) {
     const { field, values, type, ...rest } = filter;
     if (field === name && (!filterType || type === filterType)) {
       const updatedFilterValues = values.filter(
-        filterValue => !matchFilter(filterValue, value)
+        filterValue => !doFilterValuesMatch(filterValue, value)
       );
       if (updatedFilterValues.length > 0) {
         return acc.concat({
@@ -22,15 +22,31 @@ export function removeSingleFilterValue(filters, name, value, filterType) {
   }, []);
 }
 
-export function matchFilter(filter1, filter2) {
+/**
+ * Useful for determining when filter values match. This could be used
+ * when matching applied filters back to facet options, or for determining
+ * whether or not a filter already exists in a list of applied filters.
+ *
+ * @param {*} filter1
+ * @param {*} filter2
+ */
+export function doFilterValuesMatch(filterValue1, filterValue2) {
   if (
-    filter1 &&
-    filter1.name &&
-    filter2 &&
-    filter2.name &&
-    filter1.name === filter2.name
+    filterValue1 &&
+    filterValue1.name &&
+    filterValue2 &&
+    filterValue2.name &&
+    filterValue1.name === filterValue2.name
   )
+    // If two filters have matching names, then they are the same filter, there
+    // is no need to do a more expensive deep equal comparison.
+    //
+    // This is also important because certain filters and facets will have
+    // differing values than their corresponding facet options. For instance,
+    // consider a time-based facet like "Last 10 Minutes". The value of the
+    // filter will be different depending on when it was selected, but the name
+    // will always match.
     return true;
-  if (deepEqual(filter1, filter2)) return true;
-  return false;
+  // We use 'strict = true' to do a '===' of leaves, rather than '=='
+  return deepEqual(filterValue1, filterValue2, { strict: true });
 }

--- a/packages/search-ui/src/helpers.js
+++ b/packages/search-ui/src/helpers.js
@@ -68,10 +68,9 @@ export function markSelectedFacetValuesFromFilters(
     data: facetValues.map(facetValue => {
       return {
         ...facetValue,
-        selected:
-          filterValuesForField.findIndex(filterValue => {
-            return doFilterValuesMatch(filterValue, facetValue.value);
-          }) >= 0
+        selected: filterValuesForField.some(filterValue => {
+          return doFilterValuesMatch(filterValue, facetValue.value);
+        })
       };
     })
   };

--- a/packages/search-ui/src/index.js
+++ b/packages/search-ui/src/index.js
@@ -1,1 +1,6 @@
+import * as helpersSource from "./helpers";
+
 export { default as SearchDriver } from "./SearchDriver";
+export const helpers = {
+  doFilterValuesMatch: helpersSource.doFilterValuesMatch
+};

--- a/packages/search-ui/src/index.js
+++ b/packages/search-ui/src/index.js
@@ -2,5 +2,5 @@ import * as helpersSource from "./helpers";
 
 export { default as SearchDriver } from "./SearchDriver";
 export const helpers = {
-  doFilterValuesMatch: helpersSource.doFilterValuesMatch
+  ...helpersSource
 };


### PR DESCRIPTION
## Description

Bufix for "Facets will break if a document includes an empty string", and related refactoring.

## Changes

### The Bugfix:

Facets were breaking both in the UI with a javascript error, and
on the server with a 4xx when documents contained fields with empty
string values.

I believe the same thing would happen for any falsy value in a document
field, including `0`.

In the App Search responseAdapter, when attempting to build our facet
objects in state, it was tripping a falsy check which made the code
perform logic as if the returned value was an object (like a range
facet) rather than a raw value.

For example, the following facet returned by the server:

```
{
  type: "value",
  data: [
    {
      value: "",
      count: 5
    }
  ]
}
```

should be converted to:

```
{
  type: "value",
  field: "states",
  data: [
    {
      value: "",
      count: 5
    }
  ]
}
```

But instead was converted to:
```
{
  type: "value",
  field: "states",
  data: [
    {
      value: {}, // This is incorrect
      count: 5
    }
  ]
}
```

After fixing the above mentioned issue, I realized that there were
problems in MultiCheckboxFacet.

The MultiCheckboxFacet's logic for determining which value is selected
was doing a truthy-based conversion to a boolean value when finding
values, which converted `""` to `false`. The `false` flag indicated
that that particular facet value was not the selected facet value, even
though it was.

For example:

```
selectedValue = ""

[ ] "Arizona"
[ ] "" <-- Should be marked as selected
[ ] "Utah"
```

After fixing that, I also realized that we were using a `deepEqual`
check, which used `==` under the hood to determine equality. That means
that if a value like `0` was the selected value, that it would
incorrectly match `==`.

For example:

```
selectedValue = ""

[x] 0 <-- Should not be marked as selected
[ ] 1
[ ] 2
```

These changes are here: https://github.com/elastic/search-ui/commit/3ef20a287615ed7787cfe764ea262c2071793959

### Refactored filter value matching logic into a helper
In order to properly write enough tests to feel confident about
this logic, I had to factor out filter value matching logic
into a helper.

This logic was duplicated in both search-ui and
react-search-ui-views. I exported a helper for this from search-ui to
react-search-ui.

The helper method is `doFilterValuesMatch`

### Refactored facet views

Additionally, this matching logic was also duplicated in each of the individual
facet views. Again, to reduce complexity and make sure that this
fix is working in all cases, I refactored these views.

We were previously making it a view responsibility to calculate
whether or not a FacetValue was selected or not.

I added a "selected" flag to FacetValues, so there is no calculation
necessary. That "selected" flag is calculated in the Facet component
and passed down to views in the "options" param. It uses a new helper
method `markSelectedFacetValuesFromFilters`. This simplifies custom view
creation and our own views.

Since we no longer rely on the "values" prop for this, I created an issue to
remove it in `2.0`: https://github.com/elastic/search-ui/issues/422

I considered moving this logic to the SearchDriver and maintaining
the flags on facets in state, but the current selection logic
relies on knowing the "filterType" for a facet, which is something
we don't have available in state.

I create an issue to update this in the future:
https://github.com/elastic/search-ui/issues/423

### New helpers

I exposed a number of helpers publicly from the search-ui package
because working with state can often be hard, and having those
helpers available can make it much simpler. See helpers.js.

## Related Issues

Fixes https://github.com/elastic/search-ui/issues/401