### PR TITLE
fix: Replace debounce-fn in DebounceManager to facilitate IE11 compat…

### DIFF
--- a/packages/search-ui/src/DebounceManager.js
+++ b/packages/search-ui/src/DebounceManager.js
@@ -6,7 +6,7 @@
  */
 function debounce(func, wait) {
   let timeout;
-  return function() {
+  const debouncedFn = function() {
     const args = arguments;
     const later = () => {
       func.apply(null, args);
@@ -14,6 +14,13 @@ function debounce(func, wait) {
     clearTimeout(timeout);
     timeout = setTimeout(later, wait);
   };
+  debouncedFn.cancel = () => {
+    if (timeout) {
+      clearTimeout(timeout);
+      timeout = null;
+    }
+  };
+  return debouncedFn;
 }
 
 class DebounceManager {

--- a/packages/search-ui/src/DebounceManager.js
+++ b/packages/search-ui/src/DebounceManager.js
@@ -1,4 +1,20 @@
-import debounceFn from "debounce-fn";
+/**
+ * minimal debounce function
+ *
+ * mostly for not spamming the server with requests when
+ * searching with type ahead
+ */
+function debounce(func, wait) {
+  let timeout;
+  return function() {
+    const args = arguments;
+    const later = () => {
+      func.apply(null, args);
+    };
+    clearTimeout(timeout);
+    timeout = setTimeout(later, wait);
+  };
+}
 
 class DebounceManager {
   debounceCache = {};
@@ -31,7 +47,7 @@ class DebounceManager {
     const key = `${functionName}|${wait.toString()}`;
     let debounced = this.debounceCache[key];
     if (!debounced) {
-      this.debounceCache[key] = debounceFn(fn, { wait });
+      this.debounceCache[key] = debounce(fn, wait);
       debounced = this.debounceCache[key];
     }
     debounced(...parameters);
@@ -70,7 +86,7 @@ class DebounceManager {
  * @param {function} fn Function to debounce
  */
 DebounceManager.debounce = (wait, fn) => {
-  return debounceFn(fn, { wait });
+  return debounce(fn, wait);
 };
 
 export default DebounceManager;


### PR DESCRIPTION
Even after adding polyfills in support of IE11, search-ui is still unable to render properly due to an issue in using Object.defineProperty() when mimic-fn a function as part of the use of debounce-fn.

On our own fork of search-ui, we've replaced the use of the debounce-fn module with our own debounce function. After discussion with my team, we wanted to submit a PR with our debounce function so that we wouldn't have to maintain our own fork specifically for IE11 compatibility.