### PR TITLE
Fixed searchQuery config for global filters

### DIFF
--- a/packages/search-ui/src/SearchDriver.js
+++ b/packages/search-ui/src/SearchDriver.js
@@ -5,6 +5,7 @@ import DebounceManager from "./DebounceManager";
 
 import * as actions from "./actions";
 import Events from "./Events";
+import { mergeFilters } from "./helpers";
 
 import * as a11y from "./A11yNotifications";
 
@@ -323,16 +324,24 @@ export default class SearchDriver {
 
       const requestId = this.searchRequestSequencer.next();
 
+      const {
+        // eslint-disable-next-line no-unused-vars
+        filters: searchQueryFilters,
+        ...restOfSearchQuery
+      } = this.searchQuery;
+
       const queryConfig = {
-        ...this.searchQuery,
+        ...restOfSearchQuery,
         facets: removeConditionalFacets(
           this.searchQuery.facets,
           this.searchQuery.conditionalFacets,
           filters
         )
       };
-
-      const requestState = filterSearchParameters(this.state);
+      const requestState = {
+        ...filterSearchParameters(this.state),
+        filters: mergeFilters(filters, this.searchQuery.filters)
+      };
 
       return this.events.search(requestState, queryConfig).then(
         resultState => {

--- a/packages/search-ui/src/__tests__/SearchDriver.test.js
+++ b/packages/search-ui/src/__tests__/SearchDriver.test.js
@@ -264,6 +264,35 @@ describe("searchQuery config", () => {
       expect(getSearchCalls()[0][1].search_fields).toEqual(search_fields);
     });
   });
+
+  describe("filters", () => {
+    function subject() {
+      const driver = new SearchDriver({
+        ...params,
+        searchQuery: {
+          filters: [{ field: "initial", values: ["value"], type: "all" }]
+        }
+      });
+
+      jest.runAllTimers();
+      driver.setFilter("initial", "newValue", "all");
+      driver.setFilter("other", "value", "all");
+      jest.runAllTimers();
+    }
+
+    it("will merge applied filters and configured filters", () => {
+      subject();
+      expect(getSearchCalls()[0][0].filters).toEqual([
+        { field: "initial", type: "all", values: ["newValue"] },
+        { field: "other", type: "all", values: ["value"] }
+      ]);
+    });
+
+    it("will remove filters parameter from queryConfig since its merged into state", () => {
+      subject();
+      expect(getSearchCalls()[0][1].filters).not.toBeDefined();
+    });
+  });
 });
 
 describe("autocompleteQuery config", () => {

--- a/packages/search-ui/src/helpers.js
+++ b/packages/search-ui/src/helpers.js
@@ -104,3 +104,15 @@ export function doFilterValuesMatch(filterValue1, filterValue2) {
   // We use 'strict = true' to do a '===' of leaves, rather than '=='
   return deepEqual(filterValue1, filterValue2, { strict: true });
 }
+
+// Mix unique filter type from one array into the other
+export function mergeFilters(filters1, filters2) {
+  if (!filters2) return filters1;
+
+  return filters2.reduce((acc, next) => {
+    if (acc.find(f => f.type === next.type && f.field === next.field)) {
+      return acc;
+    }
+    return [...acc, next];
+  }, filters1);
+}


### PR DESCRIPTION
## Description

Faceting was not working when a global filter was applied via searchQuery configuration. This fixes that.

This logic will prefer filters chosen in the UI to filters specified in searchQuery config if there is a conflict.

Ex.

```
<SearchProvider config={{
    searchQuery: {
      filters: [{ field: "world_heritage_site", values: ["true"] }],
    }}>
</SearchProvider>
```

You can apply the above and still use filters.

You can see that in action in the gif below. There are only 14 results since the data is filtered by "world_heritage_site". There is usually > 50. You can see that facet filters will still work.

![latest](https://user-images.githubusercontent.com/1427475/77958097-8af80580-72a2-11ea-9a1e-6a243bb7a0d2.gif)

## Associated Github Issues

Fixes https://github.com/elastic/search-ui/issues/470
