### PR TITLE
fix the error while passing any data except string for normalization

### DIFF
--- a/packages/react-search-ui/src/__tests__/helpers.test.ts
+++ b/packages/react-search-ui/src/__tests__/helpers.test.ts
@@ -5,5 +5,10 @@ describe("accentFold", () => {
     expect(accentFold("ǟc̈ŗÄh")).toBe("acrAh");
     expect(accentFold("abc")).toBe("abc");
     expect(accentFold("ABC")).toBe("ABC");
+    // anything other than string passed as argument should return empty string
+    expect(accentFold(123)).toBe("");
+    expect(accentFold({ a: 1, b: 2 })).toBe("");
+    expect(accentFold([1, 2])).toBe("");
+    expect(accentFold(null)).toBe("");
   });
 });

--- a/packages/react-search-ui/src/containers/Facet.tsx
+++ b/packages/react-search-ui/src/containers/Facet.tsx
@@ -93,9 +93,11 @@ export class FacetContainer extends Component<
 
     if (searchTerm.trim()) {
       facetValues = facetValues.filter((option) =>
-        accentFold(option.value)
-          .toLowerCase()
-          .includes(accentFold(searchTerm).toLowerCase())
+        typeof option.value === "string"
+          ? accentFold(option.value)
+              .toLowerCase()
+              .includes(accentFold(searchTerm).toLowerCase())
+          : false
       );
     }
 

--- a/packages/react-search-ui/src/containers/__tests__/Facet.test.tsx
+++ b/packages/react-search-ui/src/containers/__tests__/Facet.test.tsx
@@ -302,7 +302,11 @@ describe("search facets", () => {
   const fieldData = [
     { count: 20, value: "Virat" },
     { count: 9, value: "LÒpez" },
-    { count: 8, value: "bumŗÄh" }
+    { count: 8, value: "bumŗÄh" },
+    { count: 7, value: { a: 1, b: 1 } },
+    { count: 6, value: [1, 2] },
+    { count: 5, value: 123 },
+    { count: 4, value: null }
   ];
 
   function subject(additionalProps = {}, data = fieldData) {
@@ -395,6 +399,21 @@ describe("search facets", () => {
         0
       );
     });
+  });
+
+  it("should not render Facet options if data value is not string", () => {
+    const data = [
+      { count: 20, value: { a: 1, b: 1 } },
+      { count: 10, value: [1, 2] },
+      { count: 9, value: 123 },
+      { count: 8, value: null }
+    ];
+    const wrapper = subject({}, data);
+
+    wrapper.find<FacetViewProps>(View).prop("onSearch")("app");
+    const options = wrapper.find<FacetViewProps>(View).prop("options");
+
+    expect(options.length).toEqual(0);
   });
 
   it("should hide the search input", () => {

--- a/packages/react-search-ui/src/helpers.ts
+++ b/packages/react-search-ui/src/helpers.ts
@@ -1,4 +1,6 @@
 // LÒpez => Lopez
 // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/normalize
-export const accentFold = (str = ""): string =>
-  str.normalize("NFD").replace(/[\u0300-\u036f]/g, "");
+export const accentFold = (str: any): string =>
+  typeof str === "string"
+    ? str.normalize("NFD").replace(/[\u0300-\u036f]/g, "")
+    : "";


### PR DESCRIPTION
## Description
When using a `<Facet isFilterable={true} />` on a field mapped to `NUMBER`, we get the following error:
`Uncaught TypeError: str.normalize is not a function`

## List of changes
1. If anything other than string passed as argument in `accentFold` function, it should return empty string.
2. Added a shield for facet values to be string.

## Associated Github Issues
Fixes #833 