### PR TITLE
Facets should show string value for falsy values

### DIFF
--- a/packages/react-search-ui-views/src/__tests__/MultiCheckboxFacet.test.js
+++ b/packages/react-search-ui-views/src/__tests__/MultiCheckboxFacet.test.js
@@ -47,6 +47,32 @@ it("renders", () => {
   expect(wrapper).toMatchSnapshot();
 });
 
+it("renders falsey values correctly", () => {
+  const wrapper = shallow(
+    <MultiCheckboxFacet
+      {...params}
+      options={[
+        {
+          value: 0,
+          count: 10,
+          selected: false
+        },
+        {
+          value: false,
+          count: 20,
+          selected: false
+        },
+        {
+          value: "",
+          count: 30,
+          selected: false
+        }
+      ]}
+    />
+  );
+  expect(wrapper).toMatchSnapshot();
+});
+
 it("renders range filters", () => {
   const wrapper = shallow(
     <MultiCheckboxFacet {...params} option={rangeOptions} />

--- a/packages/react-search-ui-views/src/__tests__/SingleLinksFacet.test.js
+++ b/packages/react-search-ui-views/src/__tests__/SingleLinksFacet.test.js
@@ -17,6 +17,32 @@ it("renders correctly", () => {
   expect(wrapper).toMatchSnapshot();
 });
 
+it("renders falsey values correctly", () => {
+  const wrapper = shallow(
+    <SingleLinksFacet
+      {...params}
+      options={[
+        {
+          value: 0,
+          count: 10,
+          selected: false
+        },
+        {
+          value: false,
+          count: 20,
+          selected: false
+        },
+        {
+          value: "",
+          count: 30,
+          selected: false
+        }
+      ]}
+    />
+  );
+  expect(wrapper).toMatchSnapshot();
+});
+
 describe("determining selected option", () => {
   it("will correctly determine which of the options is selected", () => {
     const wrapper = shallow(

--- a/packages/react-search-ui-views/src/__tests__/SingleSelectFacet.test.js
+++ b/packages/react-search-ui-views/src/__tests__/SingleSelectFacet.test.js
@@ -32,6 +32,32 @@ it("renders", () => {
   expect(wrapper).toMatchSnapshot();
 });
 
+it("renders falsey values correctly", () => {
+  const wrapper = shallow(
+    <SingleSelectFacet
+      {...params}
+      options={[
+        {
+          value: 0,
+          count: 10,
+          selected: false
+        },
+        {
+          value: false,
+          count: 20,
+          selected: false
+        },
+        {
+          value: "",
+          count: 30,
+          selected: false
+        }
+      ]}
+    />
+  );
+  expect(wrapper).toMatchSnapshot();
+});
+
 describe("determining selected option", () => {
   it("will correctly determine which of the options is selected", () => {
     const wrapper = render(<SingleSelectFacet {...params} />);

--- a/packages/react-search-ui-views/src/__tests__/__snapshots__/MultiCheckboxFacet.test.js.snap
+++ b/packages/react-search-ui-views/src/__tests__/__snapshots__/MultiCheckboxFacet.test.js.snap
@@ -78,6 +78,109 @@ exports[`renders 1`] = `
 </fieldset>
 `;
 
+exports[`renders falsey values correctly 1`] = `
+<fieldset
+  className="sui-facet"
+>
+  <legend
+    className="sui-facet__title"
+  >
+    A Facet
+  </legend>
+  <div
+    className="sui-multi-checkbox-facet"
+  >
+    <label
+      className="sui-multi-checkbox-facet__option-label"
+      htmlFor="example_facet_A Facet0"
+      key="0"
+    >
+      <div
+        className="sui-multi-checkbox-facet__option-input-wrapper"
+      >
+        <input
+          checked={false}
+          className="sui-multi-checkbox-facet__checkbox"
+          id="example_facet_A Facet0"
+          onChange={[Function]}
+          type="checkbox"
+        />
+        <span
+          className="sui-multi-checkbox-facet__input-text"
+        >
+          0
+        </span>
+      </div>
+      <span
+        className="sui-multi-checkbox-facet__option-count"
+      >
+        10
+      </span>
+    </label>
+    <label
+      className="sui-multi-checkbox-facet__option-label"
+      htmlFor="example_facet_A Facetfalse"
+      key="false"
+    >
+      <div
+        className="sui-multi-checkbox-facet__option-input-wrapper"
+      >
+        <input
+          checked={false}
+          className="sui-multi-checkbox-facet__checkbox"
+          id="example_facet_A Facetfalse"
+          onChange={[Function]}
+          type="checkbox"
+        />
+        <span
+          className="sui-multi-checkbox-facet__input-text"
+        >
+          false
+        </span>
+      </div>
+      <span
+        className="sui-multi-checkbox-facet__option-count"
+      >
+        20
+      </span>
+    </label>
+    <label
+      className="sui-multi-checkbox-facet__option-label"
+      htmlFor="example_facet_A Facet"
+      key=""
+    >
+      <div
+        className="sui-multi-checkbox-facet__option-input-wrapper"
+      >
+        <input
+          checked={false}
+          className="sui-multi-checkbox-facet__checkbox"
+          id="example_facet_A Facet"
+          onChange={[Function]}
+          type="checkbox"
+        />
+        <span
+          className="sui-multi-checkbox-facet__input-text"
+        />
+      </div>
+      <span
+        className="sui-multi-checkbox-facet__option-count"
+      >
+        30
+      </span>
+    </label>
+  </div>
+  <button
+    aria-label="Show more options"
+    className="sui-facet-view-more"
+    onClick={[MockFunction]}
+    type="button"
+  >
+    + More
+  </button>
+</fieldset>
+`;
+
 exports[`renders range filters 1`] = `
 <fieldset
   className="sui-facet"

--- a/packages/react-search-ui-views/src/__tests__/__snapshots__/SingleLinksFacet.test.js.snap
+++ b/packages/react-search-ui-views/src/__tests__/__snapshots__/SingleLinksFacet.test.js.snap
@@ -53,3 +53,73 @@ exports[`renders correctly 1`] = `
   </div>
 </div>
 `;
+
+exports[`renders falsey values correctly 1`] = `
+<div
+  className="sui-facet"
+>
+  <div>
+    <div
+      className="sui-facet__title"
+    >
+      Facet
+    </div>
+    <ul
+      className="sui-single-option-facet"
+    >
+      <li
+        className="sui-single-option-facet__item"
+        key="0"
+      >
+        <a
+          className="sui-single-option-facet__link"
+          href="/"
+          onClick={[Function]}
+        >
+          0
+        </a>
+         
+        <span
+          className="sui-facet__count"
+        >
+          10
+        </span>
+      </li>
+      <li
+        className="sui-single-option-facet__item"
+        key="false"
+      >
+        <a
+          className="sui-single-option-facet__link"
+          href="/"
+          onClick={[Function]}
+        >
+          false
+        </a>
+         
+        <span
+          className="sui-facet__count"
+        >
+          20
+        </span>
+      </li>
+      <li
+        className="sui-single-option-facet__item"
+        key=""
+      >
+        <a
+          className="sui-single-option-facet__link"
+          href="/"
+          onClick={[Function]}
+        />
+         
+        <span
+          className="sui-facet__count"
+        >
+          30
+        </span>
+      </li>
+    </ul>
+  </div>
+</div>
+`;

--- a/packages/react-search-ui-views/src/__tests__/__snapshots__/SingleSelectFacet.test.js.snap
+++ b/packages/react-search-ui-views/src/__tests__/__snapshots__/SingleSelectFacet.test.js.snap
@@ -66,3 +66,56 @@ exports[`renders 1`] = `
   />
 </div>
 `;
+
+exports[`renders falsey values correctly 1`] = `
+<div
+  className="sui-facet"
+>
+  <div
+    className="sui-facet__title"
+  >
+    A Facet
+  </div>
+  <StateManager
+    className="sui-select"
+    classNamePrefix="sui-select"
+    components={
+      Object {
+        "Option": [Function],
+      }
+    }
+    defaultInputValue=""
+    defaultMenuIsOpen={false}
+    defaultValue={null}
+    isSearchable={false}
+    onChange={[Function]}
+    options={
+      Array [
+        Object {
+          "count": 10,
+          "label": "0",
+          "value": 0,
+        },
+        Object {
+          "count": 20,
+          "label": "false",
+          "value": false,
+        },
+        Object {
+          "count": 30,
+          "label": "",
+          "value": "",
+        },
+      ]
+    }
+    styles={
+      Object {
+        "control": [Function],
+        "dropdownIndicator": [Function],
+        "indicatorSeparator": [Function],
+        "option": [Function],
+      }
+    }
+  />
+</div>
+`;

--- a/packages/react-search-ui-views/src/view-helpers/getFilterValueDisplay.js
+++ b/packages/react-search-ui-views/src/view-helpers/getFilterValueDisplay.js
@@ -4,7 +4,7 @@ encapsulates the logic for determining how to show the label of that
 filter in the UI.
 */
 export default function getFilterValueDisplay(filterValue) {
-  if (!filterValue) return "";
+  if (filterValue === undefined || filterValue === null) return "";
   if (filterValue.hasOwnProperty("name")) return filterValue.name;
   return String(filterValue);
 }

--- a/packages/react-search-ui-views/stories/MultiCheckboxFacet.stories.js
+++ b/packages/react-search-ui-views/stories/MultiCheckboxFacet.stories.js
@@ -91,4 +91,38 @@ storiesOf("Facets/MultiCheckboxFacet", module)
         searchPlaceholder: "Search..."
       }}
     />
+  ))
+  .add("with falsey values", () => (
+    <MultiCheckboxFacet
+      {...{
+        ...baseProps,
+        options: [
+          {
+            value: 0,
+            count: 10,
+            selected: false
+          },
+          {
+            value: false,
+            count: 20,
+            selected: false
+          },
+          {
+            value: "",
+            count: 30,
+            selected: false
+          },
+          {
+            value: undefined,
+            count: 30,
+            selected: false
+          },
+          {
+            value: null,
+            count: 30,
+            selected: false
+          }
+        ]
+      }}
+    />
   ));

--- a/packages/react-search-ui-views/stories/SingleLinksFacet.stories.js
+++ b/packages/react-search-ui-views/stories/SingleLinksFacet.stories.js
@@ -84,4 +84,38 @@ storiesOf("Facets/SingleLinksFacet", module)
         )
       }}
     />
+  ))
+  .add("with falsey values", () => (
+    <SingleLinksFacet
+      {...{
+        ...baseProps,
+        options: [
+          {
+            value: 0,
+            count: 10,
+            selected: false
+          },
+          {
+            value: false,
+            count: 20,
+            selected: false
+          },
+          {
+            value: "",
+            count: 30,
+            selected: false
+          },
+          {
+            value: undefined,
+            count: 30,
+            selected: false
+          },
+          {
+            value: null,
+            count: 30,
+            selected: false
+          }
+        ]
+      }}
+    />
   ));

--- a/packages/react-search-ui-views/stories/SingleSelectFacet.stories.js
+++ b/packages/react-search-ui-views/stories/SingleSelectFacet.stories.js
@@ -62,4 +62,38 @@ storiesOf("Facets/SingleSelectFacet", module)
         )
       }}
     />
+  ))
+  .add("with falsey values", () => (
+    <SingleSelectFacet
+      {...{
+        ...baseProps,
+        options: [
+          {
+            value: 0,
+            count: 10,
+            selected: false
+          },
+          {
+            value: false,
+            count: 20,
+            selected: false
+          },
+          {
+            value: "",
+            count: 30,
+            selected: false
+          },
+          {
+            value: undefined,
+            count: 30,
+            selected: false
+          },
+          {
+            value: null,
+            count: 30,
+            selected: false
+          }
+        ]
+      }}
+    />
   ));


### PR DESCRIPTION
##  Description

Values like `0` or `false` were being thrown out and an empty string
was being shown instead. This fixes that in all facet views.

<img width="228" alt="before" src="https://user-images.githubusercontent.com/1427475/72079332-b46b4b80-32c8-11ea-9a56-e196f5e17b7f.png">

<img width="228" alt="after" src="https://user-images.githubusercontent.com/1427475/72079340-b92fff80-32c8-11ea-9b17-53e587b856b4.png">

## Associated Github Issues

Fixes #453 
