### PR TITLE
Example customizing styles and html

### DIFF
--- a/docs/examples-search-as-you-type.mdx
+++ b/docs/examples-search-as-you-type.mdx
@@ -17,7 +17,7 @@ It's a good idea to add a debounce time — the Search UI will wait for users to
 See the example implementation below.
 
 <iframe
-  src="https://codesandbox.io/embed/github/elastic/search-ui/tree/stable/examples/sandbox?autoresize=1&fontsize=12&initialpath=%2Fsearch-as-you-type&module=%2Fsrc%2Fpages%2Fsearch-as-you-type%2Findex.js&theme=light&view=preview&hidedevtools=1"
+  src="https://codesandbox.io/embed/github/elastic/search-ui/tree/master/examples/sandbox?autoresize=1&fontsize=12&initialpath=%2Fsearch-as-you-type&module=%2Fsrc%2Fpages%2Fsearch-as-you-type%2Findex.js&theme=light&view=preview&hidedevtools=1"
   style={{
     width: "100%",
     height: "800px",

--- a/docs/guides-customizing-styles-and-html.mdx
+++ b/docs/guides-customizing-styles-and-html.mdx
@@ -6,7 +6,21 @@ date: 2022-02-27
 tags: ["demo"]
 ---
 
-For a live example of the customizations made below, [check out this project on CodeSandbox](https://codesandbox.io/s/search-ui-customize-html-and-styles-demo-30v93e).
+In this guide we'll customize some styles of the Search UI, modify the default HTML of one of the Search UI components, and also create a completely new Result component.
+
+Check out the live example below to see all the code in action.
+
+<iframe
+  src="https://codesandbox.io/embed/github/elastic/search-ui/tree/master/examples/sandbox?autoresize=1&fontsize=12&initialpath=%2Fcustomizing-styles-and-html&module=%2Fsrc%2Fpages%2Fcustomizing-styles-and-html%2Findex.js&theme=light&view=preview&hidedevtools=1"
+  style={{
+    width: "100%",
+    height: "800px",
+    overflow: "hidden"
+  }}
+  title="Search UI"
+  allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
+  sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
+></iframe>
 
 ## Customizing styles
 

--- a/examples/sandbox/src/Router.js
+++ b/examples/sandbox/src/Router.js
@@ -6,6 +6,7 @@ import AppSearch from "./pages/app-search";
 import SiteSearch from "./pages/site-search";
 import WorkplaceSearch from "./pages/workplace-search";
 import SearchAsYouType from "./pages/search-as-you-type";
+import CustomizingStylesAndHtml from "./pages/customizing-styles-and-html";
 
 export default function Router() {
   return (
@@ -28,6 +29,9 @@ export default function Router() {
         </Route>
         <Route exact path="/search-as-you-type">
           <SearchAsYouType />
+        </Route>
+        <Route exact path="/customizing-styles-and-html">
+          <CustomizingStylesAndHtml />
         </Route>
       </Switch>
     </div>

--- a/examples/sandbox/src/pages/customizing-styles-and-html/ClearFilters.js
+++ b/examples/sandbox/src/pages/customizing-styles-and-html/ClearFilters.js
@@ -1,0 +1,16 @@
+import { withSearch } from "@elastic/react-search-ui";
+
+function ClearFilters({ filters, clearFilters }) {
+  return (
+    <div>
+      <button onClick={() => clearFilters()}>
+        Clear {filters.length} Filters
+      </button>
+    </div>
+  );
+}
+
+export default withSearch(({ filters, clearFilters }) => ({
+  filters,
+  clearFilters
+}))(ClearFilters);

--- a/examples/sandbox/src/pages/customizing-styles-and-html/custom.css
+++ b/examples/sandbox/src/pages/customizing-styles-and-html/custom.css
@@ -1,0 +1,19 @@
+/* We selectedivly override base styles to create a red theme */
+.sui-search-box__submit {
+  background: none;
+  background-color: red;
+}
+
+.sui-layout-sidebar-toggle {
+  color: red;
+  border: 1px solid red;
+}
+
+.sui-result__title,
+.sui-result__title-link {
+  color: red;
+}
+
+.sui-facet-view-more {
+  color: red;
+}

--- a/examples/sandbox/src/pages/customizing-styles-and-html/index.js
+++ b/examples/sandbox/src/pages/customizing-styles-and-html/index.js
@@ -1,0 +1,325 @@
+import moment from "moment";
+
+import AppSearchAPIConnector from "@elastic/search-ui-app-search-connector";
+
+import {
+  ErrorBoundary,
+  Facet,
+  SearchProvider,
+  SearchBox,
+  Results,
+  PagingInfo,
+  ResultsPerPage,
+  Paging,
+  Sorting,
+  WithSearch
+} from "@elastic/react-search-ui";
+import {
+  BooleanFacet,
+  Layout,
+  SingleSelectFacet,
+  SingleLinksFacet
+} from "@elastic/react-search-ui-views";
+import "@elastic/react-search-ui-views/lib/styles/styles.css";
+// We import custom.css here to override styles defined by the out-ofthe-box stylesheet
+// avove
+import "./custom.css";
+
+// This is a custom component we've created.
+import ClearFilters from "./ClearFilters";
+
+const SORT_OPTIONS = [
+  {
+    name: "Relevance",
+    value: []
+  },
+  {
+    name: "Title",
+    value: [
+      {
+        field: "title",
+        direction: "asc"
+      }
+    ]
+  },
+  {
+    name: "State",
+    value: [
+      {
+        field: "states",
+        direction: "asc"
+      }
+    ]
+  },
+  {
+    name: "State -> Title",
+    value: [
+      {
+        field: "states",
+        direction: "asc"
+      },
+      {
+        field: "title",
+        direction: "asc"
+      }
+    ]
+  },
+  {
+    name: "Heritage Site -> State -> Title",
+    value: [
+      {
+        field: "world_heritage_site",
+        direction: "asc"
+      },
+      {
+        field: "states",
+        direction: "asc"
+      },
+      {
+        field: "title",
+        direction: "asc"
+      }
+    ]
+  }
+];
+
+const connector = new AppSearchAPIConnector({
+  searchKey: "search-371auk61r2bwqtdzocdgutmg",
+  engineName: "search-ui-examples",
+  hostIdentifier: "host-2376rb"
+});
+
+const config = {
+  alwaysSearchOnInitialLoad: true,
+  searchQuery: {
+    result_fields: {
+      visitors: { raw: {} },
+      world_heritage_site: { raw: {} },
+      location: { raw: {} },
+      acres: { raw: {} },
+      square_km: { raw: {} },
+      title: {
+        snippet: {
+          size: 100,
+          fallback: true
+        }
+      },
+      nps_link: { raw: {} },
+      states: { raw: {} },
+      date_established: { raw: {} },
+      image_url: { raw: {} },
+      description: {
+        snippet: {
+          size: 100,
+          fallback: true
+        }
+      }
+    },
+    disjunctiveFacets: ["acres", "states", "date_established", "location"],
+    facets: {
+      world_heritage_site: { type: "value" },
+      states: { type: "value", size: 30 },
+      acres: {
+        type: "range",
+        ranges: [
+          { from: -1, name: "Any" },
+          { from: 0, to: 1000, name: "Small" },
+          { from: 1001, to: 100000, name: "Medium" },
+          { from: 100001, name: "Large" }
+        ]
+      },
+      location: {
+        // San Francisco. In the future, make this the user's current position
+        center: "37.7749, -122.4194",
+        type: "range",
+        unit: "mi",
+        ranges: [
+          { from: 0, to: 100, name: "Nearby" },
+          { from: 100, to: 500, name: "A longer drive" },
+          { from: 500, name: "Perhaps fly?" }
+        ]
+      },
+      date_established: {
+        type: "range",
+
+        ranges: [
+          {
+            from: moment().subtract(50, "years").toISOString(),
+            name: "Within the last 50 years"
+          },
+          {
+            from: moment().subtract(100, "years").toISOString(),
+            to: moment().subtract(50, "years").toISOString(),
+            name: "50 - 100 years ago"
+          },
+          {
+            to: moment().subtract(100, "years").toISOString(),
+            name: "More than 100 years ago"
+          }
+        ]
+      },
+      visitors: {
+        type: "range",
+        ranges: [
+          { from: 0, to: 10000, name: "0 - 10000" },
+          { from: 10001, to: 100000, name: "10001 - 100000" },
+          { from: 100001, to: 500000, name: "100001 - 500000" },
+          { from: 500001, to: 1000000, name: "500001 - 1000000" },
+          { from: 1000001, to: 5000000, name: "1000001 - 5000000" },
+          { from: 5000001, to: 10000000, name: "5000001 - 10000000" },
+          { from: 10000001, name: "10000001+" }
+        ]
+      }
+    }
+  },
+  autocompleteQuery: {
+    results: {
+      resultsPerPage: 5,
+      result_fields: {
+        title: {
+          snippet: {
+            size: 100,
+            fallback: true
+          }
+        },
+        nps_link: {
+          raw: {}
+        }
+      }
+    },
+    suggestions: {
+      types: {
+        documents: {
+          fields: ["title", "description"]
+        }
+      },
+      size: 4
+    }
+  },
+  apiConnector: connector
+};
+
+const CustomPagingInfoView = ({ start, end }) => (
+  <div className="paging-info">
+    <strong>
+      {start} - {end}
+    </strong>
+  </div>
+);
+
+const CustomResultView = ({ result, onClickLink }) => (
+  <li className="sui-result">
+    <div className="sui-result__header">
+      <h3>
+        {/* Maintain onClickLink to correct track click throughs for analytics*/}
+        <a onClick={onClickLink} href={result.nps_link.raw}>
+          {result.title.snippet}
+        </a>
+      </h3>
+    </div>
+    <div className="sui-result__body">
+      {/* use 'raw' values of fields to access values without snippets */}
+      <div className="sui-result__image">
+        <img src={result.image_url.raw} alt="" />
+      </div>
+      {/* Use the 'snippet' property of fields with dangerouslySetInnerHtml to render snippets */}
+      <div
+        className="sui-result__details"
+        dangerouslySetInnerHTML={{ __html: result.description.snippet }}
+      ></div>
+    </div>
+  </li>
+);
+
+export default function App() {
+  return (
+    <SearchProvider config={config}>
+      <WithSearch mapContextToProps={({ wasSearched }) => ({ wasSearched })}>
+        {({ wasSearched }) => {
+          return (
+            <div className="App">
+              <ErrorBoundary>
+                <Layout
+                  header={
+                    <SearchBox
+                      autocompleteMinimumCharacters={3}
+                      autocompleteResults={{
+                        linkTarget: "_blank",
+                        sectionTitle: "Results",
+                        titleField: "title",
+                        urlField: "nps_link",
+                        shouldTrackClickThrough: true,
+                        clickThroughTags: ["test"]
+                      }}
+                      autocompleteSuggestions={true}
+                      debounceLength={0}
+                    />
+                  }
+                  sideContent={
+                    <div>
+                      <ClearFilters />
+                      <br />
+                      <br />
+                      {wasSearched && (
+                        <Sorting label={"Sort by"} sortOptions={SORT_OPTIONS} />
+                      )}
+                      <Facet
+                        field="states"
+                        label="States"
+                        filterType="any"
+                        isFilterable={true}
+                      />
+                      <Facet
+                        field="world_heritage_site"
+                        label="World Heritage Site?"
+                        view={BooleanFacet}
+                      />
+                      <Facet
+                        field="visitors"
+                        label="Visitors"
+                        view={SingleLinksFacet}
+                      />
+                      <Facet
+                        field="date_established"
+                        label="Date Established"
+                        filterType="any"
+                      />
+                      <Facet
+                        field="location"
+                        label="Distance"
+                        filterType="any"
+                      />
+                      <Facet
+                        field="acres"
+                        label="Acres"
+                        view={SingleSelectFacet}
+                      />
+                    </div>
+                  }
+                  bodyContent={
+                    <Results
+                      resultView={CustomResultView}
+                      titleField="title"
+                      urlField="nps_link"
+                      thumbnailField="image_url"
+                      shouldTrackClickThrough={true}
+                    />
+                  }
+                  bodyHeader={
+                    <>
+                      {wasSearched && (
+                        <PagingInfo view={CustomPagingInfoView} />
+                      )}
+                      {wasSearched && <ResultsPerPage />}
+                    </>
+                  }
+                  bodyFooter={<Paging />}
+                />
+              </ErrorBoundary>
+            </div>
+          );
+        }}
+      </WithSearch>
+    </SearchProvider>
+  );
+}

--- a/examples/sandbox/src/pages/root.js
+++ b/examples/sandbox/src/pages/root.js
@@ -25,6 +25,11 @@ export default function Root() {
         <li>
           <Link to="/search-as-you-type">Search-as-you-type</Link>
         </li>
+        <li>
+          <Link to="/customizing-styles-and-html">
+            Customizing styles and HTML
+          </Link>
+        </li>
       </ul>
     </>
   );


### PR DESCRIPTION
This PR adds a new example to sandbox. 
The example was copied from already existing codesandbox: https://codesandbox.io/s/search-ui-customize-html-and-styles-demo-30v93e?file=/src/App.tsx

https://user-images.githubusercontent.com/11838280/167201219-4b64adfa-9518-4a06-9df0-927effe3844d.mp4

In the docs, I decided to add it inline rather than creating a separate page for it. Having everything in one place seems more convenient to read.