### PR TITLE
Limited App Search paging to 100 results

### DIFF
--- a/packages/search-ui-app-search-connector/src/__tests__/responseAdapter.test.js
+++ b/packages/search-ui-app-search-connector/src/__tests__/responseAdapter.test.js
@@ -124,6 +124,19 @@ const responseWithZeroFacetValue = {
   }
 };
 
+const responseWithOver100Pages = {
+  rawResults: [],
+  info: {
+    meta: {
+      request_id: "1234",
+      page: {
+        total_results: 100000,
+        total_pages: 5000
+      }
+    }
+  }
+};
+
 const adaptedResponse = {
   results: [],
   totalPages: 10,
@@ -236,6 +249,13 @@ const adaptedResponseWithZeroFacetValue = {
   }
 };
 
+const adaptedResponseOver100Pages = {
+  results: [],
+  totalPages: 100,
+  totalResults: 100000,
+  requestId: "1234"
+};
+
 const geoOptions = {
   additionalFacetValueFields: {
     location: {
@@ -295,5 +315,11 @@ describe("adaptResponse", () => {
         ]
       }
     ]);
+  });
+
+  it("will limit total pages to 100", () => {
+    expect(adaptResponse(responseWithOver100Pages)).toEqual(
+      adaptedResponseOver100Pages
+    );
   });
 });

--- a/packages/search-ui-app-search-connector/src/responseAdapter.js
+++ b/packages/search-ui-app-search-connector/src/responseAdapter.js
@@ -44,13 +44,20 @@ function adaptFacets(facets, { additionalFacetValueFields = {} }) {
   }, {});
 }
 
+function limitTo100pages(totalPages) {
+  // We limit this to 100 pages since App Search currently cannot page past 100 pages
+  return Math.min(totalPages, 100);
+}
+
 export function adaptResponse(response, options = {}) {
   const facets = response.info.facets;
   const requestId = response.info.meta.request_id;
 
-  const totalPages = response.info.meta.page
-    ? response.info.meta.page.total_pages
-    : undefined;
+  const totalPages =
+    response.info.meta.page &&
+    typeof response.info.meta.page.total_pages !== "undefined"
+      ? limitTo100pages(response.info.meta.page.total_pages)
+      : undefined;
 
   const totalResults = response.info.meta.page
     ? response.info.meta.page.total_results


### PR DESCRIPTION
There is a known issue in the App Search API in which a search response
may return a total page count of over 100, even thought the API can
only page up to page 100.

This will break Search UI's paging, which assumes that if the API
says there are 1000 pages, that they can all be paged through.

This commit rewrites the response in the App Search Connector to cap
pages to 100.

Before:
<img width="1278" alt="before" src="https://user-images.githubusercontent.com/1427475/83906870-5ab16500-a732-11ea-81e3-194edd64cd30.png">

After:
<img width="1277" alt="after" src="https://user-images.githubusercontent.com/1427475/83906886-61d87300-a732-11ea-8760-a630f5d08580.png">

## Associated Github Issues

Fixes https://github.com/elastic/search-ui/issues/485