### PR TITLE
Removed dependency on debounce-fn

### DIFF
--- a/packages/react-search-ui/package.json
+++ b/packages/react-search-ui/package.json
@@ -35,8 +35,7 @@
   "dependencies": {
     "@babel/runtime": "^7.5.4",
     "@elastic/react-search-ui-views": "1.2.0",
-    "@elastic/search-ui": "1.2.0",
-    "debounce-fn": "^1.0.0"
+    "@elastic/search-ui": "1.2.0"
   },
   "peerDependencies": {
     "react": "^16.8.0"

--- a/packages/search-ui/package.json
+++ b/packages/search-ui/package.json
@@ -41,7 +41,6 @@
   "dependencies": {
     "@babel/runtime": "^7.5.4",
     "date-fns": "^1.30.1",
-    "debounce-fn": "^1.0.0",
     "deep-equal": "^1.0.1",
     "history": "^4.9.0",
     "qs": "^6.7.0"


### PR DESCRIPTION
Usage was removed in https://github.com/elastic/search-ui/pull/442,
this commit removes it as a dependency since it is no longer used.