### PR TITLE
Switched SearchProvider to be a functional component with hooks

### DIFF
--- a/bin/sandbox
+++ b/bin/sandbox
@@ -1,0 +1,8 @@
+# Hooks will not work correctly due to linked modules from sandbox unless the react version is linked:
+#  https://reactjs.org/warnings/invalid-hook-call-warning.html
+cd packages/react-search-ui-views
+npm link ../../examples/sandbox/node_modules/react
+cd ../react-search-ui
+npm link ../../examples/sandbox/node_modules/react
+cd ../../examples/sandbox
+npm start

--- a/examples/sandbox/README.md
+++ b/examples/sandbox/README.md
@@ -30,25 +30,20 @@ The Sandbox can be used with a pre-configured Site Search Engine, using the foll
 REACT_APP_SOURCE=SITE_SEARCH
 ```
 
-## Using
+## Running and using local development version of search-ui
 
-First off, you'll need to get the dependencies installed correctly for this
-entire repository. To do this, there's a few commands you'll need to run that are listed
-in the [CONTRIBUTING](../../CONTRIBUTING.md#installing-dependencies) guide.
+This project requires a complex `npm link` based setup to properly run using your local search-ui source code.
+To start this project properly, you'll need to start it from the root directory of the search-ui project
+with the following commands
 
-After that is done, from this directory, you can actually start the Sandbox application
-by running the following command:
-
-```shell
-# Run this from the /examples/sandbox directory,
-npm start
-```
-
-This project can also be started, using a Site Search connector, rather than an
-App Search connector, using the following command.
+NOTE: The following is semi-destructive, it will "link" your "react" dependencies
+in react-search-ui and react-search-ui-views. All that means is, when running
+`npm test` on either one of those projects you may be prompted to run `npm unlink`
+before continuing.
 
 ```shell
-REACT_APP_SOURCE=SITE_SEARCH npm start
+npm install
+npm run sandbox
 ```
 
 If you're actively developing Search UI and testing in this Sandbox, you'll probably want
@@ -74,4 +69,23 @@ To delete all `node_modules` directories:
 rm -rf node_modules
 rm -rf packages/node_modules
 npx lerna exec -- rm -rf node_modules
+```
+
+## Running stand-alone
+
+To start this project against the released versions of search-ui libs defined in the local `package.json`, simply
+run the following commands from within THIS directory.
+
+```
+npm install
+npm start
+```
+
+## Startup options
+
+This project can also be started, using a Site Search connector, rather than an
+App Search connector, using the following command.
+
+```shell
+REACT_APP_SOURCE=SITE_SEARCH npm start
 ```

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "format": "prettier --write \"packages/*/src/**/*.js\"",
     "lint": "packages/node_modules/eslint/bin/eslint.js \"packages/*/src/**/*.js\"",
     "changed": "lerna changed",
-    "sandbox": "cd examples/sandbox && npm start"
+    "sandbox": "./bin/sandbox"
   },
   "husky": {
     "hooks": {

--- a/packages/react-search-ui-views/bin/test
+++ b/packages/react-search-ui-views/bin/test
@@ -1,0 +1,13 @@
+# Test if there are linked node_modules, which will cause specs to fail
+linked_modules=$(find node_modules -maxdepth 1 -type l -ls)
+if [[ $linked_modules ]]; then
+    echo "ERROR: You have some node_modules linked. Please unlink any node_modules or your tests may not run correctly."
+    echo "This may have happened as a result of running 'npm run sandbox' from the project root."
+    echo "Unlink any linked dependencies using the command 'npm unlink <dependency_name> --no-save'"
+    echo ""
+    echo "The modules you have linked are:"
+    echo $linked_modules
+    echo ""
+    exit 1
+fi
+jest

--- a/packages/react-search-ui-views/package.json
+++ b/packages/react-search-ui-views/package.json
@@ -23,7 +23,7 @@
   },
   "scripts": {
     "test-ci": "jest --runInBand",
-    "test": "jest",
+    "test": "./bin/test",
     "clean": "rimraf es lib",
     "build-css": "./bin/build-css",
     "watch-css": "./bin/watch-css",
@@ -78,6 +78,7 @@
     "autoprefixer": "^9.6.1",
     "downshift": "^3.2.10",
     "rc-pagination": "^1.20.1",
+    "react": "^16.13.1",
     "react-select": "^2.4.4"
   }
 }

--- a/packages/react-search-ui/bin/test
+++ b/packages/react-search-ui/bin/test
@@ -1,0 +1,13 @@
+# Test if there are linked node_modules, which will cause specs to fail
+linked_modules=$(find node_modules -maxdepth 1 -type l -ls)
+if [[ $linked_modules ]]; then
+    echo "ERROR: You have some node_modules linked. Please unlink any node_modules or your tests may not run correctly."
+    echo "This may have happened as a result of running 'npm run sandbox' from the project root."
+    echo "Unlink any linked dependencies using the command 'npm unlink <dependency_name> --no-save'"
+    echo ""
+    echo "The modules you have linked are:"
+    echo $linked_modules
+    echo ""
+    exit 1
+fi
+jest

--- a/packages/react-search-ui/package.json
+++ b/packages/react-search-ui/package.json
@@ -21,7 +21,7 @@
   },
   "scripts": {
     "test-ci": "jest --runInBand",
-    "test": "jest",
+    "test": "./bin/test",
     "clean": "rimraf es lib",
     "watch-js": "./bin/watch-js",
     "build-js": "./bin/build-js",
@@ -35,7 +35,8 @@
   "dependencies": {
     "@babel/runtime": "^7.5.4",
     "@elastic/react-search-ui-views": "1.3.2",
-    "@elastic/search-ui": "1.3.2"
+    "@elastic/search-ui": "1.3.2",
+    "react": "^16.13.1"
   },
   "peerDependencies": {
     "react": "^16.8.0"

--- a/packages/react-search-ui/src/SearchProvider.js
+++ b/packages/react-search-ui/src/SearchProvider.js
@@ -30,7 +30,7 @@ const SearchProvider = ({ children, config }) => {
     };
   }, []);
 
-  // Since driver is initialized in componentDidMount above, we are waiting
+  // Since driver is initialized in useEffect above, we are waiting
   // to render until the driver is available.
   if (!driver) return null;
 

--- a/packages/react-search-ui/src/SearchProvider.js
+++ b/packages/react-search-ui/src/SearchProvider.js
@@ -1,5 +1,5 @@
 import PropTypes from "prop-types";
-import React, { Component } from "react";
+import React, { useState, useEffect } from "react";
 
 import { SearchDriver } from "@elastic/search-ui";
 import SearchContext from "./SearchContext";
@@ -10,63 +10,50 @@ import defaultA11yMessages from "./A11yNotifications";
  * The SearchProvider primarily holds a reference to the SearchDriver and
  * exposes it to the rest of the application in a Context.
  */
-class SearchProvider extends Component {
-  static propTypes = {
-    children: PropTypes.node.isRequired,
-    // Not providing a shape here because the shape matches the shape of
-    // SearchDriver. SearchDriver can do it's own parameter validation.
-    config: PropTypes.object
-  };
+const SearchProvider = ({ children, config }) => {
+  const [driver, setDriver] = useState(null);
 
-  constructor() {
-    super();
-    this.state = {
-      driver: null
-    };
-  }
-
-  componentDidMount() {
-    const { config } = this.props;
-    // This initialization is done inside of componentDidMount, because initializing the SearchDriver server side
+  useEffect(() => {
+    // This initialization is done inside of useEffect, because initializing the SearchDriver server side
     // will error out, since the driver depends on window. Placing the initialization inside of componentDidMount
     // assures that it won't attempt to initialize server side.
-    const driver = new SearchDriver({
+    const newDriver = new SearchDriver({
       ...config,
       a11yNotificationMessages: {
         ...defaultA11yMessages,
         ...config.a11yNotificationMessages
       }
     });
-    this.setState({
-      driver
-    });
-  }
+    setDriver(newDriver);
+    return () => {
+      newDriver.tearDown();
+    };
+  }, []);
 
-  componentWillUnmount() {
-    this.state.driver.tearDown();
-  }
+  // Since driver is initialized in componentDidMount above, we are waiting
+  // to render until the driver is available.
+  if (!driver) return null;
 
-  render() {
-    const { children } = this.props;
+  // Passing the entire "this.state" to the Context is significant. Because
+  // Context determines when to re-render based on referential identity
+  // something like this could cause unnecessary renders:
+  //
+  // <SearchContext.Provider value={{driver: this.state.driver}}>
+  //
+  // By passing the entire state, we ensure that re-renders only occur when
+  // state is actually updated.
+  return (
+    <SearchContext.Provider value={{ driver }}>
+      {children}
+    </SearchContext.Provider>
+  );
+};
 
-    // Since driver is initialized in componentDidMount above, we are waiting
-    // to render until the driver is available.
-    if (!this.state.driver) return null;
-
-    // Passing the entire "this.state" to the Context is significant. Because
-    // Context determines when to re-render based on referential identity
-    // something like this could cause unnecessary renders:
-    //
-    // <SearchContext.Provider value={{driver: this.state.driver}}>
-    //
-    // By passing the entire state, we ensure that re-renders only occur when
-    // state is actually updated.
-    return (
-      <SearchContext.Provider value={this.state}>
-        {children}
-      </SearchContext.Provider>
-    );
-  }
-}
+SearchProvider.propTypes = {
+  children: PropTypes.node.isRequired,
+  // Not providing a shape here because the shape matches the shape of
+  // SearchDriver. SearchDriver can do it's own parameter validation.
+  config: PropTypes.object
+};
 
 export default SearchProvider;

--- a/packages/react-search-ui/src/SearchProvider.js
+++ b/packages/react-search-ui/src/SearchProvider.js
@@ -15,7 +15,7 @@ const SearchProvider = ({ children, config }) => {
 
   useEffect(() => {
     // This initialization is done inside of useEffect, because initializing the SearchDriver server side
-    // will error out, since the driver depends on window. Placing the initialization inside of componentDidMount
+    // will error out, since the driver depends on window. Placing the initialization inside of useEffect
     // assures that it won't attempt to initialize server side.
     const newDriver = new SearchDriver({
       ...config,

--- a/packages/react-search-ui/src/__tests__/SearchProvider.test.js
+++ b/packages/react-search-ui/src/__tests__/SearchProvider.test.js
@@ -33,41 +33,7 @@ describe("SearchProvider", () => {
         </WithSearch>
       </SearchProvider>
     );
+
     expect(wrapper.text()).toEqual("testfunction");
-  });
-
-  describe("merges default and custom a11yNotificationMessages", () => {
-    const getA11yNotificationMessages = a11yNotificationMessages => {
-      const wrapper = mount(
-        <SearchProvider config={{ a11yNotificationMessages }}>
-          Test
-        </SearchProvider>
-      );
-      return wrapper.state("driver").a11yNotificationMessages;
-    };
-
-    it("default messages", () => {
-      const messages = getA11yNotificationMessages({});
-
-      expect(messages.moreFilters({ visibleOptionsCount: 7 })).toEqual(
-        "7 options shown."
-      );
-    });
-
-    it("override messages", () => {
-      const messages = getA11yNotificationMessages({
-        moreFilters: () => "Example override"
-      });
-
-      expect(messages.moreFilters()).toEqual("Example override");
-    });
-
-    it("new messages", () => {
-      const messages = getA11yNotificationMessages({
-        customMessage: () => "Hello world"
-      });
-
-      expect(messages.customMessage()).toEqual("Hello world");
-    });
   });
 });

--- a/packages/react-search-ui/src/__tests__/SearchProvider_withMocks.test.js
+++ b/packages/react-search-ui/src/__tests__/SearchProvider_withMocks.test.js
@@ -1,0 +1,62 @@
+/*
+This spec mocks useState, so is split out into a separate file than
+SearchProvider.test.js
+*/
+
+import React, { useState as useStateMock } from "react";
+
+jest.mock("react", () => ({
+  ...jest.requireActual("react"),
+  useState: jest.fn()
+}));
+
+import { mount } from "enzyme";
+
+import { SearchProvider } from "../..";
+
+describe("SearchProvider", () => {
+  const setState = jest.fn();
+
+  beforeEach(() => {
+    useStateMock.mockImplementation(init => [init, setState]);
+  });
+
+  function getDriverFromComponentState() {
+    return setState.mock.calls[setState.mock.calls.length - 1][0];
+  }
+
+  describe("merges default and custom a11yNotificationMessages", () => {
+    const getA11yNotificationMessages = a11yNotificationMessages => {
+      mount(
+        <SearchProvider config={{ a11yNotificationMessages }}>
+          Test
+        </SearchProvider>
+      );
+      return getDriverFromComponentState().a11yNotificationMessages;
+    };
+
+    it("default messages", () => {
+      const messages = getA11yNotificationMessages({});
+
+      expect(messages.moreFilters({ visibleOptionsCount: 7 })).toEqual(
+        "7 options shown."
+      );
+    });
+
+    it("override messages", () => {
+      const messages = getA11yNotificationMessages({
+        moreFilters: () => "Example override"
+      });
+
+      expect(messages.moreFilters()).toEqual("Example override");
+    });
+
+    it("new messages", () => {
+      const messages = getA11yNotificationMessages({
+        customMessage: () => "Hello world"
+      });
+
+      expect(messages.customMessage()).toEqual("Hello world");
+    });
+  });
+});


### PR DESCRIPTION
This PR changes SearchProvider to use hooks in advance of fixing https://github.com/elastic/search-ui/issues/464.

In order for hooks to work within the local sandbox environment during
development, we needed to resolve an "invalid hook call" error.

A number of solutions are proposed here:
https://reactjs.org/warnings/invalid-hook-call-warning.html

In our case, the error stemmed from the fact that we link our
dependencies from sandbox to our packages. To resolve that, we
need to also link the `react` we use in our packages to the react we use
in the sandbox. 😵 

I chose to add that linking automatically so that it happens
when running `npm run sandbox`, to make it seamless for developers.

Since that unfortunately causes issues running tests, as a result, I also added a new check
to tests to inform developers if they still have this linking in place.

Lastly, in our SearchProvider test we were inspect state directly on our instantiated SearchProvider component. That won't work now that it is a functional component using 
useState, so we instead need to mock `useState` in order to access the underlying state. 

## Associated Github Issues

https://github.com/elastic/search-ui/issues/464
