### PR TITLE
Elasticsearch-connector: Facet Value Sort Feature 

### DIFF
--- a/examples/sandbox/src/pages/elasticsearch/index.js
+++ b/examples/sandbox/src/pages/elasticsearch/index.js
@@ -66,7 +66,7 @@ const config = {
     disjunctiveFacets: ["acres", "states.keyword", "date_established", "location"],
     facets: {
       "world_heritage_site.keyword": { type: "value" },
-      "states.keyword": { type: "value", size: 30 },
+      "states.keyword": { type: "value", size: 30, sort: "count" },
       acres: {
         type: "range",
         ranges: [

--- a/packages/react-search-ui/src/containers/Facet.tsx
+++ b/packages/react-search-ui/src/containers/Facet.tsx
@@ -122,7 +122,7 @@ export class FacetContainer extends Component<
       onSearch: (value) => {
         this.handleFacetSearch(value);
       },
-      searchPlaceholder: `Filter ${field}`,
+      searchPlaceholder: `Filter ${label}`,
       ...rest
     };
 

--- a/packages/react-search-ui/src/containers/__tests__/Facet.test.tsx
+++ b/packages/react-search-ui/src/containers/__tests__/Facet.test.tsx
@@ -298,6 +298,7 @@ it("passes data-foo through to the view", () => {
 describe("search facets", () => {
   let wrapper: ShallowWrapper;
   const field = "field1";
+  const label = "field label";
   const fieldData = [
     { count: 20, value: "Virat" },
     { count: 9, value: "LÒpez" },
@@ -310,6 +311,7 @@ describe("search facets", () => {
         {...{
           ...params,
           field,
+          label,
           facets: {
             field1: [
               {
@@ -336,7 +338,7 @@ describe("search facets", () => {
 
   it("should use the field name as a search input placeholder", () => {
     expect(wrapper.find(View).prop("searchPlaceholder")).toBe(
-      `Filter ${field}`
+      `Filter ${label}`
     );
   });
 

--- a/packages/react-search-ui/src/containers/__tests__/__snapshots__/Facet.test.tsx.snap
+++ b/packages/react-search-ui/src/containers/__tests__/__snapshots__/Facet.test.tsx.snap
@@ -22,7 +22,7 @@ exports[`renders correctly 1`] = `
       },
     ]
   }
-  searchPlaceholder="Filter field1"
+  searchPlaceholder="Filter Field 1"
   show={5}
   showMore={false}
   showSearch={false}

--- a/packages/search-ui-elasticsearch-connector/package.json
+++ b/packages/search-ui-elasticsearch-connector/package.json
@@ -38,6 +38,6 @@
   },
   "dependencies": {
     "@elastic/search-ui": "1.10.0",
-    "@searchkit/sdk": "^3.0.0-canary.50"
+    "@searchkit/sdk": "^3.0.0-canary.51"
   }
 }

--- a/packages/search-ui-elasticsearch-connector/src/handlers/search/Configuration.ts
+++ b/packages/search-ui-elasticsearch-connector/src/handlers/search/Configuration.ts
@@ -63,7 +63,8 @@ function buildConfiguration(
             field: facetKey,
             label: facetKey,
             size: facetConfiguration.size || 20,
-            multipleSelect: isDisJunctive
+            multipleSelect: isDisJunctive,
+            order: facetConfiguration.sort || "count"
           })
         );
       } else if (

--- a/packages/search-ui-elasticsearch-connector/src/handlers/search/__tests__/Configuration.test.ts
+++ b/packages/search-ui-elasticsearch-connector/src/handlers/search/__tests__/Configuration.test.ts
@@ -65,7 +65,8 @@ describe("Search - Configuration", () => {
         },
         type: {
           type: "value",
-          size: 20
+          size: 20,
+          sort: "value"
         }
       },
       disjunctiveFacets: ["category"]
@@ -106,14 +107,16 @@ describe("Search - Configuration", () => {
         field: "category",
         label: "category",
         size: 20,
-        multipleSelect: true
+        multipleSelect: true,
+        order: "count"
       });
       expect(RefinementSelectFacet).toHaveBeenCalledWith({
         identifier: "type",
         field: "type",
         label: "type",
         size: 20,
-        multipleSelect: false
+        multipleSelect: false,
+        order: "value"
       });
     });
 
@@ -155,14 +158,16 @@ describe("Search - Configuration", () => {
         field: "category",
         label: "category",
         size: 20,
-        multipleSelect: true
+        multipleSelect: true,
+        order: "count"
       });
       expect(RefinementSelectFacet).toHaveBeenCalledWith({
         identifier: "type",
         field: "type",
         label: "type",
         size: 20,
-        multipleSelect: false
+        multipleSelect: false,
+        order: "value"
       });
     });
 

--- a/packages/search-ui/src/types/index.ts
+++ b/packages/search-ui/src/types/index.ts
@@ -113,6 +113,7 @@ export type FacetConfiguration = {
   ranges?: FilterValueRange[];
   center?: string;
   unit?: string;
+  sort?: "count" | "value";
 };
 
 // todo: types

--- a/yarn.lock
+++ b/yarn.lock
@@ -2784,10 +2784,10 @@
   dependencies:
     any-observable "^0.3.0"
 
-"@searchkit/sdk@^3.0.0-canary.50":
-  version "3.0.0-canary.50"
-  resolved "https://registry.yarnpkg.com/@searchkit/sdk/-/sdk-3.0.0-canary.50.tgz#6872a5c162c5aa20e732df887f4d1c0dfbea60a1"
-  integrity sha512-hRlkr6wR5Tv3rhvFCv0+ujgCvmYg1mZxsLJZKODbOZQ3g5aEaosGMPtifSD6bs2sNvxQBedEbPYa6yukWA++UA==
+"@searchkit/sdk@^3.0.0-canary.51":
+  version "3.0.0-canary.51"
+  resolved "https://registry.yarnpkg.com/@searchkit/sdk/-/sdk-3.0.0-canary.51.tgz#a4a2098471fc9c26c69ac15d360a7fae54b35966"
+  integrity sha512-RUaUBS6IyuugSuk7sHbTQRR+d+uhEjflN1oI4rTZmZPBVDNZ7I2xT5Wucjj7GanVGCK+Gx5jJ0BfylBJTqzBkQ==
   dependencies:
     agentkeepalive "^4.1.3"
     lodash "^4.17.21"


### PR DESCRIPTION
Supports the ability to sort facet values alphabetically. Configuration is consistent with the facet field configuration API. Also involved building the feature into Searchkit https://github.com/searchkit/searchkit/pull/1092.

Also fixed an annoying issue where the search placeholder for Facet is now using the label value, not the field. Was putting in "states.keyword" in the placeholder and really annoyed me 😂 

```javascript
facets: {
      "world_heritage_site.keyword": { type: "value", sort: "count" },
      "states.keyword": { type: "value", size: 30, sort: "value" } // using the sort attribute
}
``` 

![image](https://user-images.githubusercontent.com/49480/158680009-5c5a1d16-4ebc-420c-9706-111b2536fc9f.png)

