### PR TITLE
Support custom headers in Elasticsearch API Connector #795

### DIFF
--- a/docs/api-connectors-elasticsearch.mdx
+++ b/docs/api-connectors-elasticsearch.mdx
@@ -27,18 +27,25 @@ const connector = new ElasticsearchAPIConnector({
   },
   host: "http://localhost:9200", // host url for the Elasticsearch instance
   index: "<index-name>", // index name where the search documents are contained
-  apiKey: "<api-key>" // Optional. apiKey used to authorize a connection to Elasticsearch instance.
+  apiKey: "<api-key>", // Optional. apiKey used to authorize a connection to Elasticsearch instance.
   // This key will be visible to everyone so ensure its setup with restricted privileges.
   // See Authentication section for more details.
+  connectionOptions: {
+    // Optional connection options.
+    headers: {
+      "x-custom-header": "value" // Optional. Specify custom headers to send with the request
+    }
+  }
 });
 ```
 
-| Param  | Description                                                                                                                       |
-| ------ | --------------------------------------------------------------------------------------------------------------------------------- |
-| cloud  | Required if `host` not provided. Object type. The cloud id for the deployment within elastic cloud.                               |
-| host   | Required if `cloud` not provided. String type. The host url to the Elasticsearch instance                                         |
-| index  | Required. String type. The search index name                                                                                      |
-| apiKey | Optional. a credential used to access the Elasticsearch instance. See [Connection & Authentication](#connection-&-authentication) |
+| Param             | Description                                                                                                                       |
+| ----------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| cloud             | Required if `host` not provided. Object type. The cloud id for the deployment within elastic cloud.                               |
+| host              | Required if `cloud` not provided. String type. The host url to the Elasticsearch instance                                         |
+| index             | Required. String type. The search index name                                                                                      |
+| apiKey            | Optional. a credential used to access the Elasticsearch instance. See [Connection & Authentication](#connection-&-authentication) |
+| connectionOptions | Optional. Object containing `headers` dictionary of header name to header value.                                                  |
 
 ## Connection & Authentication
 

--- a/packages/search-ui-elasticsearch-connector/src/handlers/autocomplete/__tests__/index.test.ts
+++ b/packages/search-ui-elasticsearch-connector/src/handlers/autocomplete/__tests__/index.test.ts
@@ -144,4 +144,30 @@ describe("Autocomplete results", () => {
 
     expect(searchkitRequestInstance.config.host).toBeUndefined();
   });
+
+  it("should pass additional headers to searchkit", async () => {
+    (Searchkit as jest.Mock).mockClear();
+    const results = await handleRequest({
+      state,
+      queryConfig,
+      host: "http://localhost:9200",
+      index: "test",
+      connectionOptions: {
+        apiKey: "test",
+        headers: {
+          Authorization: "Bearer 123"
+        }
+      }
+    });
+
+    const searchkitRequestInstance = (Searchkit as jest.Mock).mock.results[0]
+      .value;
+
+    expect(searchkitRequestInstance.config.connectionOptions).toEqual({
+      apiKey: "test",
+      headers: {
+        Authorization: "Bearer 123"
+      }
+    });
+  });
 });

--- a/packages/search-ui-elasticsearch-connector/src/handlers/autocomplete/index.ts
+++ b/packages/search-ui-elasticsearch-connector/src/handlers/autocomplete/index.ts
@@ -20,7 +20,8 @@ interface AutocompleteHandlerConfiguration {
   host?: string;
   index: string;
   connectionOptions?: {
-    apiKey: string;
+    apiKey?: string;
+    headers?: Record<string, string>;
   };
 }
 
@@ -29,7 +30,7 @@ export default async function handleRequest(
 ): Promise<AutocompleteResponseState> {
   const { state, queryConfig, host, cloud, index, connectionOptions } =
     configuration;
-  const { apiKey } = connectionOptions || {};
+  const { apiKey, headers } = connectionOptions || {};
 
   const suggestionConfigurations = [];
 
@@ -69,7 +70,8 @@ export default async function handleRequest(
     cloud,
     index,
     connectionOptions: {
-      apiKey
+      apiKey,
+      headers
     },
     suggestions: suggestionConfigurations
   };

--- a/packages/search-ui-elasticsearch-connector/src/handlers/search/Configuration.ts
+++ b/packages/search-ui-elasticsearch-connector/src/handlers/search/Configuration.ts
@@ -106,7 +106,8 @@ interface BuildConfigurationOptions {
   cloud?: CloudHost;
   host?: string;
   index: string;
-  apiKey: string;
+  apiKey?: string;
+  headers?: Record<string, string>;
   postProcessRequestBodyFn?: PostProcessRequestBodyFn;
 }
 
@@ -117,6 +118,7 @@ function buildConfiguration({
   host,
   index,
   apiKey,
+  headers,
   postProcessRequestBodyFn
 }: BuildConfigurationOptions): SearchkitConfig {
   const { hitFields, highlightFields } = getResultFields(
@@ -216,6 +218,7 @@ function buildConfiguration({
       }
     : null;
 
+  const additionalHeaders = headers || {};
   const configuration: SearchkitConfig = {
     host: host,
     cloud: cloud,
@@ -223,6 +226,7 @@ function buildConfiguration({
     connectionOptions: {
       apiKey: apiKey,
       headers: {
+        ...additionalHeaders,
         "x-elastic-client-meta": metaHeader
       }
     },

--- a/packages/search-ui-elasticsearch-connector/src/handlers/search/__tests__/Configuration.test.ts
+++ b/packages/search-ui-elasticsearch-connector/src/handlers/search/__tests__/Configuration.test.ts
@@ -310,6 +310,36 @@ describe("Search - Configuration", () => {
       });
     });
 
+    it("should return the additional headers in the connection options", () => {
+      const state: RequestState = {
+        searchTerm: "test"
+      };
+
+      expect(
+        buildConfiguration({
+          state,
+          queryConfig: { ...queryConfig, facets: null },
+          host,
+          index,
+          apiKey,
+          headers: {
+            Authorization: "Bearer 123",
+            "x-elastic-client-meta": "overridden by build configuration"
+          }
+        })
+      ).toEqual(
+        expect.objectContaining({
+          connectionOptions: {
+            apiKey: "apiKey",
+            headers: {
+              Authorization: "Bearer 123",
+              "x-elastic-client-meta": `ent=${LIB_VERSION}-es-connector,js=browser,t=${LIB_VERSION}-es-connector,ft=universal`
+            }
+          }
+        })
+      );
+    });
+
     it("works with postProcessQuery Function", () => {
       const state: RequestState = {
         searchTerm: "test"

--- a/packages/search-ui-elasticsearch-connector/src/handlers/search/index.ts
+++ b/packages/search-ui-elasticsearch-connector/src/handlers/search/index.ts
@@ -16,7 +16,8 @@ interface SearchHandlerConfiguration {
   host?: string;
   index: string;
   connectionOptions?: {
-    apiKey: string;
+    apiKey?: string;
+    headers?: Record<string, string>;
   };
   postProcessRequestBodyFn?: PostProcessRequestBodyFn;
 }
@@ -33,7 +34,7 @@ export default async function handleRequest(
     connectionOptions,
     postProcessRequestBodyFn
   } = configuration;
-  const { apiKey } = connectionOptions || {};
+  const { apiKey, headers } = connectionOptions || {};
   const searchkitConfig = buildConfiguration({
     state,
     queryConfig,
@@ -41,6 +42,7 @@ export default async function handleRequest(
     host,
     index,
     apiKey,
+    headers,
     postProcessRequestBodyFn
   });
 

--- a/packages/search-ui-elasticsearch-connector/src/index.ts
+++ b/packages/search-ui-elasticsearch-connector/src/index.ts
@@ -16,6 +16,9 @@ type ConnectionOptions = {
   cloud?: CloudHost;
   index: string;
   apiKey?: string;
+  connectionOptions?: {
+    headers?: Record<string, string>;
+  };
 };
 
 export * from "./types";
@@ -47,7 +50,8 @@ class ElasticsearchAPIConnector implements APIConnector {
       host: this.config.host,
       index: this.config.index,
       connectionOptions: {
-        apiKey: this.config.apiKey
+        apiKey: this.config.apiKey,
+        headers: this.config.connectionOptions?.headers
       },
       postProcessRequestBodyFn: this.postProcessRequestBodyFn
     });
@@ -64,7 +68,8 @@ class ElasticsearchAPIConnector implements APIConnector {
       host: this.config.host,
       index: this.config.index,
       connectionOptions: {
-        apiKey: this.config.apiKey
+        apiKey: this.config.apiKey,
+        headers: this.config.connectionOptions?.headers
       }
     });
   }


### PR DESCRIPTION
## Description

I have added support for optional `connectionOptions` as per #795 to be passed to the `ElasticsearchAPIConnector` constructor. For example:

```typescript
const connector = new ElasticsearchAPIConnector({
  // ...
  connectionOptions: {
    // Optional connection options.
    headers: {
      "x-custom-header": "value" // Optional. Specify custom headers to send with the request
    }
  }
});
```

First time contributer so please let me know if I have failed to follow any of your coding standards/guidelines.

I didn't want to break the existing contracts but it probably would make sense eventually (as some sort of major version update) to place the `apiKey` inside the `connectionOptions` to match the SearchKitConfig interface.

## List of changes

1. Accept `connectionOptions` in `ElasticsearchAPIConnector`'s `config` parameter
2. Updated the autocomplete handler to accept this optional `headers` parameter
3. Updated the `buildConfiguration` method to accept an optional `headers` parameter and return the headers as part of the SearchkitConfig object returned
4. Updated documentation to reflect changes made
5. Added tests to ensure these values are handled appropriately

## Associated Github Issues

- Fixes #795 
