### PR TITLE
Dynamic Search Configuration

### DIFF
--- a/packages/react-search-ui/src/SearchProvider.js
+++ b/packages/react-search-ui/src/SearchProvider.js
@@ -10,29 +10,40 @@ import defaultA11yMessages from "./A11yNotifications";
  * The SearchProvider primarily holds a reference to the SearchDriver and
  * exposes it to the rest of the application in a Context.
  */
-const SearchProvider = ({ children, config }) => {
-  const [driver, setDriver] = useState(null);
+const SearchProvider = ({ children, config = {}, driver }) => {
+  const [driverInstance, setDriverInstance] = useState(null);
 
   useEffect(() => {
     // This initialization is done inside of useEffect, because initializing the SearchDriver server side
     // will error out, since the driver depends on window. Placing the initialization inside of useEffect
     // assures that it won't attempt to initialize server side.
-    const newDriver = new SearchDriver({
-      ...config,
-      a11yNotificationMessages: {
-        ...defaultA11yMessages,
-        ...config.a11yNotificationMessages
-      }
-    });
-    setDriver(newDriver);
+    const currentDriver =
+      driver ||
+      new SearchDriver({
+        ...config,
+        a11yNotificationMessages: {
+          ...defaultA11yMessages,
+          ...config.a11yNotificationMessages
+        }
+      });
+    setDriverInstance(currentDriver);
+
     return () => {
-      newDriver.tearDown();
+      currentDriver.tearDown();
     };
   }, []);
 
+  // This effect allows users to dynamically update their searchQuery without re-mounting a SearchProvider,
+  // which would be destructive. An example of why this is useful is dynamically updating facets.
+  useEffect(() => {
+    if (driverInstance) {
+      driverInstance.setSearchQuery(config.searchQuery);
+    }
+  }, [config.searchQuery]);
+
   // Since driver is initialized in useEffect above, we are waiting
   // to render until the driver is available.
-  if (!driver) return null;
+  if (!driverInstance) return null;
 
   // Passing the entire "this.state" to the Context is significant. Because
   // Context determines when to re-render based on referential identity
@@ -43,7 +54,7 @@ const SearchProvider = ({ children, config }) => {
   // By passing the entire state, we ensure that re-renders only occur when
   // state is actually updated.
   return (
-    <SearchContext.Provider value={{ driver }}>
+    <SearchContext.Provider value={{ driver: driverInstance }}>
       {children}
     </SearchContext.Provider>
   );
@@ -53,7 +64,8 @@ SearchProvider.propTypes = {
   children: PropTypes.node.isRequired,
   // Not providing a shape here because the shape matches the shape of
   // SearchDriver. SearchDriver can do it's own parameter validation.
-  config: PropTypes.object
+  config: PropTypes.object,
+  driver: PropTypes.object
 };
 
 export default SearchProvider;

--- a/packages/react-search-ui/src/SearchProvider.js
+++ b/packages/react-search-ui/src/SearchProvider.js
@@ -41,6 +41,12 @@ const SearchProvider = ({ children, config = {}, driver }) => {
     }
   }, [config.searchQuery]);
 
+  useEffect(() => {
+    if (driverInstance) {
+      driverInstance.setAutocompleteQuery(config.autocompleteQuery);
+    }
+  }, [config.autocompleteQuery]);
+
   // Since driver is initialized in useEffect above, we are waiting
   // to render until the driver is available.
   if (!driverInstance) return null;

--- a/packages/react-search-ui/src/__tests__/SearchProvider.test.js
+++ b/packages/react-search-ui/src/__tests__/SearchProvider.test.js
@@ -3,7 +3,65 @@ import { mount } from "enzyme";
 
 import { SearchProvider, WithSearch } from "../..";
 
+function getMockDriver() {
+  return {
+    tearDown: jest.fn(),
+    setSearchQuery: jest.fn()
+  };
+}
+
 describe("SearchProvider", () => {
+  it("will mount even if no config is provided", () => {
+    const wrapper = mount(
+      <SearchProvider>
+        <div></div>
+      </SearchProvider>
+    );
+    expect(wrapper).toBeDefined();
+  });
+
+  it("will clean up searchDriver on unmount", () => {
+    const driver = getMockDriver();
+    const wrapper = mount(
+      <SearchProvider driver={driver}>
+        <div></div>
+      </SearchProvider>
+    );
+    expect(driver.tearDown).not.toHaveBeenCalled();
+
+    wrapper.unmount();
+    expect(driver.tearDown).toHaveBeenCalled();
+  });
+
+  it("will update searchDriver when searchQuery config changes", () => {
+    const originalSearchQueryConfig = {
+      facets: { states: { type: "value", size: 30 } }
+    };
+    const updatedSearchQueryConfig = {};
+
+    const driver = getMockDriver();
+    const wrapper = mount(
+      <SearchProvider
+        driver={driver}
+        config={{
+          searchQuery: originalSearchQueryConfig
+        }}
+      >
+        <div>test</div>
+      </SearchProvider>
+    );
+    expect(driver.setSearchQuery).not.toHaveBeenCalled();
+
+    wrapper.setProps({
+      driver,
+      config: { searchQuery: updatedSearchQueryConfig }
+    });
+
+    expect(driver.setSearchQuery).toHaveBeenCalledWith(
+      updatedSearchQueryConfig
+    );
+  });
+
   it("exposes state and actions to components", () => {
     const wrapper = mount(
       <SearchProvider

--- a/packages/react-search-ui/src/__tests__/SearchProvider.test.js
+++ b/packages/react-search-ui/src/__tests__/SearchProvider.test.js
@@ -6,7 +6,8 @@ import { SearchProvider, WithSearch } from "../..";
 function getMockDriver() {
   return {
     tearDown: jest.fn(),
-    setSearchQuery: jest.fn()
+    setSearchQuery: jest.fn(),
+    setAutocompleteQuery: jest.fn()
   };
 }
 
@@ -60,6 +61,37 @@ describe("SearchProvider", () => {
     expect(driver.setSearchQuery).toHaveBeenCalledWith(
       updatedSearchQueryConfig
     );
+    expect(driver.setAutocompleteQuery).not.toHaveBeenCalled();
+  });
+
+  it("will update searchDriver when autocompleteQuery config changes", () => {
+    const autocompleteQueryConfig = {
+      facets: { states: { type: "value", size: 30 } }
+    };
+    const updatedAutocompleteQueryConfig = {};
+
+    const driver = getMockDriver();
+    const wrapper = mount(
+      <SearchProvider
+        driver={driver}
+        config={{
+          autocompleteQuery: autocompleteQueryConfig
+        }}
+      >
+        <div>test</div>
+      </SearchProvider>
+    );
+    expect(driver.setAutocompleteQuery).not.toHaveBeenCalled();
+
+    wrapper.setProps({
+      driver,
+      config: { autocompleteQuery: updatedAutocompleteQueryConfig }
+    });
+
+    expect(driver.setAutocompleteQuery).toHaveBeenCalledWith(
+      updatedAutocompleteQueryConfig
+    );
+    expect(driver.setSearchQuery).not.toHaveBeenCalled();
   });
 
   it("exposes state and actions to components", () => {

--- a/packages/search-ui/src/SearchDriver.js
+++ b/packages/search-ui/src/SearchDriver.js
@@ -411,6 +411,13 @@ export default class SearchDriver {
   }
 
   /**
+   * @param Object autocompleteQuery
+   */
+  setAutocompleteQuery(autocompleteQuery) {
+    this.autocompleteQuery = autocompleteQuery;
+  }
+
+  /**
    * Any time state is updated in this Driver, the provided callback
    * will be executed with the updated state.
    *

--- a/packages/search-ui/src/SearchDriver.js
+++ b/packages/search-ui/src/SearchDriver.js
@@ -400,6 +400,17 @@ export default class SearchDriver {
   }
 
   /**
+   * Dynamically update the searchQuery configuration in this driver.
+   * This will issue a new query after being updated.
+   *
+   * @param Object searchQuery
+   */
+  setSearchQuery(searchQuery) {
+    this.searchQuery = searchQuery;
+    this._updateSearchResults();
+  }
+
+  /**
    * Any time state is updated in this Driver, the provided callback
    * will be executed with the updated state.
    *


### PR DESCRIPTION
## Description

This allows Search Configuration to be changed after mounting SearchProvider. This unlocks uses cases like:

- Dynamically changing the `facets` available in a Search Experience based on user selections
- Dynamically changing `search_fields` based on users selection (Imagine an experience where you have a toggle that says something like "Search In" with selection of "title", "user name", etc.".
- Dynamically changing the `result_fields` that are displayed

This works for the configurations `autocompleteQuery` and `searchQuery` on the `SearchProvider` configuration.

```jsx
function App() {
  const [searchQuery, setSearchQuery] = useState({
    facets : /*List of facets*/
  });

  const newSearchQuery = {
    facets : /*List of NEW facets*/
  }
 
  return (
    <SearchProvider config={ searchQuery }>
       <button onClick={() => setSearchQuery(newSearchQuery)}></button>
       // ...
    </SearchProvider>
  );
}
```

![latest](https://user-images.githubusercontent.com/1427475/77938245-75bfae80-7283-11ea-9694-53e05e279a91.gif)

## List of changes

- Dynamic `autocompleteQuery`
- Dynamic `searchQuery`
- SearchProvider now accepts a driver as a parameter. Mostly for testing at this point.

## Associated Github Issues
Closes https://github.com/elastic/search-ui/issues/464
Unblocks: https://github.com/elastic/app-search-team/issues/861