### PR TITLE
disable sourcemaps + update rc-pagination css

### DIFF
--- a/packages/react-search-ui-views/bin/build-css
+++ b/packages/react-search-ui-views/bin/build-css
@@ -3,5 +3,5 @@ sass --no-source-map src/:lib/
 
 # Process compiled SASS to inline imported CSS files and add vendor prefixes
 # Move it to /lib
-postcss lib/styles/styles.css --use postcss-import autoprefixer -o lib/styles/styles.css
+postcss lib/styles/styles.css --use autoprefixer -o lib/styles/styles.css
 

--- a/packages/react-search-ui-views/bin/build-css
+++ b/packages/react-search-ui-views/bin/build-css
@@ -1,5 +1,5 @@
 # Compile Sass to a temporary location
-sass src/:lib/
+sass --no-source-map src/:lib/
 
 # Process compiled SASS to inline imported CSS files and add vendor prefixes
 # Move it to /lib

--- a/packages/react-search-ui-views/package.json
+++ b/packages/react-search-ui-views/package.json
@@ -53,7 +53,6 @@
     "core-js-pure": "^3.6.5",
     "npm-run-all": "^4.1.5",
     "postcss-cli": "^6.1.3",
-    "postcss-import": "^12.0.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "rimraf": "^2.6.3",

--- a/packages/react-search-ui-views/src/styles/themes/reference-ui/components/_paging.scss
+++ b/packages/react-search-ui-views/src/styles/themes/reference-ui/components/_paging.scss
@@ -1,6 +1,6 @@
-@include block("paging") {
-  @import "../../../../node_modules/rc-pagination/dist/rc-pagination.min.css";
+@import "../../../../../../../node_modules/rc-pagination/dist/rc-pagination.min";
 
+@include block("paging") {
   > li {
     border: none;
     background: transparent;

--- a/packages/react-search-ui-views/src/styles/themes/reference-ui/components/_paging.scss
+++ b/packages/react-search-ui-views/src/styles/themes/reference-ui/components/_paging.scss
@@ -1,5 +1,4 @@
 @import "../../../../../../../node_modules/rc-pagination/dist/rc-pagination.min";
-
 @include block("paging") {
   > li {
     border: none;


### PR DESCRIPTION
### Issue

Two changes:
- replacing node-sass for sass: https://github.com/elastic/search-ui/pull/656
- yarn workspaces https://github.com/elastic/search-ui/pull/635

have caused two regressions + changes in this PR:
- sass is now generating css sourcemap files with file paths that do not exist in the packaged library. Fix is to switch off sourcemap generation so behaves the same as node-sass.
- rc-pagination css code was not included in the bundled css file. yarn workspaces has changed the location of the rc-pagination library (now in the node_modules root). Fix was to update the path to the css file. Ive also moved the positioning of the import outside the import block and removed the postcss-import task as the import now happens in sass execution.