### PR TITLE
fix: Use browser history replace instead of push on first load

### DIFF
--- a/packages/search-ui/src/URLManager.js
+++ b/packages/search-ui/src/URLManager.js
@@ -117,8 +117,12 @@ export default class URLManager {
 
   pushStateToURL(state) {
     const searchString = stateToQueryString(state);
+    const navigationFunction =
+      this.lastPushSearchString.length === 0
+        ? this.history.replace
+        : this.history.push;
     this.lastPushSearchString = searchString;
-    this.history.push({
+    navigationFunction({
       search: `?${searchString}`
     });
   }

--- a/packages/search-ui/src/URLManager.js
+++ b/packages/search-ui/src/URLManager.js
@@ -122,9 +122,10 @@ export default class URLManager {
         ? this.history.replace
         : this.history.push;
     this.lastPushSearchString = searchString;
-    navigationFunction({
-      search: `?${searchString}`
-    });
+    navigationFunction &&
+      navigationFunction({
+        search: `?${searchString}`
+      });
   }
 
   onURLStateChange(callback) {

--- a/packages/search-ui/src/__tests__/URLManager.test.js
+++ b/packages/search-ui/src/__tests__/URLManager.test.js
@@ -102,7 +102,7 @@ describe("#getStateFromURL", () => {
 });
 
 describe("#pushStateToURL", () => {
-  it("will update the url with the url corresponding to the provided state", () => {
+  it("will replace the url with the url corresponding to the provided state", () => {
     const manager = createManager();
     manager.pushStateToURL(basicParameterState);
     const queryString = manager.history.replace.mock.calls[0][0].search;
@@ -111,11 +111,33 @@ describe("#pushStateToURL", () => {
     );
   });
 
-  describe("filters", () => {
-    it("will update the url with range filter types", () => {
+  it("will update the url with the url corresponding to the provided state", () => {
+    const manager = createManager();
+    manager.pushStateToURL(basicParameterState);
+    manager.pushStateToURL(basicParameterState);
+    const queryString = manager.history.push.mock.calls[0][0].search;
+    expect(queryString).toEqual(
+      "?q=node&size=n_20_n&filters%5B0%5D%5Bdependencies%5D%5B0%5D=underscore&filters%5B0%5D%5Bdependencies%5D%5B1%5D=another&filters%5B1%5D%5Bkeywords%5D%5B0%5D=node&sort-field=name&sort-direction=asc"
+    );
+  });
+
+  describe("filtersReplace", () => {
+    it("will replace the url with range filter types", () => {
       const manager = createManager();
       manager.pushStateToURL(parameterStateWithRangeFilters);
       const queryString = manager.history.replace.mock.calls[0][0].search;
+      expect(queryString).toEqual(
+        "?filters%5B0%5D%5Bdate%5D%5B0%5D%5Bfrom%5D=n_12_n&filters%5B0%5D%5Bdate%5D%5B0%5D%5Bto%5D=n_4000_n&filters%5B0%5D%5Bdate%5D%5B1%5D%5Bto%5D=n_4000_n&filters%5B1%5D%5Bcost%5D%5B0%5D%5Bfrom%5D=n_50_n&filters%5B2%5D%5Bkeywords%5D=node"
+      );
+    });
+  });
+
+  describe("filtersPush", () => {
+    it("will update the url with range filter types", () => {
+      const manager = createManager();
+      manager.pushStateToURL(parameterStateWithRangeFilters);
+      manager.pushStateToURL(parameterStateWithRangeFilters);
+      const queryString = manager.history.push.mock.calls[0][0].search;
       expect(queryString).toEqual(
         "?filters%5B0%5D%5Bdate%5D%5B0%5D%5Bfrom%5D=n_12_n&filters%5B0%5D%5Bdate%5D%5B0%5D%5Bto%5D=n_4000_n&filters%5B0%5D%5Bdate%5D%5B1%5D%5Bto%5D=n_4000_n&filters%5B1%5D%5Bcost%5D%5B0%5D%5Bfrom%5D=n_50_n&filters%5B2%5D%5Bkeywords%5D=node"
       );

--- a/packages/search-ui/src/__tests__/URLManager.test.js
+++ b/packages/search-ui/src/__tests__/URLManager.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import URLManager from "../URLManager";
 
 function createManager() {
@@ -7,7 +8,8 @@ function createManager() {
       search: ""
     },
     listen: jest.fn(),
-    push: jest.fn()
+    push: jest.fn(),
+    replace: jest.fn()
   };
   return manager;
 }
@@ -103,7 +105,7 @@ describe("#pushStateToURL", () => {
   it("will update the url with the url corresponding to the provided state", () => {
     const manager = createManager();
     manager.pushStateToURL(basicParameterState);
-    const queryString = manager.history.push.mock.calls[0][0].search;
+    const queryString = manager.history.replace.mock.calls[0][0].search;
     expect(queryString).toEqual(
       "?q=node&size=n_20_n&filters%5B0%5D%5Bdependencies%5D%5B0%5D=underscore&filters%5B0%5D%5Bdependencies%5D%5B1%5D=another&filters%5B1%5D%5Bkeywords%5D%5B0%5D=node&sort-field=name&sort-direction=asc"
     );
@@ -113,7 +115,7 @@ describe("#pushStateToURL", () => {
     it("will update the url with range filter types", () => {
       const manager = createManager();
       manager.pushStateToURL(parameterStateWithRangeFilters);
-      const queryString = manager.history.push.mock.calls[0][0].search;
+      const queryString = manager.history.replace.mock.calls[0][0].search;
       expect(queryString).toEqual(
         "?filters%5B0%5D%5Bdate%5D%5B0%5D%5Bfrom%5D=n_12_n&filters%5B0%5D%5Bdate%5D%5B0%5D%5Bto%5D=n_4000_n&filters%5B0%5D%5Bdate%5D%5B1%5D%5Bto%5D=n_4000_n&filters%5B1%5D%5Bcost%5D%5B0%5D%5Bfrom%5D=n_50_n&filters%5B2%5D%5Bkeywords%5D=node"
       );
@@ -130,7 +132,7 @@ describe("#onURLStateChange", () => {
 
   function pushStateToURL(state) {
     manager.pushStateToURL(state);
-    return manager.history.push.mock.calls[0][0].search;
+    return manager.history.replace.mock.calls[0][0].search;
   }
 
   function simulateBrowserHistoryEvent(newUrl) {


### PR DESCRIPTION
The idea for this change is to not push browser history on the very first load. Our application uses react-router, which will capture the changes to the url. This will require the user to make 2 back navigations in order to get back to the page they entered the search page rather than just one.

Additionally, if there's some filter state captured in the url, the first of the backs will clear our the initial filter parameters, potentially leading to some odd search results. (Example, we filter out results by environment dev/stage/prod, this defect causes the environment filter to be cleared, showing results from all environments).

Fixes #434