### PR TITLE
Fixed CI and Specs

### DIFF
--- a/packages/react-search-ui-views/package.json
+++ b/packages/react-search-ui-views/package.json
@@ -62,6 +62,7 @@
     "babel-loader": "^8.0.6",
     "chokidar-cli": "^1.2.2",
     "core-js": "^3.6.5",
+    "core-js-pure": "^3.6.5",
     "enzyme": "^3.10.0",
     "enzyme-adapter-react-16": "^1.14.0",
     "enzyme-to-json": "^3.3.5",


### PR DESCRIPTION
For some reason, CI started failing due to the following error:

Cannot find module 'core-js-pure/features/url' from 'getUrlSanitizer.test.js'
@elastic/react-search-ui-views:       1 | import { getUrlSanitizer } from "../../view-helpers";
@elastic/react-search-ui-views:     > 2 | import URL from "core-js-pure/features/url";
@elastic/react-search-ui-views:         | ^

This seems like it should have been an error from the start, as we were
missing core-js-pure from devDependencies.

It may have previously been a transitive dependency and has since
been removed. Regardless, it should have been a hard dependency
from the start, so I've added it to our list of devDependencies which
appears to have fixed the issue.