### PR TITLE
Fixed INTERNAL.md

### DIFF
--- a/INTERNAL.md
+++ b/INTERNAL.md
@@ -7,19 +7,19 @@ The Search UI docs are built using an internal library (which hopefully moves in
 An overview of the syntax used can be found here: https://github.com/elastic/docsmobile/blob/main/doc-site/docs/docs_syntax.mdx.
 
 1. Clone https://github.com/elastic/docs.elastic.co next to search-ui repo
-2. Edit your source.json file so that:
+2. Edit your content.js file so that:
    ```
    {
-   "sources": [
-      {
-         "type": "file",
-         "location": "../../search-ui"
-      }
-   ]
+      "sources": [
+         {
+            "type": "file",
+            "location": "../../search-ui"
+         }
+      ]
    }
    ```
 3. Run `yarn`, then `yarn init-docs`, then `yarn dev`.
-4. After the initial setup is done, simply use `yarn docs-start` from the search-ui root.
+4. After the initial setup is done, simply use `yarn start-docs` from the search-ui root.
 
 # Publishing
 


### PR DESCRIPTION
The `start-docs` command was wrong. Additionally, the latest version of docs.elastic.co uses docsmobile 1.11 which uses a `content.js` file instead of a `sources.json` file.