### PR TITLE
[Elasticsearch-connector] Suggestions from another Index source

### DIFF
--- a/docs/api-core-configuration.mdx
+++ b/docs/api-core-configuration.mdx
@@ -302,6 +302,44 @@ Suggestions Query configuration for Search UI largely follows the same API as th
 | `types` | Object  | required  | Object, keyed by "type" of query suggestion, with configuration for that type of suggestion. |
 | `size`  | Integer | optional  | Number of suggestions to return.                                                             |
 
+### Result Suggestions
+
+<DocCallOut
+  color="warning"
+  title="Supported only by the Elasticsearch-connector"
+/>
+
+A different index can be used for the suggestions. Some examples:
+
+- Popular queries index from analytics
+- Brands index from product data
+- Categories index from product data
+
+Below we are using the `popular_queries` index and performing a prefix match search on the `query.suggest` field. One thing to note, make sure the api-key has access to the index.
+
+See <DocLink id="api-react-components-search-box" text="Example retrieving suggestions from another index" /> for more information.
+
+````js
+
+```js
+autocompleteQuery: {
+  suggestions: {
+    popularQueries: {
+      search_fields: {
+        "query.suggest": {} // fields used to query
+      },
+      result_fields: {
+        query: { // fields used for display
+          raw: {}
+        }
+      },
+      index: "popular_queries",
+      queryType: "results"
+    }
+  }
+}
+````
+
 ## Event Hooks
 
 Search UI exposes a number of event hooks which need handlers to be implemented in order for Search UI

--- a/docs/api-react-components-search-box.mdx
+++ b/docs/api-react-components-search-box.mdx
@@ -148,6 +148,64 @@ sections. Section titles can be added to help distinguish between the two.
 />
 ```
 
+### Example retrieving suggestions from another index
+
+<DocCallOut
+  color="warning"
+  title="Supported only by the Elasticsearch-connector"
+/>
+
+A different index can be used for the suggestions. Some examples:
+
+- Popular queries index from analytics
+- Brands index from product data
+- Categories index from product data
+
+Below we are using the `popular_queries` index and performing a prefix match search on the `query.suggest` field. One thing to note, make sure the api-key has access to the index.
+
+````jsx
+
+#### Autocomplete Configuration
+
+```js
+autocompleteQuery: {
+  suggestions: {
+    types: {
+      popularQueries: {
+        search_fields: {
+          "query.suggest": {} // fields used to query
+        },
+        result_fields: {
+          query: { // fields used for display
+            raw: {}
+          }
+        },
+        index: "popular_queries",
+        queryType: "results"
+      }
+    },
+    size: 4
+  }
+}
+
+````
+
+#### Component Configuration
+
+```jsx
+<SearchBox
+  autocompleteSuggestions={{
+    popularQueries: {
+      queryType: "results",
+      displayField: "query" // specify which field used to display the suggestion
+    },
+    }
+  }}
+/>
+```
+
+You also have the option to customise the `view` of the autocomplete to show more fields.
+
 ### Configuring autocomplete queries
 
 Autocomplete queries can be customized in the `SearchProvider` configuration, using the `autocompleteQuery` property.

--- a/examples/vue/cleanseCards.js
+++ b/examples/vue/cleanseCards.js
@@ -1,3 +1,5 @@
+/* eslint-disable */
+
 const fs = require("fs");
 const path = require("path");
 const snakecaseKeys = require("snakecase-keys");

--- a/packages/react-search-ui-views/src/__tests__/Autocomplete.test.tsx
+++ b/packages/react-search-ui-views/src/__tests__/Autocomplete.test.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Autocomplete } from "..";
 import { shallow } from "enzyme";
-import { AutocompletedSuggestions } from "@elastic/search-ui";
+import type { AutocompletedSuggestions } from "@elastic/search-ui";
 
 const props = {
   autocompleteResults: {

--- a/packages/react-search-ui-views/src/__tests__/Autocomplete.test.tsx
+++ b/packages/react-search-ui-views/src/__tests__/Autocomplete.test.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Autocomplete } from "..";
 import { shallow } from "enzyme";
+import { AutocompletedSuggestions } from "@elastic/search-ui";
 
 const props = {
   autocompleteResults: {
@@ -28,7 +29,9 @@ const props = {
       sectionTitle: "Suggested"
     },
     popular_queries: {
-      sectionTitle: "Popular"
+      sectionTitle: "Popular",
+      queryType: "results" as const,
+      displayField: "query"
     }
   },
   allAutocompletedItemsCount: 5,
@@ -41,13 +44,15 @@ const props = {
     ],
     popular_queries: [
       {
-        highlight: "",
-        suggestion: "how do i know when my bike needs new tires?"
-      },
-      { highlight: "", suggestion: "what is a banana bike?" },
-      { highlight: "", suggestion: "is it cool to ride a bike?" }
+        result: {
+          query: {
+            raw: "bike police"
+          }
+        },
+        queryType: "results" as const
+      }
     ]
-  },
+  } as AutocompletedSuggestions,
   getItemProps: (props) => props,
   getMenuProps: (props) => props
 };
@@ -155,7 +160,7 @@ describe("When there are suggestions", () => {
       />
     );
     expect(wrapper.find(".sui-search-box__suggestion-list li").length).toEqual(
-      6
+      4
     );
   });
 
@@ -178,6 +183,10 @@ describe("When there are suggestions", () => {
         autocompleteSuggestions={{
           documents: {
             sectionTitle: "Suggested"
+          },
+          popular_queries: {
+            queryType: "results",
+            displayField: "query"
           }
         }}
       />

--- a/packages/react-search-ui-views/src/__tests__/__snapshots__/Autocomplete.test.tsx.snap
+++ b/packages/react-search-ui-views/src/__tests__/__snapshots__/Autocomplete.test.tsx.snap
@@ -72,44 +72,13 @@ exports[`renders correctly 1`] = `
         index={3}
         item={
           Object {
-            "highlight": "",
-            "suggestion": "how do i know when my bike needs new tires?",
+            "suggestion": "bike police",
           }
         }
-        key="how do i know when my bike needs new tires?"
+        key="bike police"
       >
         <span>
-          how do i know when my bike needs new tires?
-        </span>
-      </li>
-      <li
-        data-transaction-name="query suggestion"
-        index={4}
-        item={
-          Object {
-            "highlight": "",
-            "suggestion": "what is a banana bike?",
-          }
-        }
-        key="what is a banana bike?"
-      >
-        <span>
-          what is a banana bike?
-        </span>
-      </li>
-      <li
-        data-transaction-name="query suggestion"
-        index={5}
-        item={
-          Object {
-            "highlight": "",
-            "suggestion": "is it cool to ride a bike?",
-          }
-        }
-        key="is it cool to ride a bike?"
-      >
-        <span>
-          is it cool to ride a bike?
+          bike police
         </span>
       </li>
     </ul>
@@ -122,7 +91,7 @@ exports[`renders correctly 1`] = `
       className="sui-search-box__results-list"
     >
       <li
-        index={6}
+        index={4}
         item={
           Object {
             "id": Object {
@@ -144,7 +113,7 @@ exports[`renders correctly 1`] = `
         />
       </li>
       <li
-        index={7}
+        index={5}
         item={
           Object {
             "id": Object {
@@ -166,7 +135,7 @@ exports[`renders correctly 1`] = `
         />
       </li>
       <li
-        index={8}
+        index={6}
         item={
           Object {
             "id": Object {

--- a/packages/search-ui-elasticsearch-connector/src/handlers/autocomplete/__tests__/index.test.ts
+++ b/packages/search-ui-elasticsearch-connector/src/handlers/autocomplete/__tests__/index.test.ts
@@ -4,8 +4,25 @@ import handleRequest from "../index";
 
 const mockSearchkitResponse = [
   {
-    identifier: "results",
+    identifier: "suggestions-completion-results",
     suggestions: ["sweaters", "sweatpants"]
+  },
+  {
+    identifier: "suggestions-hits-popularQueries",
+    hits: [
+      {
+        id: "acadia",
+        fields: {
+          query: "hello"
+        },
+        highlight: {
+          query: "hello"
+        },
+        rawHit: {
+          _id: "test"
+        }
+      }
+    ]
   },
   {
     identifier: "hits-suggestions",
@@ -67,6 +84,17 @@ const queryConfig: AutocompleteQueryConfig = {
     types: {
       results: {
         fields: ["title"]
+      },
+      popularQueries: {
+        queryType: "results",
+        search_fields: {
+          title: {}
+        },
+        result_fields: {
+          title: {
+            raw: {}
+          }
+        }
       }
     }
   }
@@ -111,6 +139,23 @@ describe("Autocomplete results", () => {
           },
         ],
         "autocompletedSuggestions": Object {
+          "popularQueries": Array [
+            Object {
+              "hit": Object {
+                "_meta": Object {
+                  "id": "test",
+                },
+                "id": Object {
+                  "raw": "acadia",
+                },
+                "query": Object {
+                  "raw": "hello",
+                  "snippet": "hello",
+                },
+              },
+              "queryType": "results",
+            },
+          ],
           "results": Array [
             Object {
               "suggestion": "sweaters",

--- a/packages/search-ui-elasticsearch-connector/src/handlers/autocomplete/__tests__/index.test.ts
+++ b/packages/search-ui-elasticsearch-connector/src/handlers/autocomplete/__tests__/index.test.ts
@@ -145,6 +145,9 @@ describe("Autocomplete results", () => {
               "result": Object {
                 "_meta": Object {
                   "id": "test",
+                  "rawHit": Object {
+                    "_id": "test",
+                  },
                 },
                 "id": Object {
                   "raw": "acadia",

--- a/packages/search-ui-elasticsearch-connector/src/handlers/autocomplete/__tests__/index.test.ts
+++ b/packages/search-ui-elasticsearch-connector/src/handlers/autocomplete/__tests__/index.test.ts
@@ -141,7 +141,8 @@ describe("Autocomplete results", () => {
         "autocompletedSuggestions": Object {
           "popularQueries": Array [
             Object {
-              "hit": Object {
+              "queryType": "results",
+              "result": Object {
                 "_meta": Object {
                   "id": "test",
                 },
@@ -153,7 +154,6 @@ describe("Autocomplete results", () => {
                   "snippet": "hello",
                 },
               },
-              "queryType": "results",
             },
           ],
           "results": Array [

--- a/packages/search-ui/src/types/index.ts
+++ b/packages/search-ui/src/types/index.ts
@@ -70,9 +70,26 @@ export type SearchState = RequestState &
 export type AutocompleteResponseState = {
   autocompletedResults: AutocompletedResult[];
   autocompletedResultsRequestId: string;
-  autocompletedSuggestions: any;
+  autocompletedSuggestions: AutocompletedSuggestions;
   autocompletedSuggestionsRequestId: string;
 };
+
+export type AutocompletedSuggestions = Record<
+  string,
+  AutocompletedSuggestion[] | AutocompletedResultSuggestion[]
+>;
+
+export interface AutocompletedSuggestion {
+  highlight?: string;
+  suggestion?: string;
+  data?: any;
+  queryType?: "suggestion";
+}
+
+export interface AutocompletedResultSuggestion {
+  result: Record<string, FieldResult>;
+  queryType: "results";
+}
 
 export type ResponseState = {
   requestId: string;
@@ -92,8 +109,19 @@ export type FieldConfiguration = {
     size?: number;
     fallback?: boolean;
   };
-  fields?: string[];
   raw?: any;
+};
+
+export type SuggestionConfiguration = {
+  fields: string[];
+  queryType?: "suggestions";
+};
+
+export type ResultSuggestionConfiguration = {
+  result_fields?: Record<string, FieldConfiguration>;
+  search_fields?: Record<string, SearchFieldConfiguration>;
+  index?: string;
+  queryType: "results";
 };
 
 export type SearchFieldConfiguration = {
@@ -107,7 +135,10 @@ export type AutocompleteQueryConfig = {
 };
 
 export type SuggestionsQueryConfig = {
-  types?: Record<string, FieldConfiguration>;
+  types?: Record<
+    string,
+    SuggestionConfiguration | ResultSuggestionConfiguration
+  >;
   size?: number;
 };
 
@@ -174,12 +205,23 @@ export type AutocompleteResult = {
 };
 
 export type AutocompleteSuggestionFragment = {
-  sectionTitle: string;
+  sectionTitle?: string;
+  queryType?: "suggestion";
+};
+
+export type AutocompleteResultSuggestionFragment = {
+  sectionTitle?: string;
+  queryType: "results";
+  displayField: string;
 };
 
 export type AutocompleteSuggestion =
-  | Record<string, AutocompleteSuggestionFragment>
-  | AutocompleteSuggestionFragment;
+  | Record<
+      string,
+      AutocompleteSuggestionFragment | AutocompleteResultSuggestionFragment
+    >
+  | AutocompleteSuggestionFragment
+  | AutocompleteResultSuggestionFragment;
 
 export type FieldResult = {
   raw?: string | number | boolean;
@@ -187,14 +229,5 @@ export type FieldResult = {
 };
 
 export type AutocompletedResult = any | Record<string, FieldResult>;
-
-export type AutocompletedSuggestion = Record<
-  string,
-  {
-    highlight?: string;
-    suggestion?: string;
-    data?: any;
-  }[]
->;
 
 export type SearchContextState = SearchState & SearchDriverActions;


### PR DESCRIPTION
This change enables suggestions coming from a different index. An example of this would be searching across popular queries stored in another index

https://user-images.githubusercontent.com/49480/180554628-1c3f0f0d-f9e2-4acb-9225-5387d16aacd3.mov

