### PR TITLE
Fix boolean facet check status

### DIFF
--- a/packages/react-search-ui-views/src/BooleanFacet.js
+++ b/packages/react-search-ui-views/src/BooleanFacet.js
@@ -33,6 +33,7 @@ function BooleanFacet({
                 className="sui-boolean-facet__checkbox"
                 type="checkbox"
                 onChange={toggle}
+                checked={isSelected}
               />
               <span className="sui-boolean-facet__input-text">{label}</span>
             </div>

--- a/packages/react-search-ui-views/src/__tests__/__snapshots__/BooleanFacet.test.js.snap
+++ b/packages/react-search-ui-views/src/__tests__/__snapshots__/BooleanFacet.test.js.snap
@@ -22,6 +22,7 @@ exports[`renders 1`] = `
           className="sui-boolean-facet__option-input-wrapper"
         >
           <input
+            checked={false}
             className="sui-boolean-facet__checkbox"
             onChange={[Function]}
             type="checkbox"


### PR DESCRIPTION
#482  Description
Make sure that checkbox shows checked/unchecked depending on value of `isSelected` in case filter value is set via function call rather than via clicking the checkbox.

## Associated Github Issues
#490 
