### PR TITLE
WIP: Added Typescript Definitions to search-ui-app-search-connector

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -158,7 +158,12 @@ stacks:
 - Elastic Site Search: https://search-ui-stable-site-search.netlify.com/
 - Elasticsearch: https://search-ui-stable-elasticsearch.netlify.com/
 
-### Updating Typescript Declarations
+## JSDoc
+
+JSDoc should be used for documentation public methods. The JSDoc can then be used
+as source for both documentation and Typescript Declarations.
+
+### Updating Typescript Declarations from JSDoc
 
 Typescript declarations are maintained in top level `.d.ts` file in each individual package.
 
@@ -173,4 +178,7 @@ Typescript declaration changes should follow a flow of:
 4. Manually update any `Object` types from JSDoc comments that were converted to `any` to `object`. (See https://github.com/Microsoft/TypeScript/issues/20337 for more detail).
 5. Delete all `.d.ts` files that were generated.
 
--
+### Updating Code References from JSDoc
+
+To update code references in READMEs, assuming JSDoc is in place, use the https://github.com/jsdoc2md/jsdoc-to-markdown cli. An current example of this is in the search-ui-app-search-connector
+README.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -157,3 +157,20 @@ stacks:
 - Elastic App Search: https://search-ui-stable.netlify.com/
 - Elastic Site Search: https://search-ui-stable-site-search.netlify.com/
 - Elasticsearch: https://search-ui-stable-elasticsearch.netlify.com/
+
+### Updating Typescript Declarations
+
+Typescript declarations are maintained in top level `.d.ts` file in each individual package.
+
+We primarily generate them from JSDoc comments using the typescript CLI, following the standards
+in http://www.typescriptlang.org/docs/handbook/type-checking-javascript-files.html#supported-jsdoc as a guideline.
+
+Typescript declaration changes should follow a flow of:
+
+1. Update JSDoc in source
+2. Regenerate declaration using the command `tsc --declaration --emitDeclarationOnly --allowJs --removeComments <source_file>.js`
+3. Copy updates manually from generated file into `search-ui-app-search-connector.d.ts`
+4. Manually update any `Object` types from JSDoc comments that were converted to `any` to `object`. (See https://github.com/Microsoft/TypeScript/issues/20337 for more detail).
+5. Delete all `.d.ts` files that were generated.
+
+-

--- a/packages/react-search-ui/package.json
+++ b/packages/react-search-ui/package.json
@@ -5,6 +5,7 @@
   "license": "Apache-2.0",
   "main": "lib",
   "module": "es",
+  "types": "react-search-ui.d.ts",
   "sideEffects": false,
   "directories": {
     "lib": "lib",

--- a/packages/react-search-ui/package.json
+++ b/packages/react-search-ui/package.json
@@ -13,7 +13,8 @@
   },
   "files": [
     "lib",
-    "es"
+    "es",
+    "react-search-ui.d.ts"
   ],
   "repository": {
     "type": "git",

--- a/packages/react-search-ui/react-search-ui.d.ts
+++ b/packages/react-search-ui/react-search-ui.d.ts
@@ -1,0 +1,345 @@
+declare module "@elastic/react-search-ui" {
+
+  import { Component } from 'react';
+
+  type func = (...args: any[]) => any;
+  type renderFunc = (...args: any[]) => JSX.Element;
+
+  /**
+   * FIELDS
+   */
+  export type FieldValue = string | number | boolean | Array<string | number | boolean>;
+
+  export interface FieldValueWrapper {
+    // A raw field value, like 'I am a raw result', or 2, or true. Raw values may
+    // or may not be html escaped, so *always* sanitize a raw value before rendering
+    // it on a page as html.
+    raw?: FieldValue;
+    // A snippet value contains a highlighted value. I.e., 'I <em>am</em> a raw
+    // result'. These are always sanitized and safe to render as html.
+    snippet?: string;
+  }
+
+  /**
+   * FACETS
+   */
+  export type FacetType = "range" | "value";
+
+  export interface FacetValue {
+    // Number of results for this filter
+    count: number;
+    // Filter to apply if selected
+    value: FilterValue;
+    // Whether or not this facet value is selected
+    selected?: boolean;
+  }
+
+  interface FacetT {
+    data: FacetValue[];
+    // Name of the field this facet is associated with
+    field: string;
+    type: FacetType;
+  }
+
+  /**
+   * FILTERS
+   */
+  export interface Filter {
+    field: string;
+    values: FilterValue[];
+    type: FilterType;
+  }
+
+  export type FilterType = "all" | "any" | "none";
+
+  export type FilterValueValue = FieldValue;
+
+  export interface FilterValueRange {
+    // Beginning of the range, like 1
+    from?: FieldValue;
+    // A unique name for this range, used for display
+    name: string;
+    // End of the range, like 100
+    to?: FieldValue;
+  }
+
+  export type FilterValue = FilterValueRange | FilterValueValue;
+
+  /**
+   * RESULTS
+   */
+  // Typically an object where keys are the field names, and values are field values.
+  // Also could be literally any other arbitrary value depending on the particular Search API response.
+  // Default views in Search UI know what to do with FieldValueWrapper values, but not arbitrary values, so it
+  // is usually better to work with FieldValueWrapper values.
+  // We only accept FieldValueWrapper to help typing
+  //
+  // An example would be if a user requests "grouping" in an App Search API request. That will come back
+  // as "_group: {..}". It *should* be there in the Result so that a developer has it available to work
+  // with.
+  interface ResultT {
+    [key: string]: FieldValueWrapper;
+  }
+
+  /**
+   * SORTING
+   */
+
+  export type SortDirection = "asc" | "desc";
+
+  export interface SortOption {
+    // A display name, like "Name"
+    name?: string;
+    // A field name, like "name".
+    value?: string;
+    // asc or desc
+    direction?: SortDirection | "";
+  }
+
+  export interface Suggestion {
+    suggestion?: string;
+    highlight?: string;
+    data?: object;
+  }
+
+  export interface AutocompleteSection {
+    sectionTitle?: string;
+  }
+
+  /**
+   * CONTAINERS
+   */
+  interface ErrorBoundaryProps {
+    // Props
+    children: JSX.Element;
+    className?: string;
+    view?: renderFunc;
+    // State
+    error?: string;
+  }
+
+  export class ErrorBoundary extends Component<ErrorBoundaryProps> {}
+
+  interface FacetProps {
+    // Props
+
+    className?: string;
+    field: string;
+    label: string;
+    filterType?: FilterType;
+    show?: number;
+    view?: renderFunc;
+    isFilterable?: boolean;
+
+    // State
+
+    filters?: Filter[];
+    facets?: { [key: string]: FacetT[] };
+
+    // Actions
+
+    addFilter?: func;
+    removeFilter?: func;
+    setFilter?: func;
+    a11yNotify?: func;
+  }
+
+  export class Facet extends Component<FacetProps> {}
+
+  interface ResultProps {
+    // Props
+
+    className?: string;
+    clickThroughTags?: string[];
+    titleField?: string;
+    urlField?: string;
+    view?: renderFunc;
+    result: ResultT;
+    shouldTrackClickThrough?: boolean;
+
+    // Actions
+
+    trackClickThrough?: func;
+  }
+
+  export class Result extends Component<ResultProps> {}
+
+  interface ResultsContainerProps {
+    // Props
+
+    className?: string;
+    clickThroughTags?: string[];
+    resultView?: renderFunc;
+    titleField?: string;
+    urlField?: string;
+    view?: renderFunc;
+    shouldTrackClickThrough?: boolean;
+
+    // State
+
+    results: ResultT[];
+  }
+
+  export class Results extends Component<ResultsContainerProps> {}
+
+  interface SearchBoxProps {
+    // Props
+
+    autocompleteMinimumCharacters?: number;
+    autocompleteResults?: boolean | {
+    clickThroughTags?: string[];
+    linkTarget?: string;
+    sectionTitle?: string;
+    shouldTrackClickThrough?: boolean;
+    titleField: string;
+    urlField: string
+    };
+    autocompleteSuggestions?: boolean | AutocompleteSection | {[key: string]: AutocompleteSection};
+    autocompleteView?: renderFunc;
+    className?: string;
+    shouldClearFilters?: boolean;
+    debounceLength?: number;
+    inputProps?: Partial<HTMLInputElement>;
+    inputView?: renderFunc;
+    onSelectAutocomplete?: func;
+    onSubmit?: func;
+    searchAsYouType?: boolean;
+    view?: renderFunc;
+
+    // State
+
+    autocompletedResults?: ResultT[];
+    autocompletedSuggestions?: { [key: string]: Suggestion[] };
+    searchTerm?: string;
+
+    // Actions
+
+    setSearchTerm?: func;
+    trackAutocompleteClickThrough?: func;
+  }
+
+  export class SearchBox extends Component<SearchBoxProps> {}
+
+  interface PagingInfoProps {
+    // Props
+
+    className?: string;
+    view?: renderFunc;
+
+    // State
+
+    pagingStart?: number;
+    pagingEnd?: number;
+    resultSearchTerm?: string;
+    totalResults?: number;
+  }
+
+  export class PagingInfo extends Component<PagingInfoProps> {}
+
+  interface PagingProps {
+    // Props
+
+    className?: string;
+    view?: renderFunc;
+
+    // State
+
+    current?: number;
+    resultsPerPage?: number;
+    totalPages?: number;
+
+    // Action
+
+    setCurrent?: func;
+  }
+
+  export class Paging extends Component<PagingProps> {}
+
+  interface ResultsPerPageProps {
+    // Props
+
+    className?: string;
+    view?: renderFunc;
+    options?: number[];
+
+    // State
+
+    resultsPerPage?: number;
+
+    // Actions
+
+    setResultsPerPage?: func;
+  }
+
+  export class ResultsPerPage extends Component<ResultsPerPageProps> {}
+
+  interface SortingProps {
+    // Props
+
+    className?: string;
+    label?: string;
+    sortOptions: SortOption[];
+    view?: renderFunc;
+
+    // State
+
+    sortDirection?: "asc" | "desc" | "";
+    sortField?: string;
+
+    // Actions
+
+    setSort?: func;
+  }
+
+  export class Sorting extends Component<SortingProps> {}
+
+  /**
+   * SEARCH
+   */
+  /**
+   * Context
+   */
+  export interface Context {
+    // Search State
+
+    current: number;
+    filters?: Filter[];
+    resultsPerPage?: number;
+    searchTerm?: string;
+    sortDirection?: SortDirection;
+    sortField?: string;
+
+    // Response State
+
+    autocompletedResults: Result[]; // An array of results items fetched for an autocomplete dropdown.
+    autocompletedResultsRequestId: string; // A unique ID for the current autocompleted search results.
+    autocompletedSuggestions: {[key: string]: Suggestion[] }; // A keyed object of query suggestions. It's keyed by type since multiple types of query suggestions can be set here.
+    autocompletedSuggestionsRequestId: string; // A unique ID for the current autocompleted suggestion results.
+    facets?: Facet; // Will be populated if facets configured in Advanced Configuration.
+    requestId: string; // A unique ID for the current search results.
+    results: Result[]; // An array of result items.
+    resultSearchTerm: string; // This is tied to the searchTerm for the current results.
+    totalResults: number; // Total number of results found for the current query.
+
+    // Application State
+
+    error?: string; // Error message, if an error was thrown.
+    isLoading: boolean; // Whether or not a search is currently being performed.
+    wasSearched: boolean; // Has any query been performed since this driver was created? Can be useful for displaying initial states in the UI.;
+  }
+
+  interface WithSearchProps {
+    mapContextToProps?: (context: Context) => any;
+    children: (props: any) => JSX.Element;
+  }
+
+  export class WithSearch extends Component<WithSearchProps> {}
+
+  interface SearchProviderProps {
+    config?: object;  // Matches the shape of SearchDriver, which needs to be typed
+    children: JSX.Element;
+  }
+
+  export class SearchProvider extends Component<SearchProviderProps> {}
+
+}

--- a/packages/search-ui-app-search-connector/README.md
+++ b/packages/search-ui-app-search-connector/README.md
@@ -35,12 +35,12 @@ const connector = new AppSearchAPIConnector({
 ## Typedefs
 
 <dl>
-<dt><a href="#next">next</a> : <code>function</code></dt>
+<dt><a href="#next">next</a> ⇒ <code>Object</code></dt>
 <dd></dd>
-<dt><a href="#hook">hook</a> : <code>function</code></dt>
-<dd></dd>
-<dt><a href="#Options">Options</a></dt>
-<dd></dd>
+<dt><a href="#hook">hook</a> ⇒ <code>Object</code></dt>
+<dd><p>Hooks work like middleware. This gives you an opportunity to modify the request and response
+to for a particular API call.</p>
+</dd>
 </dl>
 
 <a name="AppSearchAPIConnector"></a>
@@ -52,15 +52,23 @@ const connector = new AppSearchAPIConnector({
 
 ### new AppSearchAPIConnector(options)
 
-| Param   | Type                             |
-| ------- | -------------------------------- |
-| options | [<code>Options</code>](#Options) |
+| Param                                       | Type                       | Description                                                                                                                                                         |
+| ------------------------------------------- | -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| options                                     | <code>Object</code>        | Credential found in your App Search Dashboard                                                                                                                       |
+| options.searchKey                           | <code>string</code>        | Credential found in your App Search Dashboard                                                                                                                       |
+| options.engineName                          | <code>string</code>        | Engine to query, found in your App Search Dashboard                                                                                                                 |
+| [options.hostIdentifier]                    | <code>string</code>        | Credential found in your App Search Dashboard. Required only if not using the endpointBase option.                                                                  |
+| [options.beforeSearchCall]                  | [<code>hook</code>](#hook) | A hook to amend request or response to API for "onSearch" event.                                                                                                    |
+| [options.beforeAutocompleteResultsCall]     | [<code>hook</code>](#hook) | A hook to amend request or response to API for a "results" query on an "onAutocomplete" event.                                                                      |
+| [options.beforeAutocompleteSuggestionsCall] | [<code>hook</code>](#hook) | A hook to amend request or response to API for a "suggestions" query on an "onAutocomplete" event.                                                                  |
+| [options.endpointBase]                      | <code>string</code>        | Overrides the base of the Swiftype API endpoint completely. Useful for non-SaaS App Search deployments. For example, Elastic Cloud, Self-Managed, or proxying SaaS. |
 
 <a name="next"></a>
 
-## next : <code>function</code>
+## next ⇒ <code>Object</code>
 
 **Kind**: global typedef
+**Returns**: <code>Object</code> - The API response
 
 | Param               | Type                | Description                    |
 | ------------------- | ------------------- | ------------------------------ |
@@ -68,27 +76,15 @@ const connector = new AppSearchAPIConnector({
 
 <a name="hook"></a>
 
-## hook : <code>function</code>
+## hook ⇒ <code>Object</code>
+
+Hooks work like middleware. This gives you an opportunity to modify the request and response
+to for a particular API call.
 
 **Kind**: global typedef
+**Returns**: <code>Object</code> - The API response, which may or may not have been amended by this hook
 
 | Param        | Type                       | Description                                      |
 | ------------ | -------------------------- | ------------------------------------------------ |
 | queryOptions | <code>Object</code>        | The options that are about to be sent to the API |
-| next         | [<code>next</code>](#next) | The options that are about to be sent to the API |
-
-<a name="Options"></a>
-
-## Options
-
-**Kind**: global typedef
-
-| Param                             | Type                       | Default                                                      | Description                                                                                                                   |
-| --------------------------------- | -------------------------- | ------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------- |
-| searchKey                         | <code>string</code>        |                                                              | Credential found in your App Search Dashboard                                                                                 |
-| engineName                        | <code>string</code>        |                                                              | Engine to query, found in your App Search Dashboard                                                                           |
-| hostIdentifier                    | <code>string</code>        |                                                              | Credential found in your App Search Dashboard Useful when proxying the Swiftype API or developing against a local API server. |
-| beforeSearchCall                  | [<code>hook</code>](#hook) | <code>(queryOptions,next)&#x3D;&gt;next(queryOptions)</code> | A hook to amend query options before the request is sent to the API in a query on an "onSearch" event.                        |
-| beforeAutocompleteResultsCall     | [<code>hook</code>](#hook) | <code>(queryOptions,next)&#x3D;&gt;next(queryOptions)</code> | A hook to amend query options before the request is sent to the API in a "results" query on an "onAutocomplete" event.        |
-| beforeAutocompleteSuggestionsCall | [<code>hook</code>](#hook) | <code>(queryOptions,next)&#x3D;&gt;next(queryOptions)</code> | A hook to amend query options before the request is sent to the API in a "suggestions" query on an "onAutocomplete" event.    |
-| endpointBase                      | <code>string</code>        | <code>""</code>                                              | Overrides the base of the Swiftype API endpoint completely.                                                                   |
+| next         | [<code>next</code>](#next) | Callback to continue to make the actual API call |

--- a/packages/search-ui-app-search-connector/package.json
+++ b/packages/search-ui-app-search-connector/package.json
@@ -13,7 +13,8 @@
   },
   "files": [
     "lib",
-    "es"
+    "es",
+    "search-ui-app-search-connector.d.ts"
   ],
   "repository": {
     "type": "git",

--- a/packages/search-ui-app-search-connector/package.json
+++ b/packages/search-ui-app-search-connector/package.json
@@ -5,6 +5,7 @@
   "license": "Apache-2.0",
   "main": "lib",
   "module": "es",
+  "types": "search-ui-app-search-connector.d.ts",
   "sideEffects": false,
   "directories": {
     "lib": "lib",

--- a/packages/search-ui-app-search-connector/search-ui-app-search-connector.d.ts
+++ b/packages/search-ui-app-search-connector/search-ui-app-search-connector.d.ts
@@ -1,32 +1,5 @@
 declare module "@elastic/search-ui-app-search-connector" {
   class AppSearchAPIConnector {
-    /**
-     * @typedef {Object.<string, *>} KeyValuePairs
-     */
-    /**
-     * @callback next
-     * @param {KeyValuePairs} updatedQueryOptions The options to send to the API
-     * @returns {Object} The response
-     */
-    /**
-     * @callback hook
-     * @param {KeyValuePairs} queryOptions The options that are about to be sent to the API
-     * @param {next} next The options that are about to be sent to the API
-     */
-    /**
-     * @param {Object} options Credential found in your App Search Dashboard
-     * @param {string} options.searchKey Credential found in your App Search Dashboard
-     * @param {string} options.engineName Engine to query, found in your App Search Dashboard
-     * @param {string=} options.hostIdentifier Credential found in your App Search Dashboard. Required only if not using
-     * the endpointBase option.
-     * @param {hook=} options.beforeSearchCall A hook to amend request or response to API for "onSearch" event.
-     * @param {hook=} options.beforeAutocompleteResultsCall A hook to amend request or response to API for a "results"
-     * query on an "onAutocomplete" event.
-     * @param {hook=} options.beforeAutocompleteSuggestionsCall A hook to amend request or response to API for a "suggestions"
-     * query on an "onAutocomplete" event.
-     * @param {string=} options.endpointBase="" Overrides the base of the Swiftype API endpoint completely. Useful
-     * for non-SaaS App Search deployments. For example, Elastic Cloud, Self-Managed, or proxying SaaS.
-     */
     constructor({
       searchKey,
       engineName,
@@ -40,22 +13,16 @@ declare module "@elastic/search-ui-app-search-connector" {
       engineName: string;
       hostIdentifier?: string;
       beforeSearchCall?: (
-        queryOptions: {
-          [x: string]: any;
-        },
-        next: (updatedQueryOptions: { [x: string]: any }) => any
+        queryOptions: object,
+        next: (updatedQueryOptions: object) => any
       ) => any;
       beforeAutocompleteResultsCall?: (
-        queryOptions: {
-          [x: string]: any;
-        },
-        next: (updatedQueryOptions: { [x: string]: any }) => any
+        queryOptions: object,
+        next: (updatedQueryOptions: object) => any
       ) => any;
       beforeAutocompleteSuggestionsCall?: (
-        queryOptions: {
-          [x: string]: any;
-        },
-        next: (updatedQueryOptions: { [x: string]: any }) => any
+        queryOptions: object,
+        next: (updatedQueryOptions: object) => any
       ) => any;
       endpointBase?: string;
     });

--- a/packages/search-ui-app-search-connector/search-ui-app-search-connector.d.ts
+++ b/packages/search-ui-app-search-connector/search-ui-app-search-connector.d.ts
@@ -1,0 +1,65 @@
+declare module "@elastic/search-ui-app-search-connector" {
+  class AppSearchAPIConnector {
+    /**
+     * @typedef {Object.<string, *>} KeyValuePairs
+     */
+    /**
+     * @callback next
+     * @param {KeyValuePairs} updatedQueryOptions The options to send to the API
+     * @returns {Object} The response
+     */
+    /**
+     * @callback hook
+     * @param {KeyValuePairs} queryOptions The options that are about to be sent to the API
+     * @param {next} next The options that are about to be sent to the API
+     */
+    /**
+     * @param {Object} options Credential found in your App Search Dashboard
+     * @param {string} options.searchKey Credential found in your App Search Dashboard
+     * @param {string} options.engineName Engine to query, found in your App Search Dashboard
+     * @param {string=} options.hostIdentifier Credential found in your App Search Dashboard. Required only if not using
+     * the endpointBase option.
+     * @param {hook=} options.beforeSearchCall A hook to amend request or response to API for "onSearch" event.
+     * @param {hook=} options.beforeAutocompleteResultsCall A hook to amend request or response to API for a "results"
+     * query on an "onAutocomplete" event.
+     * @param {hook=} options.beforeAutocompleteSuggestionsCall A hook to amend request or response to API for a "suggestions"
+     * query on an "onAutocomplete" event.
+     * @param {string=} options.endpointBase="" Overrides the base of the Swiftype API endpoint completely. Useful
+     * for non-SaaS App Search deployments. For example, Elastic Cloud, Self-Managed, or proxying SaaS.
+     */
+    constructor({
+      searchKey,
+      engineName,
+      hostIdentifier,
+      beforeSearchCall,
+      beforeAutocompleteResultsCall,
+      beforeAutocompleteSuggestionsCall,
+      endpointBase
+    }: {
+      searchKey: string;
+      engineName: string;
+      hostIdentifier?: string;
+      beforeSearchCall?: (
+        queryOptions: {
+          [x: string]: any;
+        },
+        next: (updatedQueryOptions: { [x: string]: any }) => any
+      ) => any;
+      beforeAutocompleteResultsCall?: (
+        queryOptions: {
+          [x: string]: any;
+        },
+        next: (updatedQueryOptions: { [x: string]: any }) => any
+      ) => any;
+      beforeAutocompleteSuggestionsCall?: (
+        queryOptions: {
+          [x: string]: any;
+        },
+        next: (updatedQueryOptions: { [x: string]: any }) => any
+      ) => any;
+      endpointBase?: string;
+    });
+  }
+
+  export default AppSearchAPIConnector;
+}

--- a/packages/search-ui-app-search-connector/search-ui-app-search-connector.d.ts
+++ b/packages/search-ui-app-search-connector/search-ui-app-search-connector.d.ts
@@ -14,15 +14,15 @@ declare module "@elastic/search-ui-app-search-connector" {
       hostIdentifier?: string;
       beforeSearchCall?: (
         queryOptions: object,
-        next: (updatedQueryOptions: object) => any
+        next: (updatedQueryOptions: object) => object
       ) => any;
       beforeAutocompleteResultsCall?: (
         queryOptions: object,
-        next: (updatedQueryOptions: object) => any
+        next: (updatedQueryOptions: object) => object
       ) => any;
       beforeAutocompleteSuggestionsCall?: (
         queryOptions: object,
-        next: (updatedQueryOptions: object) => any
+        next: (updatedQueryOptions: object) => object
       ) => any;
       endpointBase?: string;
     });

--- a/packages/search-ui-app-search-connector/src/AppSearchAPIConnector.js
+++ b/packages/search-ui-app-search-connector/src/AppSearchAPIConnector.js
@@ -17,18 +17,14 @@ function removeEmptyFacetsAndFilters(options) {
 }
 class AppSearchAPIConnector {
   /**
-   * @typedef {Object.<string, *>} KeyValuePairs
-   */
-
-  /**
    * @callback next
-   * @param {KeyValuePairs} updatedQueryOptions The options to send to the API
+   * @param {Object} updatedQueryOptions The options to send to the API
    * @returns {Object} The response
    */
 
   /**
    * @callback hook
-   * @param {KeyValuePairs} queryOptions The options that are about to be sent to the API
+   * @param {Object} queryOptions The options that are about to be sent to the API
    * @param {next} next The options that are about to be sent to the API
    */
 

--- a/packages/search-ui-app-search-connector/src/AppSearchAPIConnector.js
+++ b/packages/search-ui-app-search-connector/src/AppSearchAPIConnector.js
@@ -19,13 +19,17 @@ class AppSearchAPIConnector {
   /**
    * @callback next
    * @param {Object} updatedQueryOptions The options to send to the API
-   * @returns {Object} The response
+   * @returns {Object} The API response
    */
 
   /**
+   * Hooks work like middleware. This gives you an opportunity to modify the request and response
+   * to for a particular API call.
+   *
    * @callback hook
    * @param {Object} queryOptions The options that are about to be sent to the API
-   * @param {next} next The options that are about to be sent to the API
+   * @param {next} next Callback to continue to make the actual API call
+   * @return {Object} The API response, which may or may not have been amended by this hook
    */
 
   /**
@@ -39,7 +43,7 @@ class AppSearchAPIConnector {
    * query on an "onAutocomplete" event.
    * @param {hook=} options.beforeAutocompleteSuggestionsCall A hook to amend request or response to API for a "suggestions"
    * query on an "onAutocomplete" event.
-   * @param {string=} options.endpointBase="" Overrides the base of the Swiftype API endpoint completely. Useful
+   * @param {string=} options.endpointBase Overrides the base of the Swiftype API endpoint completely. Useful
    * for non-SaaS App Search deployments. For example, Elastic Cloud, Self-Managed, or proxying SaaS.
    */
   constructor({

--- a/packages/search-ui-app-search-connector/src/AppSearchAPIConnector.js
+++ b/packages/search-ui-app-search-connector/src/AppSearchAPIConnector.js
@@ -17,33 +17,34 @@ function removeEmptyFacetsAndFilters(options) {
 }
 class AppSearchAPIConnector {
   /**
+   * @typedef {Object.<string, *>} KeyValuePairs
+   */
+
+  /**
    * @callback next
-   * @param {Object} updatedQueryOptions The options to send to the API
+   * @param {KeyValuePairs} updatedQueryOptions The options to send to the API
+   * @returns {Object} The response
    */
 
   /**
    * @callback hook
-   * @param {Object} queryOptions The options that are about to be sent to the API
+   * @param {KeyValuePairs} queryOptions The options that are about to be sent to the API
    * @param {next} next The options that are about to be sent to the API
    */
 
   /**
-   * @typedef Options
-   * @param {string} searchKey Credential found in your App Search Dashboard
-   * @param {string} engineName Engine to query, found in your App Search Dashboard
-   * @param {string} hostIdentifier Credential found in your App Search Dashboard
-   *  Useful when proxying the Swiftype API or developing against a local API server.
-   * @param {hook} beforeSearchCall=(queryOptions,next)=>next(queryOptions) A hook to amend query options before the request is sent to the
-   *   API in a query on an "onSearch" event.
-   * @param {hook} beforeAutocompleteResultsCall=(queryOptions,next)=>next(queryOptions) A hook to amend query options before the request is sent to the
-   *   API in a "results" query on an "onAutocomplete" event.
-   * @param {hook} beforeAutocompleteSuggestionsCall=(queryOptions,next)=>next(queryOptions) A hook to amend query options before the request is sent to
-   * the API in a "suggestions" query on an "onAutocomplete" event.
-   * @param {string} endpointBase="" Overrides the base of the Swiftype API endpoint completely.
-   */
-
-  /**
-   * @param {Options} options
+   * @param {Object} options Credential found in your App Search Dashboard
+   * @param {string} options.searchKey Credential found in your App Search Dashboard
+   * @param {string} options.engineName Engine to query, found in your App Search Dashboard
+   * @param {string=} options.hostIdentifier Credential found in your App Search Dashboard. Required only if not using
+   * the endpointBase option.
+   * @param {hook=} options.beforeSearchCall A hook to amend request or response to API for "onSearch" event.
+   * @param {hook=} options.beforeAutocompleteResultsCall A hook to amend request or response to API for a "results"
+   * query on an "onAutocomplete" event.
+   * @param {hook=} options.beforeAutocompleteSuggestionsCall A hook to amend request or response to API for a "suggestions"
+   * query on an "onAutocomplete" event.
+   * @param {string=} options.endpointBase="" Overrides the base of the Swiftype API endpoint completely. Useful
+   * for non-SaaS App Search deployments. For example, Elastic Cloud, Self-Managed, or proxying SaaS.
    */
   constructor({
     searchKey,

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -3,9 +3,10 @@ Before submitting this PR:
 1. Make sure you are PR'ing from a fork, please do not push branches directly
    to this repository.
 2. Ensure you've written sufficient tests for your work.
-3. Double check that your changes will not break existing connectors (if
+3. Make sure Typescript Declarations have been updated if necessary (See instructions in CONTRIBUTING.md)
+4. Double check that your changes will not break existing connectors (if
    applicable).
-4. Double check that your changes do not break the `react-search-ui-views`
+5. Double check that your changes do not break the `react-search-ui-views`
    storybook (if applicable).
 
 ## Description


### PR DESCRIPTION
## Description

@alexanderatallah  and I have I added TypeScript declarations to the `search-ui-app-search-connector` and `react-search-ui` packages.

NOTE: The following is true of the `search-ui-app-search-connector`, but not yet `react-search-ui`.

The declarations are generated from JSDoc in source. This hopefully helps:
- Readability of code from JSDoc comments
- JSDoc comments for non-TS users
- TS declarations for TS users which can be synced with the JSDoc with somewhat minimal effort

The JSDoc is also being used to generate documentation in READMEs, for certain projects.

## List of changes

- Updated PR template to add a Reminder to update TS declarations
- Added instructions for maintaining declarations
- Added instructions for generating documentation from JSDoc

![latest](https://user-images.githubusercontent.com/1427475/72464254-e554f000-37a2-11ea-98df-e168bebb3a57.gif)

## Testing

`npm install @elastic/search-ui-app-search-connector@canary`

## Associated Github Issues

https://github.com/elastic/search-ui/issues/289