### PR TITLE
Fix off-by-one error in results pagination state.

### DIFF
--- a/packages/search-ui/src/SearchDriver.ts
+++ b/packages/search-ui/src/SearchDriver.ts
@@ -419,7 +419,7 @@ class SearchDriver {
           const start =
             totalResults === 0 ? 0 : (current - 1) * resultsPerPage + 1;
           const end =
-            totalResults <= start + resultsPerPage
+            totalResults < start + resultsPerPage
               ? totalResults
               : start + resultsPerPage - 1;
 

--- a/packages/search-ui/src/__tests__/SearchDriver.test.ts
+++ b/packages/search-ui/src/__tests__/SearchDriver.test.ts
@@ -479,6 +479,19 @@ describe("_updateSearchResults", () => {
     expect(stateAfterCreation.pagingEnd).toEqual(30);
   });
 
+  it("calculates pagingEnd correctly when resultsPerPage is one less than totalResults", () => {
+    const mockSearchResponse = { totalResults: 41, totalPages: 2 };
+
+    const { stateAfterCreation } = setupDriver({
+      initialState,
+      mockSearchResponse
+    });
+
+    expect(stateAfterCreation.totalResults).toEqual(41);
+    expect(stateAfterCreation.pagingStart).toEqual(21);
+    expect(stateAfterCreation.pagingEnd).toEqual(40);
+  });
+
   it("zeroes out pagingStart and pagingEnd correctly", () => {
     const mockSearchResponse = { totalResults: 0 };
 


### PR DESCRIPTION
## Description
There is an off-by-one error when calculating the pageEnd of a resultset.

## List of changes
- Fixed incorrect calculation of pageEnd

## Associated Github Issues
