### PR TITLE
Removed 'swiftype_' headers

### DIFF
--- a/packages/search-ui-app-search-connector/src/AppSearchAPIConnector.js
+++ b/packages/search-ui-app-search-connector/src/AppSearchAPIConnector.js
@@ -1,5 +1,4 @@
 import * as ElasticAppSearch from "@elastic/app-search-javascript";
-import { version } from "../package.json";
 
 import { adaptResponse } from "./responseAdapter";
 import { adaptRequest } from "./requestAdapters";
@@ -67,10 +66,6 @@ class AppSearchAPIConnector {
       ...(hostIdentifier && { hostIdentifier: hostIdentifier }),
       apiKey: searchKey,
       engineName: engineName,
-      additionalHeaders: {
-        "x-swiftype-integration": "search-ui",
-        "x-swiftype-integration-version": version
-      },
       ...rest
     });
     this.beforeSearchCall = beforeSearchCall;

--- a/packages/search-ui-site-search-connector/src/SiteSearchAPIConnector.js
+++ b/packages/search-ui-site-search-connector/src/SiteSearchAPIConnector.js
@@ -1,14 +1,8 @@
 import adaptRequest from "./requestAdapter";
 import adaptResponse from "./responseAdapter";
 import request from "./request";
-import { version } from "../package.json";
 
 function _get(engineKey, path, params) {
-  const headers = new Headers({
-    "x-swiftype-integration": "search-ui",
-    "x-swiftype-integration-version": version
-  });
-
   const query = Object.entries({ engine_key: engineKey, ...params })
     .map(([paramName, paramValue]) => {
       return `${paramName}=${encodeURIComponent(paramValue)}`;
@@ -19,8 +13,7 @@ function _get(engineKey, path, params) {
     `https://search-api.swiftype.com/api/v1/public/${path}?${query}`,
     {
       method: "GET",
-      credentials: "include",
-      headers
+      credentials: "include"
     }
   );
 }

--- a/packages/search-ui-site-search-connector/src/request.js
+++ b/packages/search-ui-site-search-connector/src/request.js
@@ -1,10 +1,6 @@
-import { version } from "../package.json";
-
 export default async function request(engineKey, method, path, params) {
   const headers = new Headers({
-    "Content-Type": "application/json",
-    "x-swiftype-integration": "search-ui",
-    "x-swiftype-integration-version": version
+    "Content-Type": "application/json"
   });
 
   const response = await fetch(

--- a/packages/search-ui/README.md
+++ b/packages/search-ui/README.md
@@ -54,16 +54,3 @@ of the Advanced README.
 | `subscribeToStateChanges` | function |                                      | Function to execute when state changes. ex.<br/><br/>`(state) => {}` |
 | `getActions`              |          | [Actions](../../ADVANCED.md#actions) | All available actions.                                               |
 | `getState`                |          | [State](../../ADVANCED.md#state)     | Current state.                                                       |
-
-### Does Search UI use telemetry?
-
-If you are using the App Search or Site Search connector, we pass along 2 headers on API requests
-that identify them as Search UI requests. This ONLY happens if you are using our pre-built
-connectors.
-
-Ex.
-
-```
-x-swiftype-integration: search-ui
-x-swiftype-integration-version: 0.6.0
-```


### PR DESCRIPTION
## Description

This PR removes the 'swiftype_' prefixed headers on API calls for the App Search and Site Search connectors.

These were originally introduced when App Search and Site Search were purely SaaS products, for our own analytical purpose. These are no longer used or needed by us (Elastic).

Since this causes complications in the build as seen in #539, I'd rather just remove them entirely.

Since these headers were for internal use, I don't consider this a breaking change.

## List of changes

Removed `x-swiftype-integration` and `x-swiftype-integration-version` headers.

## Associated Github Issues

Fixes #539
Alternative to #572