### PR TITLE
Use different sequencers for autocomplete and search request

### DIFF
--- a/packages/react-search-ui-views/src/__tests__/__snapshots__/Paging.test.js.snap
+++ b/packages/react-search-ui-views/src/__tests__/__snapshots__/Paging.test.js.snap
@@ -11,7 +11,7 @@ exports[`renders correctly 1`] = `
   locale={
     Object {
       "items_per_page": "/ page",
-      "jump_to": "Goto",
+      "jump_to": "Go to",
       "jump_to_confirm": "confirm",
       "next_3": "Next 3 Pages",
       "next_5": "Next 5 Pages",

--- a/packages/search-ui/src/SearchDriver.js
+++ b/packages/search-ui/src/SearchDriver.js
@@ -121,7 +121,8 @@ export default class SearchDriver {
       );
       window.searchUI = this;
     }
-    this.requestSequencer = new RequestSequencer();
+    this.autocompleteRequestSequencer = new RequestSequencer();
+    this.searchRequestSequencer = new RequestSequencer();
     this.debounceManager = new DebounceManager();
     this.autocompleteQuery = autocompleteQuery;
     this.searchQuery = searchQuery;
@@ -201,7 +202,7 @@ export default class SearchDriver {
     searchTerm,
     { autocompleteResults, autocompleteSuggestions } = {}
   ) => {
-    const requestId = this.requestSequencer.next();
+    const requestId = this.autocompleteRequestSequencer.next();
 
     const queryConfig = {
       ...(autocompleteResults && {
@@ -215,8 +216,8 @@ export default class SearchDriver {
     return this.events
       .autocomplete({ searchTerm }, queryConfig)
       .then(autocompleted => {
-        if (this.requestSequencer.isOldRequest(requestId)) return;
-        this.requestSequencer.completed(requestId);
+        if (this.autocompleteRequestSequencer.isOldRequest(requestId)) return;
+        this.autocompleteRequestSequencer.completed(requestId);
 
         this._setState(autocompleted);
       });
@@ -320,7 +321,7 @@ export default class SearchDriver {
         isLoading: true
       });
 
-      const requestId = this.requestSequencer.next();
+      const requestId = this.searchRequestSequencer.next();
 
       const queryConfig = {
         ...this.searchQuery,
@@ -335,8 +336,8 @@ export default class SearchDriver {
 
       return this.events.search(requestState, queryConfig).then(
         resultState => {
-          if (this.requestSequencer.isOldRequest(requestId)) return;
-          this.requestSequencer.completed(requestId);
+          if (this.searchRequestSequencer.isOldRequest(requestId)) return;
+          this.searchRequestSequencer.completed(requestId);
 
           // Results paging start & end
           const { totalResults } = resultState;

--- a/packages/search-ui/src/test/helpers.js
+++ b/packages/search-ui/src/test/helpers.js
@@ -43,8 +43,12 @@ export function getMockApiConnector() {
   };
 }
 
-export function setupDriver({ mockSearchResponse, ...rest } = {}) {
-  const mockApiConnector = getMockApiConnector();
+export function setupDriver({
+  mockSearchResponse,
+  mockApiConnector,
+  ...rest
+} = {}) {
+  mockApiConnector = mockApiConnector || getMockApiConnector();
 
   if (mockSearchResponse) {
     mockApiConnector.onSearch = jest.fn().mockReturnValue({
@@ -108,4 +112,17 @@ export function getClickCalls(mockApiConnector) {
 
 export function getAutocompleteClickCalls(mockApiConnector) {
   return mockApiConnector.onAutocompleteResultClick.mock.calls;
+}
+
+/**
+ * Returns a promise that resolves after the current event loop.
+ *
+ * Useful for writing `await waitATick()` to wait for a promise to resolve.
+ */
+export function waitATick() {
+  let promiseResolve;
+  const promise = new Promise(resolve => (promiseResolve = resolve));
+  setTimeout(() => promiseResolve());
+  jest.runAllTimers();
+  return promise;
 }


### PR DESCRIPTION
Before submitting this PR:

1. Make sure you are PR'ing from a fork, please do not push branches directly
   to this repository.
2. Ensure you've written sufficient tests for your work.
3. Double check that your changes will not break existing connectors (if
   applicable).
4. Double check that your changes do not break the `react-search-ui-views`
   storybook (if applicable).

## Description
This change uses different sequencers for different types of requests. This might cause a race condition that is described by issue #452. 

## List of changes
- Initialize two sequencers one for autocomplete and other for search.
- Update snapshot for Paging.test

## Associated Github Issues
#452 