### PR TITLE
sets record_analytics to false for results autocomplete

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -53,6 +53,22 @@
       "sourceMaps": true
     },
     {
+      "name": "Jest app-search-connector",
+      "type": "node",
+      "request": "launch",
+      "program": "${workspaceRoot}/node_modules/jest/bin/jest.js",
+      "stopOnEntry": false,
+      "args": ["--runInBand", "--forceExit", "--detectOpenHandles", "--watch"],
+      "cwd": "${workspaceRoot}/packages/search-ui-app-search-connector",
+      "preLaunchTask": null,
+      "runtimeExecutable": null,
+      "env": {
+        "NODE_ENV": "test"
+      },
+      "console": "integratedTerminal",
+      "sourceMaps": true
+    },
+    {
       "name": "Jest elasticsearch-connector",
       "type": "node",
       "request": "launch",

--- a/packages/search-ui-app-search-connector/src/AppSearchAPIConnector.ts
+++ b/packages/search-ui-app-search-connector/src/AppSearchAPIConnector.ts
@@ -215,12 +215,17 @@ class AppSearchAPIConnector implements APIConnector {
       const options = removeEmptyFacetsAndFilters(withQueryConfigOptions);
       promises.push(
         this.beforeAutocompleteResultsCall(options, (newOptions) => {
-          return this.client.search(query, newOptions).then((response) => {
-            autocompletedState.autocompletedResults =
-              adaptResponse(response).results;
-            autocompletedState.autocompletedResultsRequestId =
-              response.info.meta.request_id;
-          });
+          return this.client
+            .search(query, {
+              ...newOptions,
+              record_analytics: false
+            })
+            .then((response) => {
+              autocompletedState.autocompletedResults =
+                adaptResponse(response).results;
+              autocompletedState.autocompletedResultsRequestId =
+                response.info.meta.request_id;
+            });
         })
       );
     }

--- a/packages/search-ui-app-search-connector/src/__tests__/AppSearchAPIConnector.test.ts
+++ b/packages/search-ui-app-search-connector/src/__tests__/AppSearchAPIConnector.test.ts
@@ -483,7 +483,8 @@ describe("AppSearchAPIConnector", () => {
         const [passedSearchTerm, passedOptions] = getLastSearchCall();
         expect(passedSearchTerm).toEqual(state.searchTerm);
         expect(passedOptions).toEqual({
-          page: {}
+          page: {},
+          record_analytics: false
         });
       });
 
@@ -510,6 +511,7 @@ describe("AppSearchAPIConnector", () => {
         const [passedSearchTerm, passedOptions] = getLastSearchCall();
         expect(passedSearchTerm).toEqual(state.searchTerm);
         expect(passedOptions).toEqual({
+          record_analytics: false,
           page: {},
           result_fields: {
             title: { raw: {}, snippet: { size: 20, fallback: true } }
@@ -541,7 +543,8 @@ describe("AppSearchAPIConnector", () => {
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         const [passedSearchTerm, passedOptions] = getLastSearchCall();
         expect(passedOptions).toEqual({
-          page: {}
+          page: {},
+          record_analytics: false
         });
       });
 
@@ -582,6 +585,7 @@ describe("AppSearchAPIConnector", () => {
               }
             ]
           },
+          record_analytics: false,
           page: {
             current: 2,
             size: 5
@@ -693,6 +697,7 @@ describe("AppSearchAPIConnector", () => {
         expect(getLastSearchCall()).toEqual([
           state.searchTerm,
           {
+            record_analytics: false,
             page: {
               size: 5
             },


### PR DESCRIPTION
Draft PR, waiting on approval for https://github.com/elastic/app-search-javascript/pull/40 

This PR sets `record_analytics` to false for results autocomplete