### PR TITLE
Changed sideEffects in package.json for CSS

### DIFF
--- a/packages/react-search-ui-views/package.json
+++ b/packages/react-search-ui-views/package.json
@@ -5,7 +5,9 @@
   "license": "Apache-2.0",
   "main": "lib",
   "module": "es",
-  "sideEffects": false,
+  "sideEffects": [
+    "*.css"
+  ],
   "directories": {
     "lib": "lib",
     "test": "__tests__"


### PR DESCRIPTION
## Description

CSS should be marked as having side effects in package.json. Otherwise,
an import like...

```
import "@elastic/react-search-ui-views/styles.css"
```

... will be viewed by tree shaking as an unused import. By using ...

```
sideEffects: [
  "*.css*
]
```

... we ensure that css imports will not be dropped by tree shaking.

For reference: https://github.com/gatsbyjs/gatsby/issues/19446

I set up a project to illustrate this problem: https://github.com/JasonStoltz/example-for-gatsby-issue

After pulling the project down, run:
```
npm install
npx gatsby build
npx gatsby serve
```

The resultant screen should be styled with search UI styles.

For comparison, you can revert the latest [commit](https://github.com/JasonStoltz/example-for-gatsby-issue/commit/f05cd5d4966cdde4c6e5baec07d1d1adf0965fef) in that repo to see how styles were not applied previously.

I published the changes from this PR in a `1.3.3-canary.1` pre-release version of Search UI, which the above example uses to validate the fix for this issue.

## Associated Github Issues

Fixes #440