### PR TITLE
Use codesandbox demos instead of netlify

### DIFF
--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -20,11 +20,7 @@ We will create branches for all minor releases.
 1. Create a release in Github.
 1. Close the release Milestone in Github.
 1. If this is the latest release, update the `stable` branch to this version `git checkout stable && git merge --ff-only master && git push origin`.
-1. Verify the demos on Netlify are functioning:
-
-   https://search-ui-stable-elasticsearch.netlify.app/
-   https://search-ui-stable-site-search.netlify.app/
-   https://search-ui-stable.netlify.app/
+1. Verify the demo on Codesandbox is functioning: https://codesandbox.io/s/github/elastic/search-ui/tree/stable/examples/sandbox
 
 ## Publish a patch
 
@@ -41,11 +37,7 @@ We will create branches for all minor releases.
 1. Create a release in Github.
 1. Close the release Milestone in Github.
 1. If this is the latest release, update the `stable` branch to this version `git checkout stable && git merge --ff-only master && git push origin`.
-1. Verify the demos on Netlify are functioning:
-
-   https://search-ui-stable-elasticsearch.netlify.app/
-   https://search-ui-stable-site-search.netlify.app/
-   https://search-ui-stable.netlify.app/
+1. Verify the demo on Codesandbox is functioning: https://codesandbox.io/s/github/elastic/search-ui/tree/stable/examples/sandbox
 
 ## Canary releases for testing
 
@@ -60,7 +52,7 @@ option for this.
    npm install --save @elastic/react-search-ui@canary @elastic/search-ui-app-search-connector@canary @elastic/react-search-ui-views@canary search-ui-views@canary
    ```
 
-1. To Deploy, simply push your changes to the `canary` branch, then visit "https://search-ui-canary.netlify.com/"
+1. To check your changes, simply push them to the `canary` branch, then visit https://codesandbox.io/s/github/elastic/search-ui/tree/canary/examples/sandbox
 
 ## Release candidates
 
@@ -82,8 +74,6 @@ stacks:
 - https://codesandbox.io/s/search-ui-next-js-example-tb05u
 - https://codesandbox.io/s/search-ui-national-parks-example-kdyms
 
-## Stable demos
+## Stable demo
 
-- Elastic App Search: https://search-ui-stable.netlify.com/
-- Elastic Site Search: https://search-ui-stable-site-search.netlify.com/
-- Elasticsearch: https://search-ui-stable-elasticsearch.netlify.com/
+- https://codesandbox.io/s/github/elastic/search-ui/tree/stable/examples/sandbox

--- a/docs/overview.mdx
+++ b/docs/overview.mdx
@@ -24,9 +24,17 @@ Use it with [Elastic](https://www.elastic.co/) to have a search experience up an
 
 ### Live Demo
 
-Check out the [live demo of Search UI](https://search-ui-stable.netlify.com).
-
-[![Edit search-ui-national-parks-example](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/search-ui-national-parks-example-ts-k6u5iz)
+<iframe
+  src="https://codesandbox.io/embed/github/elastic/search-ui/tree/master/examples/sandbox?autoresize=1&fontsize=12&initialpath=%2Felasticsearch&module=%2Fsrc%2Fpages%2Felasticsearch%2Findex.js&theme=light&view=preview&hidedevtools=1"
+  style={{
+    width: "100%",
+    height: "800px",
+    overflow: "hidden"
+  }}
+  title="Search UI"
+  allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
+  sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
+></iframe>
 
 ## FAQ 🔮
 

--- a/docs/overview.mdx
+++ b/docs/overview.mdx
@@ -25,7 +25,7 @@ Use it with [Elastic](https://www.elastic.co/) to have a search experience up an
 ### Live Demo
 
 <iframe
-  src="https://codesandbox.io/embed/github/elastic/search-ui/tree/master/examples/sandbox?autoresize=1&fontsize=12&initialpath=%2Felasticsearch&module=%2Fsrc%2Fpages%2Felasticsearch%2Findex.js&theme=light&view=preview&hidedevtools=1"
+  src="https://codesandbox.io/embed/github/elastic/search-ui/tree/stable/examples/sandbox?autoresize=1&fontsize=12&initialpath=%2Felasticsearch&module=%2Fsrc%2Fpages%2Felasticsearch%2Findex.js&theme=light&view=preview&hidedevtools=1"
   style={{
     width: "100%",
     height: "800px",


### PR DESCRIPTION
This PR changes all our links to stable demos from Netlify to Codesandbox pointing at our GitHub repo.
Also updated the Overview page in docs to embed a live demo:


https://user-images.githubusercontent.com/11838280/166825932-2083380b-8f67-4af7-85f1-a602bf467d28.mp4


