### PR TITLE
Separate header example

### DIFF
--- a/examples/sandbox/src/Router.js
+++ b/examples/sandbox/src/Router.js
@@ -7,6 +7,7 @@ import SiteSearch from "./pages/site-search";
 import WorkplaceSearch from "./pages/workplace-search";
 import SearchAsYouType from "./pages/search-as-you-type";
 import CustomizingStylesAndHtml from "./pages/customizing-styles-and-html";
+import SearchBarInHeader from "./pages/search-bar-in-header";
 
 export default function Router() {
   return (
@@ -32,6 +33,9 @@ export default function Router() {
         </Route>
         <Route exact path="/customizing-styles-and-html">
           <CustomizingStylesAndHtml />
+        </Route>
+        <Route exact path="/search-bar-in-header">
+          <SearchBarInHeader />
         </Route>
       </Switch>
     </div>

--- a/examples/sandbox/src/pages/customizing-styles-and-html/index.js
+++ b/examples/sandbox/src/pages/customizing-styles-and-html/index.js
@@ -84,9 +84,12 @@ const SORT_OPTIONS = [
 ];
 
 const connector = new AppSearchAPIConnector({
-  searchKey: "search-371auk61r2bwqtdzocdgutmg",
-  engineName: "search-ui-examples",
-  hostIdentifier: "host-2376rb"
+  searchKey:
+    process.env.REACT_APP_SEARCH_KEY || "search-nyxkw1fuqex9qjhfvatbqfmw",
+  engineName: process.env.REACT_APP_SEARCH_ENGINE_NAME || "national-parks",
+  endpointBase:
+    process.env.REACT_APP_SEARCH_ENDPOINT_BASE ||
+    "https://search-ui-sandbox.ent.us-central1.gcp.cloud.es.io"
 });
 
 const config = {

--- a/examples/sandbox/src/pages/root.js
+++ b/examples/sandbox/src/pages/root.js
@@ -30,6 +30,9 @@ export default function Root() {
             Customizing styles and HTML
           </Link>
         </li>
+        <li>
+          <Link to="/search-bar-in-header">Search bar in header</Link>
+        </li>
       </ul>
     </>
   );

--- a/examples/sandbox/src/pages/search-bar-in-header/index.js
+++ b/examples/sandbox/src/pages/search-bar-in-header/index.js
@@ -208,7 +208,7 @@ export default function App() {
         >
           <SearchBox
             onSubmit={(searchTerm) => {
-              window.location.href = "https://ren2l.csb.app?q=" + searchTerm;
+              window.location.href = `${window.location.origin}${window.location.pathname}?q=${searchTerm}`;
             }}
           />
         </SearchProvider>

--- a/examples/sandbox/src/pages/search-bar-in-header/index.js
+++ b/examples/sandbox/src/pages/search-bar-in-header/index.js
@@ -1,0 +1,302 @@
+import React from "react";
+import moment from "moment";
+
+import AppSearchAPIConnector from "@elastic/search-ui-app-search-connector";
+
+import {
+  ErrorBoundary,
+  Facet,
+  SearchProvider,
+  SearchBox,
+  Results,
+  PagingInfo,
+  ResultsPerPage,
+  Paging,
+  Sorting,
+  WithSearch
+} from "@elastic/react-search-ui";
+import {
+  BooleanFacet,
+  Layout,
+  SingleSelectFacet,
+  SingleLinksFacet
+} from "@elastic/react-search-ui-views";
+import "@elastic/react-search-ui-views/lib/styles/styles.css";
+
+const SORT_OPTIONS = [
+  {
+    name: "Relevance",
+    value: []
+  },
+  {
+    name: "Title",
+    value: [
+      {
+        field: "title",
+        direction: "asc"
+      }
+    ]
+  },
+  {
+    name: "State",
+    value: [
+      {
+        field: "states",
+        direction: "asc"
+      }
+    ]
+  },
+  {
+    name: "State -> Title",
+    value: [
+      {
+        field: "states",
+        direction: "asc"
+      },
+      {
+        field: "title",
+        direction: "asc"
+      }
+    ]
+  },
+  {
+    name: "Heritage Site -> State -> Title",
+    value: [
+      {
+        field: "world_heritage_site",
+        direction: "asc"
+      },
+      {
+        field: "states",
+        direction: "asc"
+      },
+      {
+        field: "title",
+        direction: "asc"
+      }
+    ]
+  }
+];
+
+const connector = new AppSearchAPIConnector({
+  searchKey: "search-371auk61r2bwqtdzocdgutmg",
+  engineName: "search-ui-examples",
+  hostIdentifier: "host-2376rb",
+  endpointBase: ""
+});
+
+const config = {
+  alwaysSearchOnInitialLoad: true,
+  searchQuery: {
+    result_fields: {
+      visitors: { raw: {} },
+      world_heritage_site: { raw: {} },
+      location: { raw: {} },
+      acres: { raw: {} },
+      square_km: { raw: {} },
+      title: {
+        snippet: {
+          size: 100,
+          fallback: true
+        }
+      },
+      nps_link: { raw: {} },
+      states: { raw: {} },
+      date_established: { raw: {} },
+      image_url: { raw: {} },
+      description: {
+        snippet: {
+          size: 100,
+          fallback: true
+        }
+      }
+    },
+    disjunctiveFacets: ["acres", "states", "date_established", "location"],
+    facets: {
+      world_heritage_site: { type: "value" },
+      states: { type: "value", size: 30 },
+      acres: {
+        type: "range",
+        ranges: [
+          { from: -1, name: "Any" },
+          { from: 0, to: 1000, name: "Small" },
+          { from: 1001, to: 100000, name: "Medium" },
+          { from: 100001, name: "Large" }
+        ]
+      },
+      location: {
+        // San Francisco. In the future, make this the user's current position
+        center: "37.7749, -122.4194",
+        type: "range",
+        unit: "mi",
+        ranges: [
+          { from: 0, to: 100, name: "Nearby" },
+          { from: 100, to: 500, name: "A longer drive" },
+          { from: 500, name: "Perhaps fly?" }
+        ]
+      },
+      date_established: {
+        type: "range",
+
+        ranges: [
+          {
+            from: moment().subtract(50, "years").toISOString(),
+            name: "Within the last 50 years"
+          },
+          {
+            from: moment().subtract(100, "years").toISOString(),
+            to: moment().subtract(50, "years").toISOString(),
+            name: "50 - 100 years ago"
+          },
+          {
+            to: moment().subtract(100, "years").toISOString(),
+            name: "More than 100 years ago"
+          }
+        ]
+      },
+      visitors: {
+        type: "range",
+        ranges: [
+          { from: 0, to: 10000, name: "0 - 10000" },
+          { from: 10001, to: 100000, name: "10001 - 100000" },
+          { from: 100001, to: 500000, name: "100001 - 500000" },
+          { from: 500001, to: 1000000, name: "500001 - 1000000" },
+          { from: 1000001, to: 5000000, name: "1000001 - 5000000" },
+          { from: 5000001, to: 10000000, name: "5000001 - 10000000" },
+          { from: 10000001, name: "10000001+" }
+        ]
+      }
+    }
+  },
+  autocompleteQuery: {
+    results: {
+      resultsPerPage: 5,
+      result_fields: {
+        title: {
+          snippet: {
+            size: 100,
+            fallback: true
+          }
+        },
+        nps_link: {
+          raw: {}
+        }
+      }
+    },
+    suggestions: {
+      types: {
+        documents: {
+          fields: ["title", "description"]
+        }
+      },
+      size: 4
+    }
+  },
+  apiConnector: connector
+};
+
+export default function App() {
+  return (
+    <div>
+      <div style={{ height: "100px", border: "1px solid black" }}>
+        <SearchProvider
+          config={{
+            trackUrlState: false
+          }}
+        >
+          <SearchBox
+            onSubmit={(searchTerm) => {
+              window.location.href = "https://ren2l.csb.app?q=" + searchTerm;
+            }}
+          />
+        </SearchProvider>
+      </div>
+      <SearchProvider config={config}>
+        <WithSearch mapContextToProps={({ wasSearched }) => ({ wasSearched })}>
+          {({ wasSearched }) => {
+            return (
+              <div className="App">
+                <ErrorBoundary>
+                  <Layout
+                    header={
+                      <SearchBox
+                        autocompleteMinimumCharacters={3}
+                        //searchAsYouType={true}
+                        autocompleteResults={{
+                          linkTarget: "_blank",
+                          sectionTitle: "Results",
+                          titleField: "title",
+                          urlField: "nps_link",
+                          shouldTrackClickThrough: true,
+                          clickThroughTags: ["test"]
+                        }}
+                        autocompleteSuggestions={true}
+                        debounceLength={0}
+                      />
+                    }
+                    sideContent={
+                      <div>
+                        {wasSearched && (
+                          <Sorting
+                            label={"Sort by"}
+                            sortOptions={SORT_OPTIONS}
+                          />
+                        )}
+                        <Facet
+                          field="states"
+                          label="States"
+                          filterType="any"
+                          isFilterable={true}
+                        />
+                        <Facet
+                          field="world_heritage_site"
+                          label="World Heritage Site?"
+                          view={BooleanFacet}
+                        />
+                        <Facet
+                          field="visitors"
+                          label="Visitors"
+                          view={SingleLinksFacet}
+                        />
+                        <Facet
+                          field="date_established"
+                          label="Date Established"
+                          filterType="any"
+                        />
+                        <Facet
+                          field="location"
+                          label="Distance"
+                          filterType="any"
+                        />
+                        <Facet
+                          field="acres"
+                          label="Acres"
+                          view={SingleSelectFacet}
+                        />
+                      </div>
+                    }
+                    bodyContent={
+                      <Results
+                        titleField="title"
+                        urlField="nps_link"
+                        thumbnailField="image_url"
+                        shouldTrackClickThrough={true}
+                      />
+                    }
+                    bodyHeader={
+                      <React.Fragment>
+                        {wasSearched && <PagingInfo />}
+                        {wasSearched && <ResultsPerPage />}
+                      </React.Fragment>
+                    }
+                    bodyFooter={<Paging />}
+                  />
+                </ErrorBoundary>
+              </div>
+            );
+          }}
+        </WithSearch>
+      </SearchProvider>
+    </div>
+  );
+}

--- a/examples/sandbox/src/pages/search-bar-in-header/index.js
+++ b/examples/sandbox/src/pages/search-bar-in-header/index.js
@@ -79,10 +79,12 @@ const SORT_OPTIONS = [
 ];
 
 const connector = new AppSearchAPIConnector({
-  searchKey: "search-371auk61r2bwqtdzocdgutmg",
-  engineName: "search-ui-examples",
-  hostIdentifier: "host-2376rb",
-  endpointBase: ""
+  searchKey:
+    process.env.REACT_APP_SEARCH_KEY || "search-nyxkw1fuqex9qjhfvatbqfmw",
+  engineName: process.env.REACT_APP_SEARCH_ENGINE_NAME || "national-parks",
+  endpointBase:
+    process.env.REACT_APP_SEARCH_ENDPOINT_BASE ||
+    "https://search-ui-sandbox.ent.us-central1.gcp.cloud.es.io"
 });
 
 const config = {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "examples/*"
   ],
   "scripts": {
+    "start": "yarn --cwd examples/sandbox start",
     "test": "lerna run test --stream --no-private",
     "test-ci": "lerna run test-ci --stream --no-private",
     "watch": "lerna run watch --parallel",


### PR DESCRIPTION
This PR moves existing guide to our repo so we could use it in docs later:
https://codesandbox.io/s/search-ui-national-parks-example-with-seperate-global-nav-ren2l?file=/src/ResultView.js:0-2118