### PR TITLE
Fix facet filters for ranges

### DIFF
--- a/examples/sandbox/src/pages/app-search/index.js
+++ b/examples/sandbox/src/pages/app-search/index.js
@@ -252,6 +252,7 @@ export default function App() {
                       <Facet
                         field="date_established"
                         label="Date Established"
+                        isFilterable={true}
                         filterType="any"
                       />
                       <Facet

--- a/examples/sandbox/src/pages/elasticsearch/index.js
+++ b/examples/sandbox/src/pages/elasticsearch/index.js
@@ -268,6 +268,7 @@ export default function App() {
                       <Facet
                         field="date_established"
                         label="Date Established"
+                        isFilterable={true}
                         filterType="any"
                       />
                       <Facet

--- a/packages/react-search-ui/src/containers/Facet.tsx
+++ b/packages/react-search-ui/src/containers/Facet.tsx
@@ -92,13 +92,30 @@ export class FacetContainer extends Component<
     if (!facetValues.length && !selectedValues.length) return null;
 
     if (searchTerm.trim()) {
-      facetValues = facetValues.filter((option) =>
-        typeof option.value === "string"
-          ? accentFold(option.value)
-              .toLowerCase()
-              .includes(accentFold(searchTerm).toLowerCase())
-          : false
-      );
+      facetValues = facetValues.filter((option) => {
+        let valueToSearch;
+        switch (typeof option.value) {
+          case "string":
+            valueToSearch = accentFold(option.value).toLowerCase();
+            break;
+          case "number":
+            valueToSearch = option.value.toString();
+            break;
+          case "object":
+            valueToSearch =
+              option.value &&
+              option.value.name &&
+              typeof option.value.name === "string"
+                ? accentFold(option.value.name).toLowerCase()
+                : "";
+            break;
+
+          default:
+            valueToSearch = "";
+            break;
+        }
+        return valueToSearch.includes(accentFold(searchTerm).toLowerCase());
+      });
     }
 
     const View: React.ComponentType<FacetViewProps> =

--- a/packages/react-search-ui/src/containers/Facet.tsx
+++ b/packages/react-search-ui/src/containers/Facet.tsx
@@ -103,9 +103,7 @@ export class FacetContainer extends Component<
             break;
           case "object":
             valueToSearch =
-              option.value &&
-              option.value.name &&
-              typeof option.value.name === "string"
+              typeof option?.value?.name === "string"
                 ? accentFold(option.value.name).toLowerCase()
                 : "";
             break;

--- a/packages/react-search-ui/src/containers/__tests__/Facet.test.tsx
+++ b/packages/react-search-ui/src/containers/__tests__/Facet.test.tsx
@@ -306,7 +306,15 @@ describe("search facets", () => {
     { count: 7, value: { a: 1, b: 1 } },
     { count: 6, value: [1, 2] },
     { count: 5, value: 123 },
-    { count: 4, value: null }
+    { count: 4, value: null },
+    {
+      count: 4,
+      value: {
+        from: 0,
+        to: 9,
+        name: "0 to 9"
+      }
+    }
   ];
 
   function subject(additionalProps = {}, data = fieldData) {
@@ -347,6 +355,23 @@ describe("search facets", () => {
   });
 
   describe("after a search is performed", () => {
+    it("should match Facet options that have an object value with name property", () => {
+      wrapper.find<FacetViewProps>(View).prop("onSearch")("0 to");
+
+      const filteredOptions = wrapper
+        .find<FacetViewProps>(View)
+        .prop("options");
+
+      expect(filteredOptions.length).toEqual(1);
+      expect(filteredOptions.map((opt) => opt.value)).toEqual([
+        {
+          from: 0,
+          to: 9,
+          name: "0 to 9"
+        }
+      ]);
+    });
+
     it("should match Facet options with/without accented characters", () => {
       wrapper.find<FacetViewProps>(View).prop("onSearch")("ra");
 


### PR DESCRIPTION
## Description
Currently the ability to filter a Facet (`isFilterable` prop) does not work with range based facets for app-search, as the structure of the `value` property is different. Assuming this is intended, this change gives the ability to filter by that type of value.

If this is unintentional, we can change the connector to change the way the value structured in the response.

## List of changes
A bit of duck typing for the `value` property in `facetValues` to facilitate filtering better.