### PR TITLE
Fix: Fixed auto complete not working due to missing raw hit

### DIFF
--- a/packages/search-ui-elasticsearch-connector/src/handlers/autocomplete/results.ts
+++ b/packages/search-ui-elasticsearch-connector/src/handlers/autocomplete/results.ts
@@ -39,7 +39,8 @@ function buildConfiguration({
     }),
     hits: {
       fields: hitFields,
-      highlightedFields: highlightFields
+      highlightedFields: highlightFields,
+      includeRawHit: true
     }
   };
   return searchkitConfiguration;


### PR DESCRIPTION

## Description
This fixes the autocomplete feature broken by #715 , Autocomplete query doesn't include raw hit which broke it. 

## List of changes
Change to include Rawhit in autocomplete response of elastic search connector,

## Associated Github Issues
#704 