### PR TITLE
elasticsearch connector to use search_fields

### DIFF
--- a/examples/sandbox/src/pages/elasticsearch/index.js
+++ b/examples/sandbox/src/pages/elasticsearch/index.js
@@ -26,7 +26,7 @@ import "@elastic/react-search-ui-views/lib/styles/styles.css";
 
 const connector = new ElasticSearchAPIConnector(
   {
-    host: "http://localhost:9200",
+    host: process.env.REACT_ELASTICSEARCH_HOST || "http://localhost:9200",
     index: process.env.REACT_ELASTICSEARCH_INDEX || "us_parks"
   }
 );

--- a/examples/sandbox/src/pages/elasticsearch/index.js
+++ b/examples/sandbox/src/pages/elasticsearch/index.js
@@ -26,11 +26,8 @@ import "@elastic/react-search-ui-views/lib/styles/styles.css";
 
 const connector = new ElasticSearchAPIConnector(
   {
-    host: process.env.REACT_ELASTICSEARCH_HOST || "http://localhost:9200",
+    host: "http://localhost:9200",
     index: process.env.REACT_ELASTICSEARCH_INDEX || "us_parks"
-  },
-  {
-    queryFields: ["title", "description", "states"]
   }
 );
 
@@ -40,6 +37,14 @@ const config = {
   apiConnector: connector,
   hasA11yNotifications: true,
   searchQuery: {
+    search_fields: {
+      title: { 
+        weight: 3
+      },
+      description: {
+        
+      }
+    },
     result_fields: {
       visitors: { raw: {} },
       world_heritage_site: { raw: {} },

--- a/packages/search-ui-elasticsearch-connector/README.md
+++ b/packages/search-ui-elasticsearch-connector/README.md
@@ -13,18 +13,13 @@ npm install --save @elastic/search-ui-elasticsearch-connector
 ```js
 import ElasticsearchAPIConnector from "@elastic/search-ui-elasticsearch-connector";
 
-const connector = new ElasticsearchAPIConnector(
-  {
-    host: "http://localhost:9200", // host url for the elasticsearch instance
-    index: "search-ui-examples", // index name where the search documents are contained
-    apiKey: "apiKeyExample" // Optional. apiKey used to authorize a connection to Elasticsearch instance.
-    // This key will be visible to everyone so ensure its setup with restricted privileges.
-    // See Authentication section for more details.
-  },
-  {
-    queryFields: ["title", "description"]
-  }
-);
+const connector = new ElasticsearchAPIConnector({
+  host: "http://localhost:9200", // host url for the elasticsearch instance
+  index: "search-ui-examples", // index name where the search documents are contained
+  apiKey: "apiKeyExample" // Optional. apiKey used to authorize a connection to Elasticsearch instance.
+  // This key will be visible to everyone so ensure its setup with restricted privileges.
+  // See Authentication section for more details.
+});
 ```
 
 ## ElasticsearchAPIConnector
@@ -33,10 +28,9 @@ const connector = new ElasticsearchAPIConnector(
 
 ### new ElasticsearchAPIConnector(options)
 
-| Param         | Type                                    |
-| ------------- | --------------------------------------- |
-| options       | [<code>Options</code>](#Options)        |
-| searchOptions | [<code>Options</code>](#Search Options) |
+| Param   | Type                             |
+| ------- | -------------------------------- |
+| options | [<code>Options</code>](#Options) |
 
 ## Options
 
@@ -48,13 +42,9 @@ const connector = new ElasticsearchAPIConnector(
 | index  | <code>string</code> |         | Index name for where the search documents are contained in                                                                                     |
 | apiKey | <code>string</code> |         | Optional. Credential thats setup within Kibana's UI. see [kibana API keys guide](https://www.elastic.co/guide/en/kibana/master/api-keys.html). |
 
-## Search Options
+## Query Configuration Requirements
 
-**Kind**: global typedef
-
-| Param       | Type                  | Default | Description                          |
-| ----------- | --------------------- | ------- | ------------------------------------ |
-| queryFields | <code>[string]</code> |         | String Array of fields to search on. |
+- `search_fields` object is required with all fields you want to search by.
 
 ## Connection & Authentication
 

--- a/packages/search-ui-elasticsearch-connector/src/handlers/autocomplete/__tests__/results.test.ts
+++ b/packages/search-ui-elasticsearch-connector/src/handlers/autocomplete/__tests__/results.test.ts
@@ -55,6 +55,11 @@ describe("Autocomplete results", () => {
     const queryConfig: AutocompleteQueryConfig = {
       results: {
         resultsPerPage: 5,
+        search_fields: {
+          title: {
+            weight: 2
+          }
+        },
         result_fields: {
           title: {
             snippet: {
@@ -75,8 +80,7 @@ describe("Autocomplete results", () => {
       index: "test",
       connectionOptions: {
         apiKey: "test"
-      },
-      queryFields: ["title", "description"]
+      }
     });
 
     expect(results).toMatchInlineSnapshot(`

--- a/packages/search-ui-elasticsearch-connector/src/handlers/autocomplete/index.ts
+++ b/packages/search-ui-elasticsearch-connector/src/handlers/autocomplete/index.ts
@@ -14,21 +14,17 @@ interface AutocompleteHandlerConfiguration {
   connectionOptions?: {
     apiKey: string;
   };
-  queryFields: string[];
 }
 
 export default async function handleRequest(
   configuration: AutocompleteHandlerConfiguration
 ): Promise<AutocompleteResponseState> {
-  const { state, queryConfig, host, index, connectionOptions, queryFields } =
-    configuration;
+  const { state, queryConfig, host, index, connectionOptions } = configuration;
   const { apiKey } = connectionOptions || {};
   const requests = [];
 
   if (queryConfig.results) {
-    requests.push(
-      resultsHandler(state, queryConfig, host, index, apiKey, queryFields)
-    );
+    requests.push(resultsHandler(state, queryConfig, host, index, apiKey));
   }
 
   if (queryConfig.suggestions && queryConfig.suggestions.types) {

--- a/packages/search-ui-elasticsearch-connector/src/handlers/autocomplete/results.ts
+++ b/packages/search-ui-elasticsearch-connector/src/handlers/autocomplete/results.ts
@@ -1,17 +1,20 @@
 import {
+  AutocompletedResult,
   AutocompleteQueryConfig,
   FieldConfiguration,
-  RequestState
+  RequestState,
+  ResponseState,
+  SearchFieldConfiguration
 } from "@elastic/search-ui";
 import Searchkit, { MultiMatchQuery, SearchkitConfig } from "@searchkit/sdk";
 import { fieldResponseMapper } from "../common";
-import { getResultFields } from "../search/Configuration";
+import { getResultFields, getQueryFields } from "../search/Configuration";
 
 interface ConfigurationOptions {
   host: string;
   index: string;
   apiKey?: string;
-  queryFields: string[];
+  searchFields: Record<string, SearchFieldConfiguration>;
   resultFields: Record<string, FieldConfiguration>;
 }
 
@@ -19,10 +22,11 @@ function buildConfiguration({
   host,
   index,
   apiKey,
-  queryFields,
+  searchFields,
   resultFields
 }: ConfigurationOptions): SearchkitConfig {
   const { hitFields, highlightFields } = getResultFields(resultFields);
+  const queryFields = getQueryFields(searchFields);
 
   const searchkitConfiguration: SearchkitConfig = {
     host: host,
@@ -46,14 +50,13 @@ export default async function handler(
   queryConfig: AutocompleteQueryConfig,
   host: string,
   index: string,
-  apiKey: string,
-  queryFields: string[]
-): Promise<any> {
+  apiKey: string
+): Promise<AutocompletedResult[]> {
   const searchkitConfiguration = buildConfiguration({
     host,
     index,
     apiKey,
-    queryFields,
+    searchFields: queryConfig.results.search_fields,
     resultFields: queryConfig.results.result_fields
   });
 

--- a/packages/search-ui-elasticsearch-connector/src/handlers/search/Configuration.ts
+++ b/packages/search-ui-elasticsearch-connector/src/handlers/search/Configuration.ts
@@ -40,11 +40,11 @@ export function getResultFields(
 export function getQueryFields(
   searchFields: Record<string, SearchFieldConfiguration> = {}
 ): string[] {
-  return Object.keys(searchFields).reduce((sum, fieldKey) => {
+  return Object.keys(searchFields).map((fieldKey) => {
     const fieldConfiguration = searchFields[fieldKey];
-    const weight = fieldConfiguration.weight || 1;
-    return [...sum, `${fieldKey}^${weight}`];
-  }, []);
+    const weight = `^${fieldConfiguration.weight || 1}`;
+    return fieldKey + weight;
+  });
 }
 
 function isValidDateString(dateString: unknown): boolean {

--- a/packages/search-ui-elasticsearch-connector/src/handlers/search/Configuration.ts
+++ b/packages/search-ui-elasticsearch-connector/src/handlers/search/Configuration.ts
@@ -1,7 +1,8 @@
 import {
   FieldConfiguration,
   QueryConfig,
-  RequestState
+  RequestState,
+  SearchFieldConfiguration
 } from "@elastic/search-ui";
 import {
   GeoDistanceOptionsFacet,
@@ -36,6 +37,16 @@ export function getResultFields(
   return { hitFields, highlightFields };
 }
 
+export function getQueryFields(
+  searchFields: Record<string, SearchFieldConfiguration>
+): string[] {
+  return Object.keys(searchFields).reduce((sum, fieldKey) => {
+    const fieldConfiguration = searchFields[fieldKey];
+    const weight = fieldConfiguration.weight || 1;
+    return [...sum, `${fieldKey}^${weight}`];
+  }, []);
+}
+
 function isValidDateString(dateString: unknown): boolean {
   return typeof dateString === "string" && !isNaN(Date.parse(dateString));
 }
@@ -45,12 +56,13 @@ function buildConfiguration(
   queryConfig: QueryConfig,
   host: string,
   index: string,
-  apiKey: string,
-  queryFields: string[]
+  apiKey: string
 ): SearchkitConfig {
   const { hitFields, highlightFields } = getResultFields(
     queryConfig.result_fields
   );
+
+  const queryFields = getQueryFields(queryConfig.search_fields);
 
   const facets = Object.keys(queryConfig.facets || {}).reduce(
     (sum, facetKey) => {

--- a/packages/search-ui-elasticsearch-connector/src/handlers/search/Configuration.ts
+++ b/packages/search-ui-elasticsearch-connector/src/handlers/search/Configuration.ts
@@ -38,7 +38,7 @@ export function getResultFields(
 }
 
 export function getQueryFields(
-  searchFields: Record<string, SearchFieldConfiguration>
+  searchFields: Record<string, SearchFieldConfiguration> = {}
 ): string[] {
   return Object.keys(searchFields).reduce((sum, fieldKey) => {
     const fieldConfiguration = searchFields[fieldKey];

--- a/packages/search-ui-elasticsearch-connector/src/handlers/search/__tests__/Configuration.test.ts
+++ b/packages/search-ui-elasticsearch-connector/src/handlers/search/__tests__/Configuration.test.ts
@@ -46,6 +46,12 @@ describe("Search - Configuration", () => {
 
   describe("buildConfiguration", () => {
     const queryConfig: QueryConfig = {
+      search_fields: {
+        title: {
+          weight: 2
+        },
+        description: {}
+      },
       result_fields: {
         title: {
           raw: {},
@@ -74,7 +80,6 @@ describe("Search - Configuration", () => {
     const host = "http://localhost:9200";
     const index = "test_index";
     const apiKey = "apiKey";
-    const queryFields = ["title", "description"];
 
     it("builds configuration", () => {
       const state: RequestState = {
@@ -82,7 +87,7 @@ describe("Search - Configuration", () => {
       };
 
       expect(
-        buildConfiguration(state, queryConfig, host, index, apiKey, queryFields)
+        buildConfiguration(state, queryConfig, host, index, apiKey)
       ).toEqual(
         expect.objectContaining({
           host: "http://localhost:9200",
@@ -98,7 +103,7 @@ describe("Search - Configuration", () => {
       );
 
       expect(MultiMatchQuery).toHaveBeenCalledWith({
-        fields: ["title", "description"]
+        fields: ["title^2", "description^1"]
       });
 
       expect(RefinementSelectFacet).toHaveBeenCalledTimes(2);
@@ -131,8 +136,7 @@ describe("Search - Configuration", () => {
           { ...queryConfig, facets: null },
           host,
           index,
-          apiKey,
-          queryFields
+          apiKey
         )
       ).toEqual(
         expect.objectContaining({
@@ -149,7 +153,7 @@ describe("Search - Configuration", () => {
       );
 
       expect(MultiMatchQuery).toHaveBeenCalledWith({
-        fields: ["title", "description"]
+        fields: ["title^2", "description^1"]
       });
 
       expect(RefinementSelectFacet).toHaveBeenCalledTimes(2);
@@ -227,8 +231,7 @@ describe("Search - Configuration", () => {
           },
           host,
           index,
-          apiKey,
-          queryFields
+          apiKey
         )
       ).toEqual(
         expect.objectContaining({

--- a/packages/search-ui-elasticsearch-connector/src/handlers/search/__tests__/index.test.ts
+++ b/packages/search-ui-elasticsearch-connector/src/handlers/search/__tests__/index.test.ts
@@ -98,8 +98,7 @@ describe("Search results", () => {
       index: "test",
       connectionOptions: {
         apiKey: "test"
-      },
-      queryFields: ["title", "description"]
+      }
     });
 
     expect(results).toMatchInlineSnapshot(`

--- a/packages/search-ui-elasticsearch-connector/src/handlers/search/index.ts
+++ b/packages/search-ui-elasticsearch-connector/src/handlers/search/index.ts
@@ -12,22 +12,19 @@ interface SearchHandlerConfiguration {
   connectionOptions?: {
     apiKey: string;
   };
-  queryFields: string[];
 }
 
 export default async function handleRequest(
   configuration: SearchHandlerConfiguration
 ): Promise<ResponseState> {
-  const { state, queryConfig, host, index, connectionOptions, queryFields } =
-    configuration;
+  const { state, queryConfig, host, index, connectionOptions } = configuration;
   const { apiKey } = connectionOptions || {};
   const searchkitConfig = buildConfiguration(
     state,
     queryConfig,
     host,
     index,
-    apiKey,
-    queryFields
+    apiKey
   );
   const request = Searchkit(searchkitConfig);
 

--- a/packages/search-ui-elasticsearch-connector/src/index.ts
+++ b/packages/search-ui-elasticsearch-connector/src/index.ts
@@ -16,15 +16,8 @@ type ConnectionOptions = {
   apiKey?: string;
 };
 
-type SearchConfiguration = {
-  queryFields: string[];
-};
-
 class ElasticsearchAPIConnector implements APIConnector {
-  constructor(
-    private config: ConnectionOptions,
-    private searchConfig: SearchConfiguration
-  ) {}
+  constructor(private config: ConnectionOptions) {}
 
   onResultClick(): void {
     console.error("not implemented");
@@ -45,8 +38,7 @@ class ElasticsearchAPIConnector implements APIConnector {
       index: this.config.index,
       connectionOptions: {
         apiKey: this.config.apiKey
-      },
-      queryFields: this.searchConfig.queryFields
+      }
     });
   }
 
@@ -61,8 +53,7 @@ class ElasticsearchAPIConnector implements APIConnector {
       index: this.config.index,
       connectionOptions: {
         apiKey: this.config.apiKey
-      },
-      queryFields: this.searchConfig.queryFields
+      }
     });
   }
 }

--- a/packages/search-ui/src/types/index.ts
+++ b/packages/search-ui/src/types/index.ts
@@ -87,6 +87,10 @@ export type ResponseState = {
   rawResponse: any;
 };
 
+export type SearchFieldConfiguration = {
+  weight?: number;
+};
+
 export type FieldConfiguration = {
   snippet?: {
     size?: number;
@@ -124,7 +128,7 @@ export type SearchQuery = {
   disjunctiveFacets?: string[];
   disjunctiveFacetsAnalyticsTags?: string[];
   result_fields?: Record<string, FieldConfiguration>;
-  search_fields?: Record<string, FieldConfiguration>;
+  search_fields?: Record<string, SearchFieldConfiguration>;
 } & RequestState;
 
 export type AutocompleteSearchQuery = {


### PR DESCRIPTION
Search Fields were explicitly specified via the connectors constructor options. With this change, it now uses Search UI's configuration of search_fields.