### PR TITLE
Efficent generation of filters for App Search Connector 

### DIFF
--- a/packages/search-ui-app-search-connector/src/__tests__/AppSearchAPIConnector.test.ts
+++ b/packages/search-ui-app-search-connector/src/__tests__/AppSearchAPIConnector.test.ts
@@ -391,10 +391,7 @@ describe("AppSearchAPIConnector", () => {
             {
               all: [
                 {
-                  title: "Acadia"
-                },
-                {
-                  title: "Grand Canyon"
+                  title: ["Acadia", "Grand Canyon"]
                 }
               ]
             },

--- a/packages/search-ui-app-search-connector/src/__tests__/AppSearchAPIConnector.test.ts
+++ b/packages/search-ui-app-search-connector/src/__tests__/AppSearchAPIConnector.test.ts
@@ -391,7 +391,10 @@ describe("AppSearchAPIConnector", () => {
             {
               all: [
                 {
-                  title: ["Acadia", "Grand Canyon"]
+                  title: "Acadia"
+                },
+                {
+                  title: "Grand Canyon"
                 }
               ]
             },

--- a/packages/search-ui-app-search-connector/src/__tests__/requestAdapters.test.ts
+++ b/packages/search-ui-app-search-connector/src/__tests__/requestAdapters.test.ts
@@ -46,6 +46,11 @@ const request = {
       field: "whatever",
       values: ["value"]
       // TODO: is it possible to not have type here?
+    },
+    {
+      field: "whatevernone",
+      values: ["value", "value2"],
+      type: "none" as const
     }
   ]
 };
@@ -80,7 +85,13 @@ const adaptedRequest = {
       {
         all: [
           {
-            initial: ["additional values", "and values", "and even more values"]
+            initial: "additional values"
+          },
+          {
+            initial: "and values"
+          },
+          {
+            initial: "and even more values"
           }
         ]
       },
@@ -93,6 +104,13 @@ const adaptedRequest = {
       },
       {
         any: [{ whatever: "value" }]
+      },
+      {
+        none: [
+          {
+            whatevernone: ["value", "value2"]
+          }
+        ]
       }
     ]
   }

--- a/packages/search-ui-app-search-connector/src/__tests__/requestAdapters.test.ts
+++ b/packages/search-ui-app-search-connector/src/__tests__/requestAdapters.test.ts
@@ -1,21 +1,5 @@
 import { adaptRequest } from "../requestAdapters";
 
-describe("adaptRequest", () => {
-  it("adapts request", () => {
-    expect(adaptRequest(request as any)).toEqual(adaptedRequest);
-  });
-
-  it("adapts sortList request", () => {
-    expect(adaptRequest(sortListRequest as any)).toEqual(
-      adaptedSortListRequest
-    );
-  });
-
-  it("adapts empty request", () => {
-    expect(adaptRequest(emptyRequest)).toEqual(adaptedEmptyRequest);
-  });
-});
-
 const emptyRequest = {
   searchTerm: ""
 };
@@ -95,16 +79,16 @@ const adaptedRequest = {
       },
       {
         all: [
-          { initial: "additional values" },
-          { initial: "and values" },
-          { initial: "and even more values" }
+          {
+            initial: ["additional values", "and values", "and even more values"]
+          }
         ]
       },
       {
         any: [
-          { initial: "additional values" },
-          { initial: "and values" },
-          { initial: "and even more values" }
+          {
+            initial: ["additional values", "and values", "and even more values"]
+          }
         ]
       },
       {
@@ -140,3 +124,19 @@ const adaptedSortListRequest = {
   ...adaptedRequest,
   sort: [{ states: "asc" }, { title: "desc" }]
 };
+
+describe("adaptRequest", () => {
+  it("adapts request", () => {
+    expect(adaptRequest(request as any)).toEqual(adaptedRequest);
+  });
+
+  it("adapts sortList request", () => {
+    expect(adaptRequest(sortListRequest as any)).toEqual(
+      adaptedSortListRequest
+    );
+  });
+
+  it("adapts empty request", () => {
+    expect(adaptRequest(emptyRequest)).toEqual(adaptedEmptyRequest);
+  });
+});

--- a/packages/search-ui-app-search-connector/src/requestAdapters.ts
+++ b/packages/search-ui-app-search-connector/src/requestAdapters.ts
@@ -20,10 +20,20 @@ function removeName(v: FilterValue) {
 }
 
 function rollup(f: Filter) {
-  const values = f.values.map(removeName).map((v) => ({
-    [f.field]: v
-  }));
+  const hasRangeInValues = f.values.some(helpers.isFilterValueRange);
+  let values;
 
+  if (hasRangeInValues || f.values.length === 1) {
+    values = f.values.map(removeName).map((v) => ({
+      [f.field]: v
+    }));
+  } else {
+    values = [
+      {
+        [f.field]: f.values.map(removeName).map((v) => v)
+      }
+    ];
+  }
   return {
     [f.type || "any"]: values
   };

--- a/packages/search-ui-app-search-connector/src/requestAdapters.ts
+++ b/packages/search-ui-app-search-connector/src/requestAdapters.ts
@@ -21,13 +21,15 @@ function removeName(v: FilterValue) {
 
 function rollup(f: Filter) {
   const hasRangeInValues = f.values.some(helpers.isFilterValueRange);
+  const isAllType = f.type === "all";
   let values;
 
-  if (hasRangeInValues || f.values.length === 1) {
+  if (isAllType || hasRangeInValues || f.values.length === 1) {
     values = f.values.map(removeName).map((v) => ({
       [f.field]: v
     }));
   } else {
+    // Used for "any" and "none" types that have multiple values and are not ranges
     values = [
       {
         [f.field]: f.values.map(removeName).map((v) => v)


### PR DESCRIPTION
fixes https://github.com/elastic/search-ui/issues/837. 

- We are currently creating a new "filter" per value, even if it was grouped together inside values. This hits a ceiling fast with only 32 filters can be applied. 
- we should be using one filter per field with an **array** of values. https://www.elastic.co/guide/en/app-search/current/filters.html#filters-arrays-all-none
- ranges will not be able to be grouped together. Requires a filter per range type
