### PR TITLE
Added a view customization example to Results

### DIFF
--- a/docs/api-react-components-results.mdx
+++ b/docs/api-react-components-results.mdx
@@ -34,6 +34,22 @@ import { Results } from "@elastic/react-search-ui";
 />
 ```
 
+### Example overriding results and wrapper
+
+```jsx
+<Results
+  view={({ children }) => <ul>{children}</ul>}
+  resultView={({ result, onClickLink }) => {
+    return (
+      <li onClick={onClickLink}>
+        <h4>{result.title.snippet}</h4>
+        <a href={result.nps_link.raw}>Link</a>
+      </li>
+    );
+  }}
+/>
+```
+
 for more examples on how to override the view, see <DocLink id="guides-customizing-styles-and-html" section="results-component" text="Customizing styles and HTML" />.
 
 ### Configuring search queries


### PR DESCRIPTION
It's not immediately apparent how to do this and someone asked about it so I thought I'd add it to our docs.