### PR TITLE
Make state property on APIConnector interface optional

### DIFF
--- a/packages/react-search-ui/src/__tests__/SearchProvider.test.tsx
+++ b/packages/react-search-ui/src/__tests__/SearchProvider.test.tsx
@@ -10,8 +10,7 @@ function getMocks() {
     onSearch: jest.fn(),
     onAutocomplete: jest.fn(),
     onResultClick: jest.fn(),
-    onAutocompleteResultClick: jest.fn(),
-    state: {}
+    onAutocompleteResultClick: jest.fn()
   };
 
   const driver = new SearchDriver({

--- a/packages/react-search-ui/src/__tests__/WithSearchRenderProps.test.tsx
+++ b/packages/react-search-ui/src/__tests__/WithSearchRenderProps.test.tsx
@@ -22,8 +22,7 @@ describe("WithSearch", () => {
     onSearch: jest.fn(),
     onAutocomplete: jest.fn(),
     onResultClick: jest.fn(),
-    onAutocompleteResultClick: jest.fn(),
-    state: {}
+    onAutocompleteResultClick: jest.fn()
   };
 
   it("exposes state and actions to components", () => {

--- a/packages/search-ui-app-search-connector/src/AppSearchAPIConnector.ts
+++ b/packages/search-ui-app-search-connector/src/AppSearchAPIConnector.ts
@@ -88,7 +88,6 @@ class AppSearchAPIConnector implements APIConnector {
    */
 
   client: any;
-  state: any = {};
   beforeSearchCall?: SearchQueryHook;
   beforeAutocompleteResultsCall?: SearchQueryHook;
   beforeAutocompleteSuggestionsCall?: SuggestionsQueryHook;

--- a/packages/search-ui-elasticsearch-connector/src/index.ts
+++ b/packages/search-ui-elasticsearch-connector/src/index.ts
@@ -21,8 +21,6 @@ type SearchConfiguration = {
 };
 
 class ElasticsearchAPIConnector implements APIConnector {
-  state = {};
-
   constructor(
     private config: ConnectionOptions,
     private searchConfig: SearchConfiguration

--- a/packages/search-ui/src/test/helpers.ts
+++ b/packages/search-ui/src/test/helpers.ts
@@ -54,8 +54,7 @@ export function getMockApiConnector(): APIConnector {
     }),
     onSearch: jest.fn().mockReturnValue({ then: (cb) => cb(searchResponse) }),
     onResultClick: jest.fn().mockReturnValue(Promise.resolve(true)),
-    onAutocompleteResultClick: jest.fn().mockReturnValue(Promise.resolve(true)),
-    state: {}
+    onAutocompleteResultClick: jest.fn().mockReturnValue(Promise.resolve(true))
   };
 }
 

--- a/packages/search-ui/src/types/index.ts
+++ b/packages/search-ui/src/types/index.ts
@@ -142,7 +142,7 @@ export interface APIConnector {
   ): Promise<AutocompleteResponseState>;
   onResultClick(params): void;
   onAutocompleteResultClick(params): void;
-  state: any;
+  state?: any;
   actions?: any;
 }
 


### PR DESCRIPTION
It is only needed in the Workplace Search connector and it's possible that it will be removed from that interface at some point.

This is a follow-up to https://github.com/elastic/search-ui/pull/682, where the state property was added to APIConnector interface.