### PR TITLE
Removed React dependency from packages

### DIFF
--- a/packages/react-search-ui-views/package.json
+++ b/packages/react-search-ui-views/package.json
@@ -79,7 +79,6 @@
     "autoprefixer": "^9.6.1",
     "downshift": "^3.2.10",
     "rc-pagination": "^1.20.1",
-    "react": "^16.13.1",
     "react-select": "^2.4.4"
   }
 }

--- a/packages/react-search-ui/package.json
+++ b/packages/react-search-ui/package.json
@@ -35,8 +35,7 @@
   "dependencies": {
     "@babel/runtime": "^7.5.4",
     "@elastic/react-search-ui-views": "1.4.0",
-    "@elastic/search-ui": "1.4.0",
-    "react": "^16.13.1"
+    "@elastic/search-ui": "1.4.0"
   },
   "peerDependencies": {
     "react": "^16.8.0"


### PR DESCRIPTION
I accidentally introduced a hard dependency on `react` to the `@elastic/react-search-ui` and `@elastic/react-search-ui-views` libraries.

If a consuming project is using a different version of React, this will cause a version conflict error.

I simply removed the dependency in order to fix this. I plan to publish this in a 1.4.1 patch.

For example, when I updated the search-ui 1.4.0 in the reference ui, I received the following error:
<img width="1679" alt="bad" src="https://user-images.githubusercontent.com/1427475/84428025-c6447800-abf3-11ea-8f14-465b6a15e342.png">

If you reference that error on the React documentation site, it tells you this can be caused by two separate versions of React conflicting.

The following confirms that:
```
→npm ls react
app-search-reference-ui-react@1.2.0 /Users/jasonstoltzfus/workspace/app-search-reference-ui-react
→npm ls react
app-search-reference-ui-react@1.2.0 /Users/jasonstoltzfus/workspace/app-search-reference-ui-react
├─┬ @elastic/react-search-ui@1.4.0
│ ├─┬ @elastic/react-search-ui-views@1.4.0
│ │ └── react@16.13.1 
│ └── react@16.13.1 
└── react@16.8.6 
```