### PR TITLE
Fix Typescript type definition of `onSearchHook`, `onAutocompleteHook`

### DIFF
--- a/packages/search-ui/src/SearchDriver.ts
+++ b/packages/search-ui/src/SearchDriver.ts
@@ -103,7 +103,7 @@ export type onSearchHook = (
 export type onAutocompleteHook = (
   query: AutocompleteSearchQuery,
   queryConfig: QueryConfig,
-  next: () => Promise<AutocompleteResponseState>
+  next: (state: RequestState, queryConfig: QueryConfig) => Promise<ResponseState>
 ) => Promise<AutocompleteResponseState>;
 
 export type onResultClickHook = (resultParams: any) => void;

--- a/packages/search-ui/src/SearchDriver.ts
+++ b/packages/search-ui/src/SearchDriver.ts
@@ -97,7 +97,7 @@ function removeConditionalFacets(
 export type onSearchHook = (
   query: RequestState,
   queryConfig: QueryConfig,
-  next: () => Promise<ResponseState>
+  next: (state: RequestState, queryConfig: QueryConfig) => Promise<ResponseState>
 ) => Promise<ResponseState>;
 
 export type onAutocompleteHook = (

--- a/packages/search-ui/src/SearchDriver.ts
+++ b/packages/search-ui/src/SearchDriver.ts
@@ -97,13 +97,19 @@ function removeConditionalFacets(
 export type onSearchHook = (
   query: RequestState,
   queryConfig: QueryConfig,
-  next: (state: RequestState, queryConfig: QueryConfig) => Promise<ResponseState>
+  next: (
+    state: RequestState,
+    queryConfig: QueryConfig
+  ) => Promise<ResponseState>
 ) => Promise<ResponseState>;
 
 export type onAutocompleteHook = (
   query: AutocompleteSearchQuery,
   queryConfig: QueryConfig,
-  next: (state: RequestState, queryConfig: QueryConfig) => Promise<ResponseState>
+  next: (
+    state: RequestState,
+    queryConfig: QueryConfig
+  ) => Promise<AutocompleteResponseState>
 ) => Promise<AutocompleteResponseState>;
 
 export type onResultClickHook = (resultParams: any) => void;

--- a/packages/search-ui/src/__tests__/SearchDriver.test.ts
+++ b/packages/search-ui/src/__tests__/SearchDriver.test.ts
@@ -799,7 +799,7 @@ describe("Request sequencing", () => {
             expect(searchConfig).toBeDefined();
             expect(searchConfig.facets).toEqual({});
             expect(typeof next).toBe("function");
-            const x = await next();
+            const x = await next(query, searchConfig);
             return x;
           }
         );
@@ -825,7 +825,7 @@ describe("Request sequencing", () => {
             expect(searchConfig).toBeDefined();
             expect(searchConfig.results).toEqual({});
             expect(typeof next).toBe("function");
-            return next();
+            return next(query, searchConfig);
           }
         );
       const mockApiConnector = getMockApiConnector();


### PR DESCRIPTION
## Description
The type definition is wrong. As `next()` will not work without the required params.

## List of changes
Add required params to Typescript type definition of `onSearchHook`, `onAutocompleteHook`.

Related #689, @joemcelroy

## Associated Github Issues
