### PR TITLE
Add data-transaction-name to interactive elements

### DIFF
--- a/packages/react-search-ui-views/src/Autocomplete.tsx
+++ b/packages/react-search-ui-views/src/Autocomplete.tsx
@@ -96,6 +96,7 @@ function Autocomplete({
                               index: index - 1,
                               item: suggestion
                             })}
+                            data-transaction-name="query suggestion"
                           >
                             {suggestion.highlight ? (
                               <span

--- a/packages/react-search-ui-views/src/BooleanFacet.tsx
+++ b/packages/react-search-ui-views/src/BooleanFacet.tsx
@@ -29,6 +29,7 @@ function BooleanFacet({
           <label className="sui-boolean-facet__option-label">
             <div className="sui-boolean-facet__option-input-wrapper">
               <input
+                data-transaction-name={`facet - ${label}`}
                 className="sui-boolean-facet__checkbox"
                 type="checkbox"
                 onChange={toggle}

--- a/packages/react-search-ui-views/src/MultiCheckboxFacet.tsx
+++ b/packages/react-search-ui-views/src/MultiCheckboxFacet.tsx
@@ -48,6 +48,7 @@ function MultiCheckboxFacet({
             >
               <div className="sui-multi-checkbox-facet__option-input-wrapper">
                 <input
+                  data-transaction-name={`facet - ${label}`}
                   id={`example_facet_${label}${getFilterValueDisplay(
                     option.value
                   )}`}

--- a/packages/react-search-ui-views/src/ResultsPerPage.tsx
+++ b/packages/react-search-ui-views/src/ResultsPerPage.tsx
@@ -1,6 +1,6 @@
 import type { SearchContextState } from "@elastic/search-ui";
 import React from "react";
-import Select from "react-select";
+import Select, { components } from "react-select";
 import { BaseContainerProps, Rename } from "./types";
 
 import { appendClassName } from "./view-helpers";
@@ -42,6 +42,10 @@ const setDefaultStyle = {
 
 const wrapOption = (option) => ({ label: option, value: option });
 
+function Option(props) {
+  return <components.Option {...props}>{props.data.label}</components.Option>;
+}
+
 function ResultsPerPage({
   className,
   onChange,
@@ -71,6 +75,12 @@ function ResultsPerPage({
         options={options.map(wrapOption)}
         isSearchable={false}
         styles={setDefaultStyle}
+        components={{
+          Option: (props) => {
+            props.innerProps["data-transaction-name"] = `results per page`;
+            return Option(props);
+          }
+        }}
       />
     </div>
   );

--- a/packages/react-search-ui-views/src/SearchBox.tsx
+++ b/packages/react-search-ui-views/src/SearchBox.tsx
@@ -132,6 +132,7 @@ function SearchBox(props: SearchBoxViewProps) {
                 getInputProps={(additionalProps) => {
                   const { className, ...rest } = additionalProps || {};
                   return getInputProps({
+                    "data-transaction-name": "search input",
                     placeholder: "Search",
                     ...inputProps,
                     className: appendClassName("sui-search-box__text-input", [
@@ -145,6 +146,7 @@ function SearchBox(props: SearchBoxViewProps) {
                 getButtonProps={(additionalProps) => {
                   const { className, ...rest } = additionalProps || {};
                   return {
+                    "data-transaction-name": "search submit",
                     type: "submit",
                     value: "Search",
                     className: appendClassName(

--- a/packages/react-search-ui-views/src/SingleLinksFacet.tsx
+++ b/packages/react-search-ui-views/src/SingleLinksFacet.tsx
@@ -43,6 +43,7 @@ function SingleLinksFacet({
                 key={getFilterValueDisplay(option.value)}
               >
                 <a
+                  data-transaction-name={`facet - ${label}`}
                   className="sui-single-option-facet__link"
                   href="/"
                   onClick={(e) => {

--- a/packages/react-search-ui-views/src/SingleSelectFacet.tsx
+++ b/packages/react-search-ui-views/src/SingleSelectFacet.tsx
@@ -62,7 +62,12 @@ function SingleSelectFacet({
       <Select
         className="sui-select"
         classNamePrefix="sui-select"
-        components={{ Option }}
+        components={{
+          Option: (props) => {
+            props.innerProps["data-transaction-name"] = `facet - ${label}`;
+            return Option(props);
+          }
+        }}
         value={selectedSelectBoxOption}
         onChange={(o) => onChange(o.value)}
         options={selectBoxOptions}

--- a/packages/react-search-ui-views/src/Sorting.tsx
+++ b/packages/react-search-ui-views/src/Sorting.tsx
@@ -1,6 +1,6 @@
 import type { SearchContextState } from "@elastic/search-ui";
 import React from "react";
-import Select from "react-select";
+import Select, { components } from "react-select";
 import { BaseContainerProps } from "./types";
 
 import { appendClassName } from "./view-helpers";
@@ -34,6 +34,10 @@ export type SortingContainerProps = BaseContainerProps &
     sortOptions: any;
   };
 
+function Option(props) {
+  return <components.Option {...props}>{props.data.label}</components.Option>;
+}
+
 function Sorting({
   className,
   label,
@@ -59,6 +63,12 @@ function Sorting({
         options={options}
         isSearchable={false}
         styles={setDefaultStyle}
+        components={{
+          Option: (props) => {
+            props.innerProps["data-transaction-name"] = `sorting`;
+            return Option(props);
+          }
+        }}
       />
     </div>
   );

--- a/packages/react-search-ui-views/src/__tests__/__snapshots__/Autocomplete.test.tsx.snap
+++ b/packages/react-search-ui-views/src/__tests__/__snapshots__/Autocomplete.test.tsx.snap
@@ -14,6 +14,7 @@ exports[`renders correctly 1`] = `
       className="sui-search-box__suggestion-list"
     >
       <li
+        data-transaction-name="query suggestion"
         index={0}
         item={
           Object {
@@ -28,6 +29,7 @@ exports[`renders correctly 1`] = `
         </span>
       </li>
       <li
+        data-transaction-name="query suggestion"
         index={1}
         item={
           Object {
@@ -42,6 +44,7 @@ exports[`renders correctly 1`] = `
         </span>
       </li>
       <li
+        data-transaction-name="query suggestion"
         index={2}
         item={
           Object {
@@ -65,6 +68,7 @@ exports[`renders correctly 1`] = `
       className="sui-search-box__suggestion-list"
     >
       <li
+        data-transaction-name="query suggestion"
         index={3}
         item={
           Object {
@@ -79,6 +83,7 @@ exports[`renders correctly 1`] = `
         </span>
       </li>
       <li
+        data-transaction-name="query suggestion"
         index={4}
         item={
           Object {
@@ -93,6 +98,7 @@ exports[`renders correctly 1`] = `
         </span>
       </li>
       <li
+        data-transaction-name="query suggestion"
         index={5}
         item={
           Object {

--- a/packages/react-search-ui-views/src/__tests__/__snapshots__/BooleanFacet.test.tsx.snap
+++ b/packages/react-search-ui-views/src/__tests__/__snapshots__/BooleanFacet.test.tsx.snap
@@ -24,6 +24,7 @@ exports[`renders 1`] = `
           <input
             checked={false}
             className="sui-boolean-facet__checkbox"
+            data-transaction-name="facet - A Facet"
             onChange={[Function]}
             type="checkbox"
           />

--- a/packages/react-search-ui-views/src/__tests__/__snapshots__/MultiCheckboxFacet.test.tsx.snap
+++ b/packages/react-search-ui-views/src/__tests__/__snapshots__/MultiCheckboxFacet.test.tsx.snap
@@ -23,6 +23,7 @@ exports[`renders 1`] = `
         <input
           checked={false}
           className="sui-multi-checkbox-facet__checkbox"
+          data-transaction-name="facet - A Facet"
           id="example_facet_A FacetfieldValue1"
           onChange={[Function]}
           type="checkbox"
@@ -50,6 +51,7 @@ exports[`renders 1`] = `
         <input
           checked={true}
           className="sui-multi-checkbox-facet__checkbox"
+          data-transaction-name="facet - A Facet"
           id="example_facet_A FacetfieldValue2"
           onChange={[Function]}
           type="checkbox"
@@ -101,6 +103,7 @@ exports[`renders falsey values correctly 1`] = `
         <input
           checked={false}
           className="sui-multi-checkbox-facet__checkbox"
+          data-transaction-name="facet - A Facet"
           id="example_facet_A Facet0"
           onChange={[Function]}
           type="checkbox"
@@ -128,6 +131,7 @@ exports[`renders falsey values correctly 1`] = `
         <input
           checked={false}
           className="sui-multi-checkbox-facet__checkbox"
+          data-transaction-name="facet - A Facet"
           id="example_facet_A Facetfalse"
           onChange={[Function]}
           type="checkbox"
@@ -155,6 +159,7 @@ exports[`renders falsey values correctly 1`] = `
         <input
           checked={false}
           className="sui-multi-checkbox-facet__checkbox"
+          data-transaction-name="facet - A Facet"
           id="example_facet_A Facet"
           onChange={[Function]}
           type="checkbox"
@@ -203,6 +208,7 @@ exports[`renders range filters 1`] = `
       >
         <input
           className="sui-multi-checkbox-facet__checkbox"
+          data-transaction-name="facet - A Facet"
           id="example_facet_A FacetThe first option"
           onChange={[Function]}
           type="checkbox"
@@ -229,6 +235,7 @@ exports[`renders range filters 1`] = `
       >
         <input
           className="sui-multi-checkbox-facet__checkbox"
+          data-transaction-name="facet - A Facet"
           id="example_facet_A FacetThe second option"
           onChange={[Function]}
           type="checkbox"

--- a/packages/react-search-ui-views/src/__tests__/__snapshots__/ResultsPerPage.test.tsx.snap
+++ b/packages/react-search-ui-views/src/__tests__/__snapshots__/ResultsPerPage.test.tsx.snap
@@ -12,6 +12,11 @@ exports[`renders correctly when there is a selected value 1`] = `
   <StateManager
     className="sui-select sui-select--inline"
     classNamePrefix="sui-select"
+    components={
+      Object {
+        "Option": [Function],
+      }
+    }
     defaultInputValue=""
     defaultMenuIsOpen={false}
     defaultValue={null}
@@ -61,6 +66,11 @@ exports[`renders correctly when there is not a selected value 1`] = `
   <StateManager
     className="sui-select sui-select--inline"
     classNamePrefix="sui-select"
+    components={
+      Object {
+        "Option": [Function],
+      }
+    }
     defaultInputValue=""
     defaultMenuIsOpen={false}
     defaultValue={null}

--- a/packages/react-search-ui-views/src/__tests__/__snapshots__/SingleLinksFacet.test.tsx.snap
+++ b/packages/react-search-ui-views/src/__tests__/__snapshots__/SingleLinksFacet.test.tsx.snap
@@ -19,6 +19,7 @@ exports[`renders correctly 1`] = `
       >
         <a
           className="sui-single-option-facet__link"
+          data-transaction-name="facet - Facet"
           href="/"
           onClick={[Function]}
         >
@@ -37,6 +38,7 @@ exports[`renders correctly 1`] = `
       >
         <a
           className="sui-single-option-facet__link"
+          data-transaction-name="facet - Facet"
           href="/"
           onClick={[Function]}
         >
@@ -73,6 +75,7 @@ exports[`renders falsey values correctly 1`] = `
       >
         <a
           className="sui-single-option-facet__link"
+          data-transaction-name="facet - Facet"
           href="/"
           onClick={[Function]}
         >
@@ -91,6 +94,7 @@ exports[`renders falsey values correctly 1`] = `
       >
         <a
           className="sui-single-option-facet__link"
+          data-transaction-name="facet - Facet"
           href="/"
           onClick={[Function]}
         >
@@ -109,6 +113,7 @@ exports[`renders falsey values correctly 1`] = `
       >
         <a
           className="sui-single-option-facet__link"
+          data-transaction-name="facet - Facet"
           href="/"
           onClick={[Function]}
         />

--- a/packages/react-search-ui-views/src/__tests__/__snapshots__/Sorting.test.tsx.snap
+++ b/packages/react-search-ui-views/src/__tests__/__snapshots__/Sorting.test.tsx.snap
@@ -7,6 +7,11 @@ exports[`renders correctly when there is a value 1`] = `
   <StateManager
     className="sui-select"
     classNamePrefix="sui-select"
+    components={
+      Object {
+        "Option": [Function],
+      }
+    }
     defaultInputValue=""
     defaultMenuIsOpen={false}
     defaultValue={null}
@@ -49,6 +54,11 @@ exports[`renders correctly when there is not a value 1`] = `
   <StateManager
     className="sui-select"
     classNamePrefix="sui-select"
+    components={
+      Object {
+        "Option": [Function],
+      }
+    }
     defaultInputValue=""
     defaultMenuIsOpen={false}
     defaultValue={null}

--- a/packages/react-search-ui/src/containers/__tests__/__snapshots__/ResultsPerPage.test.tsx.snap
+++ b/packages/react-search-ui/src/containers/__tests__/__snapshots__/ResultsPerPage.test.tsx.snap
@@ -19,6 +19,11 @@ exports[`renders the component with custom page options 1`] = `
   <StateManager
     className="sui-select sui-select--inline"
     classNamePrefix="sui-select"
+    components={
+      Object {
+        "Option": [Function],
+      }
+    }
     defaultInputValue=""
     defaultMenuIsOpen={false}
     defaultValue={null}
@@ -74,6 +79,11 @@ exports[`renders when it doesn't have any results or a search term 1`] = `
   <StateManager
     className="sui-select sui-select--inline"
     classNamePrefix="sui-select"
+    components={
+      Object {
+        "Option": [Function],
+      }
+    }
     defaultInputValue=""
     defaultMenuIsOpen={false}
     defaultValue={null}

--- a/packages/react-search-ui/src/containers/__tests__/__snapshots__/Sorting.test.tsx.snap
+++ b/packages/react-search-ui/src/containers/__tests__/__snapshots__/Sorting.test.tsx.snap
@@ -9,6 +9,11 @@ exports[`renders when it doesn't have results or a search term 1`] = `
   <StateManager
     className="sui-select"
     classNamePrefix="sui-select"
+    components={
+      Object {
+        "Option": [Function],
+      }
+    }
     defaultInputValue=""
     defaultMenuIsOpen={false}
     defaultValue={null}


### PR DESCRIPTION
Closes https://github.com/elastic/enterprise-search-team/issues/2155

That will help recognize user interactions in the APM dashboard

Example:
Instead of "Click - input" we will now show "Click - search button"