### PR TITLE
Added ResultWithRequiredId type

### DIFF
--- a/packages/react-search-ui-views/src/Autocomplete.js
+++ b/packages/react-search-ui-views/src/Autocomplete.js
@@ -1,7 +1,7 @@
 import PropTypes from "prop-types";
 import React from "react";
 
-import { Result } from "./types";
+import { ResultWithRequiredId as Result } from "./types";
 import { Suggestion } from "./types";
 import { appendClassName } from "./view-helpers";
 

--- a/packages/react-search-ui-views/src/types/Result.js
+++ b/packages/react-search-ui-views/src/types/Result.js
@@ -2,15 +2,10 @@ import PropTypes from "prop-types";
 
 import FieldValueWrapper from "./FieldValueWrapper";
 
-// Typically an object where keys are the field names, and values are field values.
-// Also could be literally any other arbitrary value depending on the particular Search API response.
-// Default views in Search UI know what to do with FieldValueWrapper values, but not arbitrary values, so it
-// is usually better to work with FieldValueWrapper values. We encourage FieldValueWrapper, but we accept
-// anything because we don't want users to have type error warnings unnecessarily.
+// If field is a "FieldValueWrapper", it can be displayed by the UI.
 //
-// An example would be if a user requests "grouping" in an App Search API request. That will come back
-// as "_group: {..}". It *should* be there in the Result so that a developer has it available to work
-// with.
+// If it is any other object ("PropTypes.any"), it will be passed along with
+// the object but will be ignored by the UI.
 export default PropTypes.objectOf(
   PropTypes.oneOfType([PropTypes.any, FieldValueWrapper])
 );

--- a/packages/react-search-ui-views/src/types/ResultWithRequiredId.js
+++ b/packages/react-search-ui-views/src/types/ResultWithRequiredId.js
@@ -1,0 +1,18 @@
+import PropTypes from "prop-types";
+
+/*
+  [TODO Next Major]
+
+  This file exists alongside Result.js to enforce that Result objects have an
+  ID in certain views that already require it.
+
+  I wanted to add id directly to Result.js, but that would be a breaking change. This exists
+  to give better validation warnings to those files that already implicitly required it.
+*/
+export default PropTypes.objectOf(
+  PropTypes.shape({
+    id: PropTypes.shape({
+      raw: PropTypes.string
+    }).isRequired
+  }).isRequired
+);

--- a/packages/react-search-ui-views/src/types/index.js
+++ b/packages/react-search-ui-views/src/types/index.js
@@ -9,4 +9,5 @@ export { default as FilterValue } from "./FilterValue";
 export { default as FilterValueValue } from "./FilterValueValue";
 export { default as FilterValueRange } from "./FilterValueRange";
 export { default as Result } from "./Result";
+export { default as ResultWithRequiredId } from "./ResultWithRequiredId";
 export { default as Suggestion } from "./Suggestion";

--- a/packages/react-search-ui/src/containers/Result.js
+++ b/packages/react-search-ui/src/containers/Result.js
@@ -3,7 +3,7 @@ import { Component } from "react";
 import { Result } from "@elastic/react-search-ui-views";
 
 import { withSearch } from "..";
-import { Result as ResultType } from "../types";
+import { ResultWithRequiredId as ResultType } from "../types";
 
 export class ResultContainer extends Component {
   static propTypes = {

--- a/packages/react-search-ui/src/containers/Results.js
+++ b/packages/react-search-ui/src/containers/Results.js
@@ -4,7 +4,7 @@ import { Result, Results } from "@elastic/react-search-ui-views";
 
 import { withSearch } from "..";
 import { Result as ResultContainer } from ".";
-import { Result as ResultType } from "../types";
+import { ResultWithRequiredId as ResultType } from "../types";
 
 function getRaw(result, value) {
   if (!result[value] || !result[value].raw) return;

--- a/packages/react-search-ui/src/types/Result.js
+++ b/packages/react-search-ui/src/types/Result.js
@@ -2,15 +2,10 @@ import PropTypes from "prop-types";
 
 import FieldValueWrapper from "./FieldValueWrapper";
 
-// Typically an object where keys are the field names, and values are field values.
-// Also could be literally any other arbitrary value depending on the particular Search API response.
-// Default views in Search UI know what to do with FieldValueWrapper values, but not arbitrary values, so it
-// is usually better to work with FieldValueWrapper values. We encourage FieldValueWrapper, but we accept
-// anything because we don't want users to have type error warnings unnecessarily.
+// If field is a "FieldValueWrapper", it can be displayed by the UI.
 //
-// An example would be if a user requests "grouping" in an App Search API request. That will come back
-// as "_group: {..}". It *should* be there in the Result so that a developer has it available to work
-// with.
+// If it is any other object ("PropTypes.any"), it will be passed along with
+// the object but will be ignored by the UI.
 export default PropTypes.objectOf(
   PropTypes.oneOfType([PropTypes.any, FieldValueWrapper])
 );

--- a/packages/react-search-ui/src/types/ResultWithRequiredId.js
+++ b/packages/react-search-ui/src/types/ResultWithRequiredId.js
@@ -1,0 +1,18 @@
+import PropTypes from "prop-types";
+
+/*
+  [TODO Next Major]
+
+  This file exists alongside Result.js to enforce that Result objects have an
+  ID in certain views that already require it.
+
+  I wanted to add id directly to Result.js, but that would be a breaking change. This exists
+  to give better validation warnings to those files that already implicitly required it.
+*/
+export default PropTypes.objectOf(
+  PropTypes.shape({
+    id: PropTypes.shape({
+      raw: PropTypes.string
+    }).isRequired
+  }).isRequired
+);

--- a/packages/react-search-ui/src/types/index.js
+++ b/packages/react-search-ui/src/types/index.js
@@ -8,6 +8,7 @@ export { default as FilterValue } from "./FilterValue";
 export { default as FilterValueValue } from "./FilterValueValue";
 export { default as FilterValueRange } from "./FilterValueRange";
 export { default as Result } from "./Result";
+export { default as ResultWithRequiredId } from "./ResultWithRequiredId";
 export { default as Suggestion } from "./Suggestion";
 
 export { default as SortOption } from "./SortOption";


### PR DESCRIPTION
Some views actually required an "id" property on result objects
to function properly, which was not expressed in validations.

I couldn't simply turn on an "id" requirement for Result across
the board because it could break certain views that actually
don't require it currently.

For that reason, I create a separate view, ResultWithRequiredId, which
enforces the "id" requirement.

The views will still error if an "id" is missing, but at least now a proper error message will be shown in the console.

I also added a special "TODO Next Major" to help indicate breaking
changes that should be made in the next major.

<img width="1678" alt="React_App" src="https://user-images.githubusercontent.com/1427475/72286579-6bdac780-3613-11ea-8d69-9b0ffcd53f3a.png">


## Associated Github Issues

Fixes #444
