### PR TITLE
Removing unnecessary array brackets invoking parsing errors

### DIFF
--- a/examples/elasticsearch/src/buildRequestFilter.js
+++ b/examples/elasticsearch/src/buildRequestFilter.js
@@ -15,22 +15,22 @@ function getTermFilter(filter) {
   if (filter.type === "any") {
     return {
       bool: {
-        should: [
+        should: 
           filter.values.map(filterValue => ({
             term: getTermFilterValue(filter.field, filterValue)
           }))
-        ],
+        ,
         minimum_should_match: 1
       }
     };
   } else if (filter.type === "all") {
     return {
       bool: {
-        filter: [
+        filter: 
           filter.values.map(filterValue => ({
             term: getTermFilterValue(filter.field, filterValue)
           }))
-        ]
+        
       }
     };
   }
@@ -40,7 +40,7 @@ function getRangeFilter(filter) {
   if (filter.type === "any") {
     return {
       bool: {
-        should: [
+        should: 
           filter.values.map(filterValue => ({
             range: {
               [filter.field]: {
@@ -49,14 +49,14 @@ function getRangeFilter(filter) {
               }
             }
           }))
-        ],
+        ,
         minimum_should_match: 1
       }
     };
   } else if (filter.type === "all") {
     return {
       bool: {
-        filter: [
+        filter: 
           filter.values.map(filterValue => ({
             range: {
               [filter.field]: {
@@ -65,7 +65,7 @@ function getRangeFilter(filter) {
               }
             }
           }))
-        ]
+        
       }
     };
   }

--- a/examples/elasticsearch/src/buildRequestFilter.js
+++ b/examples/elasticsearch/src/buildRequestFilter.js
@@ -15,8 +15,7 @@ function getTermFilter(filter) {
   if (filter.type === "any") {
     return {
       bool: {
-        should: 
-          filter.values.map(filterValue => ({
+        should: filter.values.map(filterValue => ({
             term: getTermFilterValue(filter.field, filterValue)
           }))
         ,
@@ -26,8 +25,7 @@ function getTermFilter(filter) {
   } else if (filter.type === "all") {
     return {
       bool: {
-        filter: 
-          filter.values.map(filterValue => ({
+        filter: filter.values.map(filterValue => ({
             term: getTermFilterValue(filter.field, filterValue)
           }))
         
@@ -40,8 +38,7 @@ function getRangeFilter(filter) {
   if (filter.type === "any") {
     return {
       bool: {
-        should: 
-          filter.values.map(filterValue => ({
+        should: filter.values.map(filterValue => ({
             range: {
               [filter.field]: {
                 ...(filterValue.to && { lt: filterValue.to }),
@@ -56,8 +53,7 @@ function getRangeFilter(filter) {
   } else if (filter.type === "all") {
     return {
       bool: {
-        filter: 
-          filter.values.map(filterValue => ({
+        filter: filter.values.map(filterValue => ({
             range: {
               [filter.field]: {
                 ...(filterValue.to && { lt: filterValue.to }),


### PR DESCRIPTION
## Description
I have tested your example project. When I run the project and use filters to filter data, it throws 400 bad request error.

Error messages said "failed to parse field [something]".

It turned out that there's something wrong in BuildRequestFilter.js. When you write queries for "request body parameters", you don't have to add "[]" to make an array because map function return an array. Array inside array invoked parsing errors, I think.

After I remove all unnessary array brackets and tested it, everything worked out well

## List of changes
Remove unnessary array brackets in BuildRequestFilter.js

