### PR TITLE
fix: Search-UI smart url forces extra history push

### DIFF
--- a/packages/search-ui/src/SearchDriver.js
+++ b/packages/search-ui/src/SearchDriver.js
@@ -189,6 +189,14 @@ export default class SearchDriver {
     }
   }
 
+  /**
+   * This method is used to update state and trigger a new autocomplete search.
+   *
+   * @param {string} searchTerm
+   * @param {Object=} Object
+   * @param {boolean|Object} options.autocompleteResults - Should autocomplete results
+   * @param {boolean|Object} options.autocompleteSuggestions - Should autocomplete suggestions
+   */
   _updateAutocomplete = (
     searchTerm,
     { autocompleteResults, autocompleteSuggestions } = {}
@@ -216,6 +224,19 @@ export default class SearchDriver {
 
   /**
    * This method is used to update state and trigger a new search.
+   *
+   * @typedef {Object} RequestState
+   * @property {number} current
+   * @property {number} resultsPerPage
+   * @property {string} searchTerm
+   * @property {string} sortDirection
+   * @property {string} sortField
+   *
+   * @param {RequestState} searchParameters - RequestState
+   * @param {Object=} Object
+   * @param {boolean} options.skipPushToUrl - Skip pushing the updated to the URL
+   * @param {boolean} options.replaceUrl - When pushing state to the URL, use history 'replace'
+   * rather than 'push' to avoid adding a new history entry
    */
   _updateSearchResults = (
     searchParameters,
@@ -277,6 +298,11 @@ export default class SearchDriver {
    *
    * Application state updates are performed in _updateSearchResults, but we
    * wait to make the actual API calls until all actions have been called.
+   *
+   * @param {Object} options
+   * @param {boolean} options.skipPushToUrl - Skip pushing the updated to the URL
+   * @param {boolean} options.replaceUrl - When pushing state to the URL, use history 'replace'
+   * rather than 'push' to avoid adding a new history entry
    */
   _makeSearchRequest = DebounceManager.debounce(
     0,

--- a/packages/search-ui/src/URLManager.js
+++ b/packages/search-ui/src/URLManager.js
@@ -111,10 +111,23 @@ export default class URLManager {
     this.lastPushSearchString = "";
   }
 
+  /**
+   * Parse the current URL into application state
+   *
+   * @return {Object} - The parsed state object
+   */
   getStateFromURL() {
     return paramsToState(queryString.parse(this.history.location.search));
   }
 
+  /**
+   * Push the current state of the application to the URL
+   *
+   * @param {Object} state - The entire current state from the SearchDriver
+   * @param {boolean} options
+   * @param {boolean} options.replaceUrl - When pushing state to the URL, use history 'replace'
+   * rather than 'push' to avoid adding a new history entry
+   */
   pushStateToURL(state, { replaceUrl = false } = {}) {
     const searchString = stateToQueryString(state);
     this.lastPushSearchString = searchString;
@@ -126,6 +139,14 @@ export default class URLManager {
     });
   }
 
+  /**
+   * Add an event handler to be executed whenever state is pushed to the URL
+   *
+   * @callback requestCallback
+   * @param {Object} state - Updated application state parsed from the new URL
+   *
+   * @param {requestCallback} callback
+   */
   onURLStateChange(callback) {
     this.unlisten = this.history.listen(location => {
       // If this URL is updated as a result of a pushState request, we don't

--- a/packages/search-ui/src/URLManager.js
+++ b/packages/search-ui/src/URLManager.js
@@ -115,10 +115,13 @@ export default class URLManager {
     return paramsToState(queryString.parse(this.history.location.search));
   }
 
-  pushStateToURL(state) {
+  pushStateToURL(state, { replaceUrl = false } = {}) {
     const searchString = stateToQueryString(state);
     this.lastPushSearchString = searchString;
-    this.history.push({
+    const navigationFunction = replaceUrl
+      ? this.history.replace
+      : this.history.push;
+    navigationFunction({
       search: `?${searchString}`
     });
   }

--- a/packages/search-ui/src/__tests__/SearchDriver.test.js
+++ b/packages/search-ui/src/__tests__/SearchDriver.test.js
@@ -134,9 +134,10 @@ it("will sync initial state to the URL", () => {
 
   setupDriver({ initialState });
 
-  expect(URLManager.mock.instances[0].pushStateToURL.mock.calls).toHaveLength(
-    1
-  );
+  const pushStateCalls = URLManager.mock.instances[0].pushStateToURL.mock.calls;
+  expect(pushStateCalls).toHaveLength(1);
+  // "will sync to the url with 'replace' rather than 'push'"
+  expect(pushStateCalls[0][1].replaceUrl).toEqual(true);
 });
 
 it("will not sync initial state to the URL if trackURLState is set to false", () => {

--- a/packages/search-ui/src/__tests__/URLManager.test.js
+++ b/packages/search-ui/src/__tests__/URLManager.test.js
@@ -7,7 +7,8 @@ function createManager() {
       search: ""
     },
     listen: jest.fn(),
-    push: jest.fn()
+    push: jest.fn(),
+    replace: jest.fn()
   };
   return manager;
 }
@@ -116,6 +117,17 @@ describe("#pushStateToURL", () => {
       const queryString = manager.history.push.mock.calls[0][0].search;
       expect(queryString).toEqual(
         "?filters%5B0%5D%5Bdate%5D%5B0%5D%5Bfrom%5D=n_12_n&filters%5B0%5D%5Bdate%5D%5B0%5D%5Bto%5D=n_4000_n&filters%5B0%5D%5Bdate%5D%5B1%5D%5Bto%5D=n_4000_n&filters%5B1%5D%5Bcost%5D%5B0%5D%5Bfrom%5D=n_50_n&filters%5B2%5D%5Bkeywords%5D=node"
+      );
+    });
+  });
+
+  describe("replaceUrl", () => {
+    it("will update the url using 'replace' instead of 'push", () => {
+      const manager = createManager();
+      manager.pushStateToURL(basicParameterState, { replaceUrl: true });
+      const queryString = manager.history.replace.mock.calls[0][0].search;
+      expect(queryString).toEqual(
+        "?q=node&size=n_20_n&filters%5B0%5D%5Bdependencies%5D%5B0%5D=underscore&filters%5B0%5D%5Bdependencies%5D%5B1%5D=another&filters%5B1%5D%5Bkeywords%5D%5B0%5D=node&sort-field=name&sort-direction=asc"
       );
     });
   });


### PR DESCRIPTION
Currently, when showing search results on page load, an extra history
event is added to history, causing a few issues, including the
inconvenience on users of having to press the back button twice to get
back to where they were originally.

The fix is to simply use a browser history "replace" instead of "push"
on the any queries happening on page load.

This PR is based on the following PR:
https://github.com/elastic/search-ui/pull/443

Fixes Fixes https://github.com/elastic/search-ui/issues/434

![latest](https://user-images.githubusercontent.com/1427475/71025673-86358a00-20d5-11ea-8be0-91611c1ede8d.gif)
