### PR TITLE
Add search-as-you-type example 

### DIFF
--- a/docs/examples-search-as-you-type.mdx
+++ b/docs/examples-search-as-you-type.mdx
@@ -1,0 +1,34 @@
+---
+id: examples-search-as-you-type
+slug: /search-ui/examples/search-as-you-type
+title: Search-as-you-type
+date: 2022-05-05
+tags: ["search-as-you-type"]
+---
+
+Usually, the search query is executed when the user presses the enter key or clicks the search button.
+
+Search-as-you-type feature allows search queries to be executed on every keystroke.
+
+To implement this in Search UI, you'll need to add a `searchAsYouType={true}` prop to `<SearchBox/>` component.
+
+It's a good idea to add a debounce time — the Search UI will wait for users to finish typing before issuing the request. You can do it by adding a `debounceLength={300}` prop to `<SearchBox/>` component.
+
+See the example implementation below.
+
+<iframe
+  src="https://codesandbox.io/embed/github/elastic/search-ui/tree/stable/examples/sandbox?autoresize=1&fontsize=12&initialpath=%2Fsearch-as-you-type&module=%2Fsrc%2Fpages%2Fsearch-as-you-type%2Findex.js&theme=light&view=preview&hidedevtools=1"
+  style={{
+    width: "100%",
+    height: "800px",
+    overflow: "hidden"
+  }}
+  highlights="218,219,220"
+  title="Search UI"
+  allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
+  sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
+></iframe>
+
+Related documentation:
+
+- <DocLink id="api-react-components-search-box" text="SearchBox component" />

--- a/docs/nav-searchui.docnav.json
+++ b/docs/nav-searchui.docnav.json
@@ -32,6 +32,15 @@
       ]
     },
     {
+      "label": "Examples",
+      "items": [
+        {
+          "id": "examples-search-as-you-type",
+          "label": "Search-as-you-type"
+        }
+      ]
+    },
+    {
       "label": "API",
       "items": [
         { "id": "api-configuration" },

--- a/examples/sandbox/src/Router.js
+++ b/examples/sandbox/src/Router.js
@@ -5,6 +5,7 @@ import Elasticsearch from "./pages/elasticsearch";
 import AppSearch from "./pages/app-search";
 import SiteSearch from "./pages/site-search";
 import WorkplaceSearch from "./pages/workplace-search";
+import SearchAsYouType from "./pages/search-as-you-type";
 
 export default function Router() {
   return (
@@ -24,6 +25,9 @@ export default function Router() {
         </Route>
         <Route exact path="/workplace-search">
           <WorkplaceSearch />
+        </Route>
+        <Route exact path="/search-as-you-type">
+          <SearchAsYouType />
         </Route>
       </Switch>
     </div>

--- a/examples/sandbox/src/pages/root.js
+++ b/examples/sandbox/src/pages/root.js
@@ -19,6 +19,13 @@ export default function Root() {
           <Link to="/workplace-search">Elastic Workplace Search</Link>
         </li>
       </ul>
+
+      <p>Or check out our examples:</p>
+      <ul>
+        <li>
+          <Link to="/search-as-you-type">Search-as-you-type</Link>
+        </li>
+      </ul>
     </>
   );
 }

--- a/examples/sandbox/src/pages/search-as-you-type/index.js
+++ b/examples/sandbox/src/pages/search-as-you-type/index.js
@@ -1,0 +1,292 @@
+import React from "react";
+import "@elastic/eui/dist/eui_theme_light.css";
+
+import AppSearchAPIConnector from "@elastic/search-ui-app-search-connector";
+
+import moment from "moment";
+
+import {
+  ErrorBoundary,
+  Facet,
+  SearchProvider,
+  SearchBox,
+  Results,
+  PagingInfo,
+  ResultsPerPage,
+  Paging,
+  Sorting,
+  WithSearch
+} from "@elastic/react-search-ui";
+import {
+  BooleanFacet,
+  Layout,
+  SingleLinksFacet,
+  SingleSelectFacet
+} from "@elastic/react-search-ui-views";
+import "@elastic/react-search-ui-views/lib/styles/styles.css";
+
+const connector = new AppSearchAPIConnector({
+  searchKey:
+    process.env.REACT_APP_SEARCH_KEY || "search-nyxkw1fuqex9qjhfvatbqfmw",
+  engineName: process.env.REACT_APP_SEARCH_ENGINE_NAME || "national-parks",
+  endpointBase:
+    process.env.REACT_APP_SEARCH_ENDPOINT_BASE ||
+    "https://search-ui-sandbox.ent.us-central1.gcp.cloud.es.io"
+});
+
+const config = {
+  debug: true,
+  alwaysSearchOnInitialLoad: true,
+  apiConnector: connector,
+  hasA11yNotifications: true,
+  searchQuery: {
+    result_fields: {
+      visitors: { raw: {} },
+      world_heritage_site: { raw: {} },
+      location: { raw: {} },
+      acres: { raw: {} },
+      square_km: { raw: {} },
+      title: {
+        snippet: {
+          size: 100,
+          fallback: true
+        }
+      },
+      nps_link: { raw: {} },
+      states: { raw: {} },
+      date_established: { raw: {} },
+      image_url: { raw: {} },
+      description: {
+        snippet: {
+          size: 100,
+          fallback: true
+        }
+      }
+    },
+    disjunctiveFacets: ["acres", "states", "date_established", "location"],
+    facets: {
+      world_heritage_site: { type: "value" },
+      states: { type: "value", size: 30 },
+      acres: {
+        type: "range",
+        ranges: [
+          { from: -1, name: "Any" },
+          { from: 0, to: 1000, name: "Small" },
+          { from: 1001, to: 100000, name: "Medium" },
+          { from: 100001, name: "Large" }
+        ]
+      },
+      location: {
+        // San Francisco. In the future, make this the user's current position
+        center: "37.7749, -122.4194",
+        type: "range",
+        unit: "mi",
+        ranges: [
+          { from: 0, to: 100, name: "Nearby" },
+          { from: 100, to: 500, name: "A longer drive" },
+          { from: 500, name: "Perhaps fly?" }
+        ]
+      },
+      date_established: {
+        type: "range",
+        ranges: [
+          {
+            from: moment().subtract(50, "years").toISOString(),
+            name: "Within the last 50 years"
+          },
+          {
+            from: moment().subtract(100, "years").toISOString(),
+            to: moment().subtract(50, "years").toISOString(),
+            name: "50 - 100 years ago"
+          },
+          {
+            to: moment().subtract(100, "years").toISOString(),
+            name: "More than 100 years ago"
+          }
+        ]
+      },
+      visitors: {
+        type: "range",
+        ranges: [
+          { from: 0, to: 10000, name: "0 - 10000" },
+          { from: 10001, to: 100000, name: "10001 - 100000" },
+          { from: 100001, to: 500000, name: "100001 - 500000" },
+          { from: 500001, to: 1000000, name: "500001 - 1000000" },
+          { from: 1000001, to: 5000000, name: "1000001 - 5000000" },
+          { from: 5000001, to: 10000000, name: "5000001 - 10000000" },
+          { from: 10000001, name: "10000001+" }
+        ]
+      }
+    }
+  },
+  autocompleteQuery: {
+    results: {
+      resultsPerPage: 5,
+      result_fields: {
+        title: {
+          snippet: {
+            size: 100,
+            fallback: true
+          }
+        },
+        nps_link: {
+          raw: {}
+        }
+      }
+    },
+    suggestions: {
+      types: {
+        documents: {
+          fields: ["title"]
+        }
+      },
+      size: 4
+    }
+  }
+};
+
+const SORT_OPTIONS = [
+  {
+    name: "Relevance",
+    value: []
+  },
+  {
+    name: "Title",
+    value: [
+      {
+        field: "title",
+        direction: "asc"
+      }
+    ]
+  },
+  {
+    name: "State",
+    value: [
+      {
+        field: "states",
+        direction: "asc"
+      }
+    ]
+  },
+  {
+    name: "State -> Title",
+    value: [
+      {
+        field: "states",
+        direction: "asc"
+      },
+      {
+        field: "title",
+        direction: "asc"
+      }
+    ]
+  },
+  {
+    name: "Heritage Site -> State -> Title",
+    value: [
+      {
+        field: "world_heritage_site",
+        direction: "asc"
+      },
+      {
+        field: "states",
+        direction: "asc"
+      },
+      {
+        field: "title",
+        direction: "asc"
+      }
+    ]
+  }
+];
+
+export default function App() {
+  return (
+    <SearchProvider config={config}>
+      <WithSearch
+        mapContextToProps={({ wasSearched }) => ({
+          wasSearched
+        })}
+      >
+        {({ wasSearched }) => {
+          return (
+            <div className="App">
+              <ErrorBoundary>
+                <Layout
+                  header={
+                    <SearchBox
+                      autocompleteMinimumCharacters={3}
+                      autocompleteResults={{
+                        linkTarget: "_blank",
+                        sectionTitle: "Results",
+                        titleField: "title",
+                        urlField: "nps_link",
+                        shouldTrackClickThrough: true,
+                        clickThroughTags: ["test"]
+                      }}
+                      autocompleteSuggestions={true}
+                      debounceLength={0}
+                    />
+                  }
+                  sideContent={
+                    <div>
+                      {wasSearched && (
+                        <Sorting label={"Sort by"} sortOptions={SORT_OPTIONS} />
+                      )}
+                      <Facet
+                        field={"states"}
+                        label="States"
+                        filterType="any"
+                        isFilterable={true}
+                      />
+                      <Facet
+                        field={"world_heritage_site"}
+                        label="World Heritage Site"
+                        view={BooleanFacet}
+                      />
+                      <Facet
+                        field="visitors"
+                        label="Visitors"
+                        view={SingleLinksFacet}
+                      />
+                      <Facet
+                        field="date_established"
+                        label="Date Established"
+                        filterType="any"
+                      />
+                      <Facet
+                        field="location"
+                        label="Distance"
+                        filterType="any"
+                      />
+                      <Facet
+                        field="acres"
+                        label="Acres"
+                        view={SingleSelectFacet}
+                      />
+                    </div>
+                  }
+                  bodyContent={
+                    <Results
+                      titleField="title"
+                      urlField="nps_link"
+                      thumbnailField="image_url"
+                      shouldTrackClickThrough={true}
+                    />
+                  }
+                  bodyHeader={
+                    <React.Fragment>
+                      {wasSearched && <PagingInfo />}
+                      {wasSearched && <ResultsPerPage />}
+                    </React.Fragment>
+                  }
+                  bodyFooter={<Paging />}
+                />
+              </ErrorBoundary>
+            </div>
+          );
+        }}
+      </WithSearch>
+    </SearchProvider>
+  );
+}

--- a/examples/sandbox/src/pages/search-as-you-type/index.js
+++ b/examples/sandbox/src/pages/search-as-you-type/index.js
@@ -215,17 +215,23 @@ export default function App() {
                 <Layout
                   header={
                     <SearchBox
-                      autocompleteMinimumCharacters={3}
-                      autocompleteResults={{
-                        linkTarget: "_blank",
-                        sectionTitle: "Results",
-                        titleField: "title",
-                        urlField: "nps_link",
-                        shouldTrackClickThrough: true,
-                        clickThroughTags: ["test"]
-                      }}
-                      autocompleteSuggestions={true}
-                      debounceLength={0}
+                      // 1. Remove the autocomplete-related props
+                      // (to prevent autocomplete dropdown from covering the results
+
+                      //   autocompleteMinimumCharacters={3}
+                      //   autocompleteResults={{
+                      //     linkTarget: "_blank",
+                      //     sectionTitle: "Results",
+                      //     titleField: "title",
+                      //     urlField: "nps_link",
+                      //     shouldTrackClickThrough: true,
+                      //     clickThroughTags: ["test"]
+                      //   }}
+                      //   autocompleteSuggestions={true}
+
+                      // 2. Set debounceLength and searchAsYouType props
+                      debounceLength={500}
+                      searchAsYouType={true}
                     />
                   }
                   sideContent={

--- a/examples/sandbox/src/pages/search-as-you-type/index.js
+++ b/examples/sandbox/src/pages/search-as-you-type/index.js
@@ -215,22 +215,8 @@ export default function App() {
                 <Layout
                   header={
                     <SearchBox
-                      // 1. Remove the autocomplete-related props
-                      // (to prevent autocomplete dropdown from covering the results
-
-                      //   autocompleteMinimumCharacters={3}
-                      //   autocompleteResults={{
-                      //     linkTarget: "_blank",
-                      //     sectionTitle: "Results",
-                      //     titleField: "title",
-                      //     urlField: "nps_link",
-                      //     shouldTrackClickThrough: true,
-                      //     clickThroughTags: ["test"]
-                      //   }}
-                      //   autocompleteSuggestions={true}
-
-                      // 2. Set debounceLength and searchAsYouType props
-                      debounceLength={500}
+                      // Set debounceLength and searchAsYouType props
+                      debounceLength={300}
                       searchAsYouType={true}
                     />
                   }


### PR DESCRIPTION
This PR adds a new example page to sandbox and docs.

New sandbox page:

https://user-images.githubusercontent.com/11838280/167008950-5561d532-a495-45bb-ac57-8a9ea474db8c.mp4

New docs page (the embed is not working yet since the code is still in PR):
![image](https://user-images.githubusercontent.com/11838280/167009373-2d817b6d-6e5e-4cd5-94ab-4df9c310597a.png)

I put the new section below the tutorials since users need to go through a tutorial first and then follow the examples.