### PR TITLE
Workplace Search header and logout

### DIFF
--- a/examples/sandbox/src/pages/workplace-search/index.css
+++ b/examples/sandbox/src/pages/workplace-search/index.css
@@ -1,5 +1,9 @@
 /* EUI overrides */
 
+html {
+  background: none !important;
+}
+
 .sui-search-box__text-input:focus:focus-visible {
   outline: none;
 }

--- a/examples/sandbox/src/pages/workplace-search/index.js
+++ b/examples/sandbox/src/pages/workplace-search/index.js
@@ -1,13 +1,18 @@
 import React from "react";
 import {
   EuiButton,
+  EuiButtonEmpty,
   EuiModal,
   EuiModalBody,
   EuiModalFooter,
   EuiModalHeader,
   EuiModalHeaderTitle,
   EuiText,
-  EuiProvider
+  EuiProvider,
+  EuiHeader,
+  EuiHeaderSectionItem,
+  EuiHeaderSection,
+  EuiHeaderLogo
 } from "@elastic/eui";
 import "@elastic/eui/dist/eui_theme_light.css";
 
@@ -53,7 +58,7 @@ let connector = new WorkplaceSearchAPIConnector({
     "https://search-ui-sandbox.ent.us-central1.gcp.cloud.es.io",
   redirectUri:
     process.env.REACT_WORKPLACE_SEARCH_REDIRECT_URI ||
-    "http://localhost:3000/workplace-search",
+    "http://localhost:3000/workplace-search/",
   clientId:
     process.env.REACT_WORKPLACE_SEARCH_CLIENT_ID ||
     "8e495e40fc1e6acf515e557e534de39d4f727f7f60a3afed24a99ce3a6607c1e"
@@ -117,7 +122,27 @@ export default function WorkplaceSearch() {
           {({ wasSearched, authorizeUrl, isLoggedIn, logout }) => {
             return (
               <div className="App">
-                <EuiButton onClick={() => logout()}>Logout</EuiButton>
+                <EuiHeader>
+                  <EuiHeaderSection>
+                    <EuiHeaderSectionItem>
+                      <EuiHeaderLogo iconType="logoWorkplaceSearch">
+                        Workplace Search
+                      </EuiHeaderLogo>
+                    </EuiHeaderSectionItem>
+                  </EuiHeaderSection>
+                  {isLoggedIn && (
+                    <EuiHeaderSection side="right">
+                      <EuiHeaderSectionItem>
+                        <EuiButtonEmpty
+                          iconType="exit"
+                          onClick={() => logout()}
+                        >
+                          Logout
+                        </EuiButtonEmpty>
+                      </EuiHeaderSectionItem>
+                    </EuiHeaderSection>
+                  )}
+                </EuiHeader>
                 <ErrorBoundary>
                   {!isLoggedIn && (
                     <EuiModal

--- a/examples/sandbox/src/pages/workplace-search/index.js
+++ b/examples/sandbox/src/pages/workplace-search/index.js
@@ -24,9 +24,7 @@ import {
   Sorting,
   WithSearch
 } from "@elastic/react-search-ui";
-import {
-  Layout
-} from "@elastic/react-search-ui-views";
+import { Layout } from "@elastic/react-search-ui-views";
 import "@elastic/react-search-ui-views/lib/styles/styles.css";
 import "./index.css";
 
@@ -103,15 +101,22 @@ export default function WorkplaceSearch() {
     <EuiProvider colorMode="light">
       <SearchProvider config={config}>
         <WithSearch
-          mapContextToProps={({ wasSearched, authorizeUrl, isLoggedIn }) => ({
+          mapContextToProps={({
             wasSearched,
             authorizeUrl,
-            isLoggedIn
+            isLoggedIn,
+            logout
+          }) => ({
+            wasSearched,
+            authorizeUrl,
+            isLoggedIn,
+            logout
           })}
         >
-          {({ wasSearched, authorizeUrl, isLoggedIn }) => {
+          {({ wasSearched, authorizeUrl, isLoggedIn, logout }) => {
             return (
               <div className="App">
+                <EuiButton onClick={() => logout()}>Logout</EuiButton>
                 <ErrorBoundary>
                   {!isLoggedIn && (
                     <EuiModal

--- a/examples/sandbox/src/pages/workplace-search/index.js
+++ b/examples/sandbox/src/pages/workplace-search/index.js
@@ -52,7 +52,8 @@ let connector = new WorkplaceSearchAPIConnector({
     process.env.REACT_WORKPLACE_SEARCH_ENTERPRISE_SEARCH_BASE ||
     "https://search-ui-sandbox.ent.us-central1.gcp.cloud.es.io",
   redirectUri:
-    process.env.REACT_WORKPLACE_SEARCH_REDIRECT_URI || "http://localhost:3000",
+    process.env.REACT_WORKPLACE_SEARCH_REDIRECT_URI ||
+    "http://localhost:3000/workplace-search",
   clientId:
     process.env.REACT_WORKPLACE_SEARCH_CLIENT_ID ||
     "8e495e40fc1e6acf515e557e534de39d4f727f7f60a3afed24a99ce3a6607c1e"

--- a/packages/search-ui-workplace-search-connector/src/WorkplaceSearchAPIConnector.ts
+++ b/packages/search-ui-workplace-search-connector/src/WorkplaceSearchAPIConnector.ts
@@ -111,6 +111,9 @@ class WorkplaceSearchAPIConnector {
     authorizeUrl: string;
     isLoggedIn: boolean;
   };
+  actions: {
+    logout: () => void;
+  };
 
   /**
    * @param {Options} options
@@ -132,6 +135,12 @@ class WorkplaceSearchAPIConnector {
     }
 
     const authorizeUrl = `${kibanaBase}/app/enterprise_search/workplace_search/p/oauth/authorize?client_id=${clientId}&redirect_uri=${redirectUri}&response_type=token`;
+    // We need to logout from both application: Kibana, because a user can get a new access token with it,
+    // and Enterprise Search, because it serves the default search experience with the same data.
+    // There are 2 logout urls: [kibanaBase]/logout and [enterpriseSearchBase]/logout
+    // Hitting the Kibana logout only logs out of Kibana, but hitting the Enterprise Search logout logs out of both Entperise Search and Kibana.
+    // That's why we use [enterpriseSearchBase]/logout as the logout url.
+    const logoutUrl = `${enterpriseSearchBase}/logout`;
 
     // There are 3 ways the initial load might happen:
     // 1) First load: there is no accessToken in localStorage
@@ -155,6 +164,14 @@ class WorkplaceSearchAPIConnector {
     this.state = {
       authorizeUrl,
       isLoggedIn: !!this.accessToken || false
+    };
+
+    this.actions = {
+      logout: () => {
+        this.accessToken = null;
+        this.state.isLoggedIn = false;
+        window.location.href = logoutUrl;
+      }
     };
 
     this.enterpriseSearchBase = enterpriseSearchBase;

--- a/packages/search-ui/src/SearchDriver.ts
+++ b/packages/search-ui/src/SearchDriver.ts
@@ -163,6 +163,12 @@ class SearchDriver {
       },
       {}
     ) as actions.SearchDriverActions;
+
+    this.actions = {
+      ...this.actions,
+      ...(apiConnector?.actions && { ...apiConnector.actions })
+    };
+
     Object.assign(this, this.actions);
 
     this.events = new Events({

--- a/packages/search-ui/src/__tests__/SearchDriver.test.ts
+++ b/packages/search-ui/src/__tests__/SearchDriver.test.ts
@@ -4,6 +4,7 @@ import {
   doesStateHaveResponseData,
   setupDriver,
   getMockApiConnector,
+  getMockApiConnectorWithStateAndActions,
   waitATick
 } from "../test/helpers";
 
@@ -432,7 +433,7 @@ describe("tearDown", () => {
 });
 
 describe("#getActions", () => {
-  it("returns the current state", () => {
+  it("returns the current actions", () => {
     const driver = new SearchDriver(params);
     const actions = driver.getActions();
     expect(Object.keys(actions).length).toBe(12);
@@ -448,6 +449,16 @@ describe("#getActions", () => {
     expect(actions.trackClickThrough).toBeInstanceOf(Function);
     expect(actions.trackAutocompleteClickThrough).toBeInstanceOf(Function);
     expect(actions.a11yNotify).toBeInstanceOf(Function);
+  });
+
+  it("includes connector actions if they're available", () => {
+    const driver = new SearchDriver({
+      apiConnector: getMockApiConnectorWithStateAndActions(),
+      trackUrlState: false
+    });
+
+    const actions = driver.getActions();
+    expect(Object.keys(actions).length).toBe(13);
   });
 });
 

--- a/packages/search-ui/src/test/helpers.ts
+++ b/packages/search-ui/src/test/helpers.ts
@@ -53,6 +53,16 @@ export function getMockApiConnector() {
   };
 }
 
+export function getMockApiConnectorWithStateAndActions() {
+  return {
+    ...getMockApiConnector(),
+    state: { foo: "foo" },
+    actions: {
+      bar: jest.fn().mockReturnValue("bar")
+    }
+  };
+}
+
 type SetupDriverOptions = {
   mockSearchResponse?: any; //eslint-disable-line @typescript-eslint/no-explicit-any
   mockApiConnector?: APIConnector;


### PR DESCRIPTION
This PR adds a header to the Workplace Search sandbox and implements a logout button.

Clicking on the logout button does two things:
1) Removes the token from the localstorage
2) Redirects user to [ent-search]/logout which invalidates the ent-search session and redirects to [kibana]/logout which invalidates the kibana session

The logout method was implemented on the Workplace Search connector and passed as an action to search-ui core actions.

https://user-images.githubusercontent.com/11838280/158480315-7cb9d316-6bcb-41dc-af72-95cef9227a33.mp4
