### PR TITLE
Fix errors on Elasticsearch Demo

### DIFF
--- a/examples/elasticsearch/functions/search.js
+++ b/examples/elasticsearch/functions/search.js
@@ -2,6 +2,12 @@
   This is a Netlify Function that proxies our Elasticsearch instance.
 */
 import fetch from "node-fetch";
+import https from "https";
+
+// Don't do this in production, this is in place to aid with demo environments which have self-signed certificates.
+const agent = new https.Agent({
+  rejectUnauthorized: false
+});
 
 exports.handler = function(event, context, callback) {
   const host = process.env.ELASTICSEARCH_HOST;
@@ -9,7 +15,8 @@ exports.handler = function(event, context, callback) {
   fetch(`${host}/national-parks/_search`, {
     method: "POST",
     headers: { "content-type": "application/json" },
-    body: event.body
+    body: event.body,
+    agent
   })
     .then(response => response.text().then(body => [response, body]))
     .then(([response, body]) => {
@@ -18,10 +25,10 @@ exports.handler = function(event, context, callback) {
         body: body
       });
     })
-    .catch(() => {
+    .catch(e => {
       callback(null, {
         statusCode: 500,
-        body: "An error occurred"
+        body: `An error occurred: ${e}`
       });
     });
 };


### PR DESCRIPTION
Users who use this demo may often times be pointing at an instance
that has a self-signed certificate. For the sake of the demo, we simply
trust all certificates.

Additionally, the error message printed by our Netlify function was
not helpful. This should resolve that.

## Associated Github Issues

Fixes https://github.com/elastic/search-ui/issues/497
