### PR TITLE
Extract Workplace Search sandbox to a different page

### DIFF
--- a/examples/sandbox/package.json
+++ b/examples/sandbox/package.json
@@ -15,7 +15,7 @@
     "moment": "^2.24.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "react-router-dom": "^6.2.2",
+    "react-router-dom": "^5.0.0",
     "react-scripts": "^5.0.0"
   },
   "scripts": {

--- a/examples/sandbox/package.json
+++ b/examples/sandbox/package.json
@@ -8,14 +8,14 @@
     "@elastic/react-search-ui": "1.10.0-rc.1",
     "@elastic/react-search-ui-views": "1.10.0-rc.1",
     "@elastic/search-ui": "1.10.0-rc.1",
-    "@elastic/search-ui-elasticsearch-connector": "1.10.0-rc.1",
-
     "@elastic/search-ui-app-search-connector": "1.10.0-rc.1",
+    "@elastic/search-ui-elasticsearch-connector": "1.10.0-rc.1",
     "@elastic/search-ui-site-search-connector": "1.10.0-rc.1",
     "@emotion/react": "^11.8.1",
     "moment": "^2.24.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
+    "react-router-dom": "^6.2.2",
     "react-scripts": "^5.0.0"
   },
   "scripts": {

--- a/examples/sandbox/src/App.js
+++ b/examples/sandbox/src/App.js
@@ -1,19 +1,8 @@
 import React from "react";
-import {
-  EuiButton,
-  EuiModal,
-  EuiModalBody,
-  EuiModalFooter,
-  EuiModalHeader,
-  EuiModalHeaderTitle,
-  EuiText,
-  EuiProvider
-} from "@elastic/eui";
 import "@elastic/eui/dist/eui_theme_light.css";
 
 import AppSearchAPIConnector from "@elastic/search-ui-app-search-connector";
 import SiteSearchAPIConnector from "@elastic/search-ui-site-search-connector";
-import WorkplaceSearchAPIConnector from "@elastic/search-ui-workplace-search-connector";
 import ElasticSearchAPIConnector from "@elastic/search-ui-elasticsearch-connector";
 import {
   ErrorBoundary,
@@ -34,13 +23,20 @@ import {
   SingleSelectFacet
 } from "@elastic/react-search-ui-views";
 import "@elastic/react-search-ui-views/lib/styles/styles.css";
-import { config as ElasticSearchConfig, fields as ElasticsearchFields } from './configurations/Elasticsearch';
-import { config as EntSearchConfig, fields as EntSearchFields } from './configurations/EntSearch';
+import {
+  config as ElasticSearchConfig,
+  fields as ElasticsearchFields
+} from "./configurations/Elasticsearch";
+import {
+  config as EntSearchConfig,
+  fields as EntSearchFields
+} from "./configurations/EntSearch";
 import "./App.css";
 
-const sourceMode = process.env.REACT_APP_SOURCE
+const sourceMode = process.env.REACT_APP_SOURCE;
 
-const isElasticsearchSource = sourceMode && sourceMode.indexOf("ELASTICSEARCH") !== -1;
+const isElasticsearchSource =
+  sourceMode && sourceMode.indexOf("ELASTICSEARCH") !== -1;
 
 const fields = isElasticsearchSource ? ElasticsearchFields : EntSearchFields;
 
@@ -99,17 +95,20 @@ const SORT_OPTIONS = [
   }
 ];
 
-let connector = null
-let queryConfig = null
+let connector = null;
+let queryConfig = null;
 
 if (sourceMode === "ELASTICSEARCH_CONNECTOR") {
-  connector = new ElasticSearchAPIConnector({
-    host: process.env.REACT_ELASTICSEARCH_HOST || "http://localhost:9200",
-    index: process.env.REACT_ELASTICSEARCH_INDEX || "us_parks"
-  }, {
-    queryFields: ["title", "description", "states"]
-  });
-  queryConfig = ElasticSearchConfig
+  connector = new ElasticSearchAPIConnector(
+    {
+      host: process.env.REACT_ELASTICSEARCH_HOST || "http://localhost:9200",
+      index: process.env.REACT_ELASTICSEARCH_INDEX || "us_parks"
+    },
+    {
+      queryFields: ["title", "description", "states"]
+    }
+  );
+  queryConfig = ElasticSearchConfig;
 } else if (process.env.REACT_APP_SOURCE === "SITE_SEARCH") {
   connector = new SiteSearchAPIConnector({
     engineKey:
@@ -117,22 +116,6 @@ if (sourceMode === "ELASTICSEARCH_CONNECTOR") {
     documentType: process.env.REACT_SITE_SEARCH_ENGINE_NAME || "national-parks"
   });
   queryConfig = EntSearchConfig;
-} else if (process.env.REACT_APP_SOURCE === "WORKPLACE_SEARCH") {
-  queryConfig = EntSearchConfig;
-  connector = new WorkplaceSearchAPIConnector({
-    kibanaBase:
-      process.env.REACT_WORKPLACE_SEARCH_KIBANA_BASE ||
-      "https://search-ui-sandbox.kb.us-central1.gcp.cloud.es.io:9243",
-    enterpriseSearchBase:
-      process.env.REACT_WORKPLACE_SEARCH_ENTERPRISE_SEARCH_BASE ||
-      "https://search-ui-sandbox.ent.us-central1.gcp.cloud.es.io",
-    redirectUri:
-      process.env.REACT_WORKPLACE_SEARCH_REDIRECT_URI ||
-      "http://localhost:3000",
-    clientId:
-      process.env.REACT_WORKPLACE_SEARCH_CLIENT_ID ||
-      "8e495e40fc1e6acf515e557e534de39d4f727f7f60a3afed24a99ce3a6607c1e"
-  });
 } else {
   connector = new AppSearchAPIConnector({
     searchKey:
@@ -156,129 +139,93 @@ const config = {
 
 export default function App() {
   return (
-    <EuiProvider colorMode="light">
-      <SearchProvider config={config}>
-        <WithSearch
-          mapContextToProps={({ wasSearched, authorizeUrl, isLoggedIn }) => ({
-            wasSearched,
-            authorizeUrl,
-            isLoggedIn
-          })}
-        >
-          {({ wasSearched, authorizeUrl, isLoggedIn }) => {
-            return (
-              <div className="App">
-                <ErrorBoundary>
-                  {process.env.REACT_APP_SOURCE === "WORKPLACE_SEARCH" &&
-                    !isLoggedIn && (
-                      <EuiModal
-                        onClose={() => {}}
-                        maxWidth={354}
-                        className="login-modal"
-                      >
-                        <EuiModalHeader className="login-modal__header">
-                          <EuiModalHeaderTitle>
-                            <h1>Log in to continue</h1>
-                          </EuiModalHeaderTitle>
-                        </EuiModalHeader>
-
-                        <EuiModalBody>
-                          <EuiText size="m">
-                            <p>
-                              Search UI requires an active, authorized
-                              connection to Elastic Enteprise Search.
-                              <br />
-                              Select “Log in” below to continue.
-                            </p>
-                          </EuiText>
-                        </EuiModalBody>
-
-                        <EuiModalFooter>
-                          <EuiButton href={authorizeUrl} fill fullWidth>
-                            Log in
-                          </EuiButton>
-                        </EuiModalFooter>
-                      </EuiModal>
-                    )}
-                  <Layout
-                    header={
-                      <SearchBox
-                        autocompleteMinimumCharacters={3}
-                        autocompleteResults={{
-                          linkTarget: "_blank",
-                          sectionTitle: "Results",
-                          titleField: "title",
-                          urlField: "nps_link",
-                          shouldTrackClickThrough: true,
-                          clickThroughTags: ["test"]
-                        }}
-                        autocompleteSuggestions={true}
-                        debounceLength={0}
+    <SearchProvider config={config}>
+      <WithSearch
+        mapContextToProps={({ wasSearched, authorizeUrl, isLoggedIn }) => ({
+          wasSearched,
+          authorizeUrl,
+          isLoggedIn
+        })}
+      >
+        {({ wasSearched, authorizeUrl, isLoggedIn }) => {
+          return (
+            <div className="App">
+              <ErrorBoundary>
+                <Layout
+                  header={
+                    <SearchBox
+                      autocompleteMinimumCharacters={3}
+                      autocompleteResults={{
+                        linkTarget: "_blank",
+                        sectionTitle: "Results",
+                        titleField: "title",
+                        urlField: "nps_link",
+                        shouldTrackClickThrough: true,
+                        clickThroughTags: ["test"]
+                      }}
+                      autocompleteSuggestions={true}
+                      debounceLength={0}
+                    />
+                  }
+                  sideContent={
+                    <div>
+                      {wasSearched && (
+                        <Sorting label={"Sort by"} sortOptions={SORT_OPTIONS} />
+                      )}
+                      <Facet
+                        field={fields.states}
+                        label="States"
+                        filterType="any"
+                        isFilterable={true}
                       />
-                    }
-                    sideContent={
-                      <div>
-                        {wasSearched && (
-                          <Sorting
-                            label={"Sort by"}
-                            sortOptions={SORT_OPTIONS}
-                          />
-                        )}
-                        <Facet
-                          field={fields.states}
-                          label="States"
-                          filterType="any"
-                          isFilterable={true}
-                        />
-                        <Facet
-                          field={fields.world_heritage_site}
-                          label="World Heritage Site"
-                          view={BooleanFacet}
-                        />
-                        <Facet
-                          field="visitors"
-                          label="Visitors"
-                          view={SingleLinksFacet}
-                        />
-                        <Facet
-                          field="date_established"
-                          label="Date Established"
-                          filterType="any"
-                        />
-                        <Facet
-                          field="location"
-                          label="Distance"
-                          filterType="any"
-                        />
-                        <Facet
-                          field="acres"
-                          label="Acres"
-                          view={SingleSelectFacet}
-                        />
-                      </div>
-                    }
-                    bodyContent={
-                      <Results
-                        titleField="title"
-                        urlField="nps_link"
-                        thumbnailField="image_url"
-                        shouldTrackClickThrough={true}
+                      <Facet
+                        field={fields.world_heritage_site}
+                        label="World Heritage Site"
+                        view={BooleanFacet}
                       />
-                    }
-                    bodyHeader={
-                      <React.Fragment>
-                        {wasSearched && <PagingInfo />}
-                        {wasSearched && <ResultsPerPage />}
-                      </React.Fragment>
-                    }
-                    bodyFooter={<Paging />}
-                  />
-                </ErrorBoundary>
-              </div>
-            );
-          }}
-        </WithSearch>
-      </SearchProvider>
-    </EuiProvider>
+                      <Facet
+                        field="visitors"
+                        label="Visitors"
+                        view={SingleLinksFacet}
+                      />
+                      <Facet
+                        field="date_established"
+                        label="Date Established"
+                        filterType="any"
+                      />
+                      <Facet
+                        field="location"
+                        label="Distance"
+                        filterType="any"
+                      />
+                      <Facet
+                        field="acres"
+                        label="Acres"
+                        view={SingleSelectFacet}
+                      />
+                    </div>
+                  }
+                  bodyContent={
+                    <Results
+                      titleField="title"
+                      urlField="nps_link"
+                      thumbnailField="image_url"
+                      shouldTrackClickThrough={true}
+                    />
+                  }
+                  bodyHeader={
+                    <React.Fragment>
+                      {wasSearched && <PagingInfo />}
+                      {wasSearched && <ResultsPerPage />}
+                    </React.Fragment>
+                  }
+                  bodyFooter={<Paging />}
+                />
+              </ErrorBoundary>
+            </div>
+          );
+        }}
+      </WithSearch>
+    </SearchProvider>
   );
 }

--- a/examples/sandbox/src/Router.js
+++ b/examples/sandbox/src/Router.js
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { Routes, Route, Link } from "react-router-dom";
+import { Switch, Route } from "react-router-dom";
 import "./App.css";
 import App from "./App";
 import WorkplaceSearch from "./WorkplaceSearch";
@@ -7,10 +7,14 @@ import WorkplaceSearch from "./WorkplaceSearch";
 export default function Router() {
   return (
     <div className="App">
-      <Routes>
-        <Route path="/" element={<App />} />
-        <Route path="workplace-search" element={<WorkplaceSearch />} />
-      </Routes>
+      <Switch>
+        <Route exact path="/">
+          <App />
+        </Route>
+        <Route exact path="/workplace-search">
+          <WorkplaceSearch />
+        </Route>
+      </Switch>
     </div>
   );
 }

--- a/examples/sandbox/src/Router.js
+++ b/examples/sandbox/src/Router.js
@@ -1,0 +1,16 @@
+import * as React from "react";
+import { Routes, Route, Link } from "react-router-dom";
+import "./App.css";
+import App from "./App";
+import WorkplaceSearch from "./WorkplaceSearch";
+
+export default function Router() {
+  return (
+    <div className="App">
+      <Routes>
+        <Route path="/" element={<App />} />
+        <Route path="workplace-search" element={<WorkplaceSearch />} />
+      </Routes>
+    </div>
+  );
+}

--- a/examples/sandbox/src/WorkplaceSearch.js
+++ b/examples/sandbox/src/WorkplaceSearch.js
@@ -1,0 +1,256 @@
+import React from "react";
+import {
+  EuiButton,
+  EuiModal,
+  EuiModalBody,
+  EuiModalFooter,
+  EuiModalHeader,
+  EuiModalHeaderTitle,
+  EuiText,
+  EuiProvider
+} from "@elastic/eui";
+import "@elastic/eui/dist/eui_theme_light.css";
+
+import WorkplaceSearchAPIConnector from "@elastic/search-ui-workplace-search-connector";
+import {
+  ErrorBoundary,
+  Facet,
+  SearchProvider,
+  SearchBox,
+  Results,
+  PagingInfo,
+  ResultsPerPage,
+  Paging,
+  Sorting,
+  WithSearch
+} from "@elastic/react-search-ui";
+import {
+  BooleanFacet,
+  Layout,
+  SingleLinksFacet,
+  SingleSelectFacet
+} from "@elastic/react-search-ui-views";
+import "@elastic/react-search-ui-views/lib/styles/styles.css";
+import {
+  config as WorkplaceSearchConfig,
+  fields as WorkplaceSearchFields
+} from "./configurations/WorkplaceSearch";
+import "./App.css";
+
+const fields = WorkplaceSearchFields;
+
+const SORT_OPTIONS = [
+  {
+    name: "Relevance",
+    value: []
+  },
+  {
+    name: "Title",
+    value: [
+      {
+        field: fields.title,
+        direction: "asc"
+      }
+    ]
+  },
+  {
+    name: "State",
+    value: [
+      {
+        field: fields.states,
+        direction: "asc"
+      }
+    ]
+  },
+  {
+    name: "State -> Title",
+    value: [
+      {
+        field: fields.states,
+        direction: "asc"
+      },
+      {
+        field: fields.title,
+        direction: "asc"
+      }
+    ]
+  },
+  {
+    name: "Heritage Site -> State -> Title",
+    value: [
+      {
+        field: fields.world_heritage_site,
+        direction: "asc"
+      },
+      {
+        field: fields.states,
+        direction: "asc"
+      },
+      {
+        field: fields.title,
+        direction: "asc"
+      }
+    ]
+  }
+];
+
+let connector = new WorkplaceSearchAPIConnector({
+  kibanaBase:
+    process.env.REACT_WORKPLACE_SEARCH_KIBANA_BASE ||
+    "https://search-ui-sandbox.kb.us-central1.gcp.cloud.es.io:9243",
+  enterpriseSearchBase:
+    process.env.REACT_WORKPLACE_SEARCH_ENTERPRISE_SEARCH_BASE ||
+    "https://search-ui-sandbox.ent.us-central1.gcp.cloud.es.io",
+  redirectUri:
+    process.env.REACT_WORKPLACE_SEARCH_REDIRECT_URI || "http://localhost:3000",
+  clientId:
+    process.env.REACT_WORKPLACE_SEARCH_CLIENT_ID ||
+    "8e495e40fc1e6acf515e557e534de39d4f727f7f60a3afed24a99ce3a6607c1e"
+});
+
+const config = {
+  debug: true,
+  alwaysSearchOnInitialLoad: true,
+  ...WorkplaceSearchConfig,
+  apiConnector: connector,
+  hasA11yNotifications: true
+};
+
+export default function WorkplaceSearch() {
+  return (
+    <EuiProvider colorMode="light">
+      <SearchProvider config={config}>
+        <WithSearch
+          mapContextToProps={({ wasSearched, authorizeUrl, isLoggedIn }) => ({
+            wasSearched,
+            authorizeUrl,
+            isLoggedIn
+          })}
+        >
+          {({ wasSearched, authorizeUrl, isLoggedIn }) => {
+            return (
+              <div className="App">
+                <ErrorBoundary>
+                  {!isLoggedIn && (
+                    <EuiModal
+                      onClose={() => {}}
+                      maxWidth={354}
+                      className="login-modal"
+                    >
+                      <EuiModalHeader className="login-modal__header">
+                        <EuiModalHeaderTitle>
+                          <h1>Log in to continue</h1>
+                        </EuiModalHeaderTitle>
+                      </EuiModalHeader>
+
+                      <EuiModalBody>
+                        <EuiText size="m">
+                          <p>
+                            Search UI requires an active, authorized connection
+                            to Elastic Enteprise Search.
+                            <br />
+                            Select “Log in” below to continue.
+                          </p>
+                        </EuiText>
+                      </EuiModalBody>
+
+                      <EuiModalFooter>
+                        <EuiButton href={authorizeUrl} fill fullWidth>
+                          Log in
+                        </EuiButton>
+                      </EuiModalFooter>
+                    </EuiModal>
+                  )}
+                  <Layout
+                    header={
+                      <SearchBox
+                        autocompleteMinimumCharacters={3}
+                        autocompleteResults={{
+                          linkTarget: "_blank",
+                          sectionTitle: "Results",
+                          titleField: "title",
+                          urlField: "nps_link",
+                          shouldTrackClickThrough: true,
+                          clickThroughTags: ["test"]
+                        }}
+                        autocompleteSuggestions={true}
+                        debounceLength={0}
+                      />
+                    }
+                    sideContent={
+                      <div>
+                        {wasSearched && (
+                          <Sorting
+                            label={"Sort by"}
+                            sortOptions={SORT_OPTIONS}
+                          />
+                        )}
+                        <Facet
+                          field={fields.source}
+                          label="Source"
+                          filterType="any"
+                        />
+                        <Facet
+                          field={fields.type}
+                          label="Type"
+                          filterType="any"
+                          isFilterable={true}
+                        />
+                        <Facet
+                          field={fields.states}
+                          label="States"
+                          filterType="any"
+                          isFilterable={true}
+                        />
+                        <Facet
+                          field={fields.world_heritage_site}
+                          label="World Heritage Site"
+                          view={BooleanFacet}
+                        />
+                        <Facet
+                          field="visitors"
+                          label="Visitors"
+                          view={SingleLinksFacet}
+                        />
+                        <Facet
+                          field="date_established"
+                          label="Date Established"
+                          filterType="any"
+                        />
+                        <Facet
+                          field="location"
+                          label="Distance"
+                          filterType="any"
+                        />
+                        <Facet
+                          field="acres"
+                          label="Acres"
+                          view={SingleSelectFacet}
+                        />
+                      </div>
+                    }
+                    bodyContent={
+                      <Results
+                        titleField="title"
+                        urlField="nps_link"
+                        thumbnailField="image_url"
+                        shouldTrackClickThrough={true}
+                      />
+                    }
+                    bodyHeader={
+                      <React.Fragment>
+                        {wasSearched && <PagingInfo />}
+                        {wasSearched && <ResultsPerPage />}
+                      </React.Fragment>
+                    }
+                    bodyFooter={<Paging />}
+                  />
+                </ErrorBoundary>
+              </div>
+            );
+          }}
+        </WithSearch>
+      </SearchProvider>
+    </EuiProvider>
+  );
+}

--- a/examples/sandbox/src/configurations/WorkplaceSearch.js
+++ b/examples/sandbox/src/configurations/WorkplaceSearch.js
@@ -1,0 +1,95 @@
+import moment from "moment";
+
+export const fields = {
+  title: "title",
+  states: "states",
+  world_heritage_site: "world_heritage_site",
+  source: "source",
+  type: "type"
+};
+
+export const config = {
+  searchQuery: {
+    disjunctiveFacets: ["acres", "states", "date_established", "location"],
+    facets: {
+      source: { type: "value" },
+      type: { type: "value" },
+      world_heritage_site: { type: "value" },
+      states: { type: "value", size: 30 },
+      acres: {
+        type: "range",
+        ranges: [
+          { from: -1, name: "Any" },
+          { from: 0, to: 1000, name: "Small" },
+          { from: 1001, to: 100000, name: "Medium" },
+          { from: 100001, name: "Large" }
+        ]
+      },
+      location: {
+        // San Francisco. In the future, make this the user's current position
+        center: "37.7749, -122.4194",
+        type: "range",
+        unit: "mi",
+        ranges: [
+          { from: 0, to: 100, name: "Nearby" },
+          { from: 100, to: 500, name: "A longer drive" },
+          { from: 500, name: "Perhaps fly?" }
+        ]
+      },
+      date_established: {
+        type: "range",
+        ranges: [
+          {
+            from: moment().subtract(50, "years").toISOString(),
+            name: "Within the last 50 years"
+          },
+          {
+            from: moment().subtract(100, "years").toISOString(),
+            to: moment().subtract(50, "years").toISOString(),
+            name: "50 - 100 years ago"
+          },
+          {
+            to: moment().subtract(100, "years").toISOString(),
+            name: "More than 100 years ago"
+          }
+        ]
+      },
+      visitors: {
+        type: "range",
+        ranges: [
+          { from: 0, to: 10000, name: "0 - 10000" },
+          { from: 10001, to: 100000, name: "10001 - 100000" },
+          { from: 100001, to: 500000, name: "100001 - 500000" },
+          { from: 500001, to: 1000000, name: "500001 - 1000000" },
+          { from: 1000001, to: 5000000, name: "1000001 - 5000000" },
+          { from: 5000001, to: 10000000, name: "5000001 - 10000000" },
+          { from: 10000001, name: "10000001+" }
+        ]
+      }
+    }
+  },
+  autocompleteQuery: {
+    results: {
+      resultsPerPage: 5,
+      result_fields: {
+        title: {
+          snippet: {
+            size: 100,
+            fallback: true
+          }
+        },
+        nps_link: {
+          raw: {}
+        }
+      }
+    },
+    suggestions: {
+      types: {
+        documents: {
+          fields: ["title"]
+        }
+      },
+      size: 4
+    }
+  }
+};

--- a/examples/sandbox/src/index.js
+++ b/examples/sandbox/src/index.js
@@ -1,10 +1,16 @@
 import React from "react";
 import ReactDOM from "react-dom";
+import { BrowserRouter } from "react-router-dom";
 import "./index.css";
-import App from "./App";
+import Router from "./Router";
 import * as serviceWorker from "./serviceWorker";
 
-ReactDOM.render(<App />, document.getElementById("root"));
+ReactDOM.render(
+  <BrowserRouter>
+    <Router />
+  </BrowserRouter>,
+  document.getElementById("root")
+);
 
 // If you want your app to work offline and load faster, you can change
 // unregister() to register() below. Note this comes with some pitfalls.

--- a/yarn.lock
+++ b/yarn.lock
@@ -1253,7 +1253,7 @@
   dependencies:
     regenerator-runtime "^0.12.0"
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.10.2", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.13", "@babel/runtime@^7.12.5", "@babel/runtime@^7.13.10", "@babel/runtime@^7.15.4", "@babel/runtime@^7.16.3", "@babel/runtime@^7.4.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.2":
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.10.2", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.13", "@babel/runtime@^7.12.5", "@babel/runtime@^7.13.10", "@babel/runtime@^7.15.4", "@babel/runtime@^7.16.3", "@babel/runtime@^7.4.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.2":
   version "7.17.2"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.17.2.tgz#66f68591605e59da47523c631416b18508779941"
   integrity sha512-hzeyJyMA1YGdJTuWU0e/j4wKXrU4OMFvY2MSlaI9B7VQb0r5cxTE3EAIS2Q7Tn2RIcDkRvTA/v2JsAEhxe99uw==
@@ -9459,6 +9459,13 @@ history@^4.9.0:
     tiny-warning "^1.0.0"
     value-equal "^1.0.1"
 
+history@^5.2.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/history/-/history-5.3.0.tgz#1548abaa245ba47992f063a0783db91ef201c73b"
+  integrity sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==
+  dependencies:
+    "@babel/runtime" "^7.7.6"
+
 hmac-drbg@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/hmac-drbg/-/hmac-drbg-1.0.1.tgz#d2745701025a6c775a6c545793ed502fc0c649a1"
@@ -14666,7 +14673,17 @@ react-docgen@^3.0.0:
     node-dir "^0.1.10"
     recast "^0.16.0"
 
-react-dom@17.0.2, react-dom@^16.7.0, react-dom@^17.0.2:
+react-dom@^16.7.0:
+  version "16.14.0"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.14.0.tgz#7ad838ec29a777fb3c75c3a190f661cf92ab8b89"
+  integrity sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.2"
+    scheduler "^0.19.1"
+
+react-dom@^17.0.2:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-17.0.2.tgz#ecffb6845e3ad8dbfcdc498f0d0a939736502c23"
   integrity sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==
@@ -14821,6 +14838,21 @@ react-remove-scroll@^2.4.1:
     tslib "^1.0.0"
     use-callback-ref "^1.2.3"
     use-sidecar "^1.0.1"
+
+react-router-dom@^6.2.2:
+  version "6.2.2"
+  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-6.2.2.tgz#f1a2c88365593c76b9612ae80154a13fcb72e442"
+  integrity sha512-AtYEsAST7bDD4dLSQHDnk/qxWLJdad5t1HFa1qJyUrCeGgEuCSw0VB/27ARbF9Fi/W5598ujvJOm3ujUCVzuYQ==
+  dependencies:
+    history "^5.2.0"
+    react-router "6.2.2"
+
+react-router@6.2.2:
+  version "6.2.2"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-6.2.2.tgz#495e683a0c04461eeb3d705fe445d6cf42f0c249"
+  integrity sha512-/MbxyLzd7Q7amp4gDOGaYvXwhEojkJD5BtExkuKmj39VEE0m3l/zipf6h2WIB2jyAO0lI6NGETh4RDcktRm4AQ==
+  dependencies:
+    history "^5.2.0"
 
 react-scripts@^5.0.0:
   version "5.0.0"
@@ -14977,7 +15009,16 @@ react-window@^1.8.6:
     "@babel/runtime" "^7.0.0"
     memoize-one ">=3.1.1 <6"
 
-react@17.0.2, react@^16.7.0, react@^17.0.2:
+react@^16.7.0:
+  version "16.14.0"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.14.0.tgz#94d776ddd0aaa37da3eda8fc5b6b18a4c9a3114d"
+  integrity sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.2"
+
+react@^17.0.2:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react/-/react-17.0.2.tgz#d0b5cc516d29eb3eee383f75b62864cfb6800037"
   integrity sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==
@@ -15731,6 +15772,14 @@ saxes@^5.0.1:
   integrity sha512-5LBh1Tls8c9xgGjw3QrMwETmTMVk0oFgvrFSvWx62llR2hcEInrKNZ2GZCCuuy2lvWrdl5jhbpeqc5hRYKFOcw==
   dependencies:
     xmlchars "^2.2.0"
+
+scheduler@^0.19.1:
+  version "0.19.1"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.19.1.tgz#4f3e2ed2c1a7d65681f4c854fa8c5a1ccb40f196"
+  integrity sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
 
 scheduler@^0.20.2:
   version "0.20.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1253,7 +1253,7 @@
   dependencies:
     regenerator-runtime "^0.12.0"
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.10.2", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.13", "@babel/runtime@^7.12.5", "@babel/runtime@^7.13.10", "@babel/runtime@^7.15.4", "@babel/runtime@^7.16.3", "@babel/runtime@^7.4.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.2":
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.10.2", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.1", "@babel/runtime@^7.12.13", "@babel/runtime@^7.12.5", "@babel/runtime@^7.13.10", "@babel/runtime@^7.15.4", "@babel/runtime@^7.16.3", "@babel/runtime@^7.4.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.2":
   version "7.17.2"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.17.2.tgz#66f68591605e59da47523c631416b18508779941"
   integrity sha512-hzeyJyMA1YGdJTuWU0e/j4wKXrU4OMFvY2MSlaI9B7VQb0r5cxTE3EAIS2Q7Tn2RIcDkRvTA/v2JsAEhxe99uw==
@@ -9459,13 +9459,6 @@ history@^4.9.0:
     tiny-warning "^1.0.0"
     value-equal "^1.0.1"
 
-history@^5.2.0:
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/history/-/history-5.3.0.tgz#1548abaa245ba47992f063a0783db91ef201c73b"
-  integrity sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==
-  dependencies:
-    "@babel/runtime" "^7.7.6"
-
 hmac-drbg@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/hmac-drbg/-/hmac-drbg-1.0.1.tgz#d2745701025a6c775a6c545793ed502fc0c649a1"
@@ -9480,7 +9473,7 @@ hoist-non-react-statics@1.x.x, hoist-non-react-statics@^1.2.0:
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-1.2.0.tgz#aa448cf0986d55cc40773b17174b7dd066cb7cfb"
   integrity sha1-qkSM8JhtVcxAdzsXF0t90GbLfPs=
 
-hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.1, hoist-non-react-statics@^3.3.2:
+hoist-non-react-statics@^3.1.0, hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.1, hoist-non-react-statics@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
   integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
@@ -10492,6 +10485,11 @@ is-wsl@^2.2.0:
   integrity sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==
   dependencies:
     is-docker "^2.0.0"
+
+isarray@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
+  integrity sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=
 
 isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
@@ -12065,6 +12063,14 @@ min-indent@^1.0.0:
   resolved "https://registry.yarnpkg.com/min-indent/-/min-indent-1.0.1.tgz#a63f681673b30571fbe8bc25686ae746eefa9869"
   integrity sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==
 
+mini-create-react-context@^0.4.0:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/mini-create-react-context/-/mini-create-react-context-0.4.1.tgz#072171561bfdc922da08a60c2197a497cc2d1d5e"
+  integrity sha512-YWCYEmd5CQeHGSAKrYvXgmzzkrvssZcuuQDDeqkT+PziKGMgE+0MCCtcKbROzocGBG1meBLl2FotlRwf4gAzbQ==
+  dependencies:
+    "@babel/runtime" "^7.12.1"
+    tiny-warning "^1.0.3"
+
 mini-css-extract-plugin@^0.4.4:
   version "0.4.5"
   resolved "https://registry.yarnpkg.com/mini-css-extract-plugin/-/mini-css-extract-plugin-0.4.5.tgz#c99e9e78d54f3fa775633aee5933aeaa4e80719a"
@@ -13395,6 +13401,13 @@ path-to-regexp@0.1.7:
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
   integrity sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=
 
+path-to-regexp@^1.7.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.8.0.tgz#887b3ba9d84393e87a0a0b9f4cb756198b53548a"
+  integrity sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==
+  dependencies:
+    isarray "0.0.1"
+
 path-type@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-1.1.0.tgz#59c44f7ee491da704da415da5a4070ba4f8fe441"
@@ -14673,17 +14686,7 @@ react-docgen@^3.0.0:
     node-dir "^0.1.10"
     recast "^0.16.0"
 
-react-dom@^16.7.0:
-  version "16.14.0"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.14.0.tgz#7ad838ec29a777fb3c75c3a190f661cf92ab8b89"
-  integrity sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==
-  dependencies:
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    prop-types "^15.6.2"
-    scheduler "^0.19.1"
-
-react-dom@^17.0.2:
+react-dom@17.0.2, react-dom@^16.7.0, react-dom@^17.0.2:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-17.0.2.tgz#ecffb6845e3ad8dbfcdc498f0d0a939736502c23"
   integrity sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==
@@ -14783,7 +14786,7 @@ react-is@17.0.2, "react-is@^16.12.0 || ^17.0.0", react-is@^17.0.0, react-is@^17.
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
 
-react-is@^16.12.0, react-is@^16.13.1, react-is@^16.7.0, react-is@^16.9.0:
+react-is@^16.12.0, react-is@^16.13.1, react-is@^16.6.0, react-is@^16.7.0, react-is@^16.9.0:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
@@ -14839,20 +14842,34 @@ react-remove-scroll@^2.4.1:
     use-callback-ref "^1.2.3"
     use-sidecar "^1.0.1"
 
-react-router-dom@^6.2.2:
-  version "6.2.2"
-  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-6.2.2.tgz#f1a2c88365593c76b9612ae80154a13fcb72e442"
-  integrity sha512-AtYEsAST7bDD4dLSQHDnk/qxWLJdad5t1HFa1qJyUrCeGgEuCSw0VB/27ARbF9Fi/W5598ujvJOm3ujUCVzuYQ==
+react-router-dom@^5.0.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-5.3.0.tgz#da1bfb535a0e89a712a93b97dd76f47ad1f32363"
+  integrity sha512-ObVBLjUZsphUUMVycibxgMdh5jJ1e3o+KpAZBVeHcNQZ4W+uUGGWsokurzlF4YOldQYRQL4y6yFRWM4m3svmuQ==
   dependencies:
-    history "^5.2.0"
-    react-router "6.2.2"
+    "@babel/runtime" "^7.12.13"
+    history "^4.9.0"
+    loose-envify "^1.3.1"
+    prop-types "^15.6.2"
+    react-router "5.2.1"
+    tiny-invariant "^1.0.2"
+    tiny-warning "^1.0.0"
 
-react-router@6.2.2:
-  version "6.2.2"
-  resolved "https://registry.yarnpkg.com/react-router/-/react-router-6.2.2.tgz#495e683a0c04461eeb3d705fe445d6cf42f0c249"
-  integrity sha512-/MbxyLzd7Q7amp4gDOGaYvXwhEojkJD5BtExkuKmj39VEE0m3l/zipf6h2WIB2jyAO0lI6NGETh4RDcktRm4AQ==
+react-router@5.2.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-5.2.1.tgz#4d2e4e9d5ae9425091845b8dbc6d9d276239774d"
+  integrity sha512-lIboRiOtDLFdg1VTemMwud9vRVuOCZmUIT/7lUoZiSpPODiiH1UQlfXy+vPLC/7IWdFYnhRwAyNqA/+I7wnvKQ==
   dependencies:
-    history "^5.2.0"
+    "@babel/runtime" "^7.12.13"
+    history "^4.9.0"
+    hoist-non-react-statics "^3.1.0"
+    loose-envify "^1.3.1"
+    mini-create-react-context "^0.4.0"
+    path-to-regexp "^1.7.0"
+    prop-types "^15.6.2"
+    react-is "^16.6.0"
+    tiny-invariant "^1.0.2"
+    tiny-warning "^1.0.0"
 
 react-scripts@^5.0.0:
   version "5.0.0"
@@ -15009,16 +15026,7 @@ react-window@^1.8.6:
     "@babel/runtime" "^7.0.0"
     memoize-one ">=3.1.1 <6"
 
-react@^16.7.0:
-  version "16.14.0"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.14.0.tgz#94d776ddd0aaa37da3eda8fc5b6b18a4c9a3114d"
-  integrity sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==
-  dependencies:
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    prop-types "^15.6.2"
-
-react@^17.0.2:
+react@17.0.2, react@^16.7.0, react@^17.0.2:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react/-/react-17.0.2.tgz#d0b5cc516d29eb3eee383f75b62864cfb6800037"
   integrity sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==
@@ -15772,14 +15780,6 @@ saxes@^5.0.1:
   integrity sha512-5LBh1Tls8c9xgGjw3QrMwETmTMVk0oFgvrFSvWx62llR2hcEInrKNZ2GZCCuuy2lvWrdl5jhbpeqc5hRYKFOcw==
   dependencies:
     xmlchars "^2.2.0"
-
-scheduler@^0.19.1:
-  version "0.19.1"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.19.1.tgz#4f3e2ed2c1a7d65681f4c854fa8c5a1ccb40f196"
-  integrity sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==
-  dependencies:
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
 
 scheduler@^0.20.2:
   version "0.20.2"
@@ -17117,7 +17117,7 @@ tiny-invariant@^1.0.2, tiny-invariant@^1.0.6:
   resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.2.0.tgz#a1141f86b672a9148c72e978a19a73b9b94a15a9"
   integrity sha512-1Uhn/aqw5C6RI4KejVeTg6mIS7IqxnLJ8Mv2tV5rTc0qWobay7pDUz6Wi392Cnc8ak1H0F2cjoRzb2/AW4+Fvg==
 
-tiny-warning@^1.0.0:
+tiny-warning@^1.0.0, tiny-warning@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/tiny-warning/-/tiny-warning-1.0.3.tgz#94a30db453df4c643d0fd566060d60a875d84754"
   integrity sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==


### PR DESCRIPTION
This PR separates sandbox into Workplace Search sandbox and everything else.

Workplace search sandbox is now available at `http://localhost:3000/workplace-search/`:

![image](https://user-images.githubusercontent.com/11838280/158070178-f88f0e1f-e8ae-4fa9-a3af-769fe7231c28.png)

I didn't do much work on facets, just added a couple to demonstrate the Ws-specific data.

Best to view changes with whitespace hidden.