### PR TITLE
Update package.json imports to use default export for Webpack 5

### DIFF
--- a/packages/search-ui-app-search-connector/src/AppSearchAPIConnector.js
+++ b/packages/search-ui-app-search-connector/src/AppSearchAPIConnector.js
@@ -1,5 +1,5 @@
 import * as ElasticAppSearch from "@elastic/app-search-javascript";
-import { version } from "../package.json";
+import packageJson from "../package.json";
 
 import { adaptResponse } from "./responseAdapter";
 import { adaptRequest } from "./requestAdapters";
@@ -69,7 +69,7 @@ class AppSearchAPIConnector {
       engineName: engineName,
       additionalHeaders: {
         "x-swiftype-integration": "search-ui",
-        "x-swiftype-integration-version": version
+        "x-swiftype-integration-version": packageJson.version
       },
       ...rest
     });

--- a/packages/search-ui-site-search-connector/src/SiteSearchAPIConnector.js
+++ b/packages/search-ui-site-search-connector/src/SiteSearchAPIConnector.js
@@ -1,12 +1,12 @@
 import adaptRequest from "./requestAdapter";
 import adaptResponse from "./responseAdapter";
 import request from "./request";
-import { version } from "../package.json";
+import packageJson from "../package.json";
 
 function _get(engineKey, path, params) {
   const headers = new Headers({
     "x-swiftype-integration": "search-ui",
-    "x-swiftype-integration-version": version
+    "x-swiftype-integration-version": packageJson.version
   });
 
   const query = Object.entries({ engine_key: engineKey, ...params })

--- a/packages/search-ui-site-search-connector/src/request.js
+++ b/packages/search-ui-site-search-connector/src/request.js
@@ -1,10 +1,10 @@
-import { version } from "../package.json";
+import packageJson from "../package.json";
 
 export default async function request(engineKey, method, path, params) {
   const headers = new Headers({
     "Content-Type": "application/json",
     "x-swiftype-integration": "search-ui",
-    "x-swiftype-integration-version": version
+    "x-swiftype-integration-version": packageJson.version
   });
 
   const response = await fetch(


### PR DESCRIPTION
## Description
As per Webpack 5's migration instructions, webpack is removing support for importing named properties from a default export. As such, all instances of importing individual keys from the package.json should be updated to import the default export.
https://webpack.js.org/migrate/5/#using-named-exports-from-json-modules

For example
```js
// old
import { version } from "./package.json";
const foo = version; // example

// new 
import packageJson from "./package.json";
const foo = packageJson.version; // example
```

## List of changes
Updated all package.json imports to import the full package.json and then use properties as you normally would from an object.

As this is only a minor semantics change, I tested by running `npm run test`.

## Associated Github Issues
#539 