### PR TITLE
Nextjs Router Documentation

### DIFF
--- a/docs/guides-nextjs-integration.mdx
+++ b/docs/guides-nextjs-integration.mdx
@@ -17,19 +17,20 @@ Below is an example of how to do achieve this.
 To highlight, we're using React memo to prevent the component from re-rendering the Search UI chrome when the URL changes.
 
 <DocTabs>
-  <DocTab name="Next Page Component">
+  <DocTab name="pages/search.jsx">
     ```jsx
     import { memo } from 'react'
+    import { useNextRouting } from "../utils/useNextRouting";
 
     export default function App() {
       // useNextRouting is a custom hook that will integrate with Next Router with Search UI config
       // config is search-ui configuration.
       // baseUrl is the path to the search page
       const combinedConfig = useNextRouting(config, "<baseUrl>");
-      return <MemoSearch config={combinedConfig} />;
+      return <Search config={combinedConfig} />;
     }
 
-    const MemoSearch = memo(({ config }) => {
+    const Search = memo(({ config }) => {
       return (
         <SearchProvider config={config}>
           <>
@@ -44,52 +45,55 @@ To highlight, we're using React memo to prevent the component from re-rendering 
     ```
 
 </DocTab>
-<DocTab name="useNextRouting hook">
+<DocTab name="utils/useNextRouting.js">
+
 ```jsx
-import { useMemo } from 'react'
-import { useRouter } from "next/router"
+import { useRouter } from "next/router";
+import { useMemo } from "react";
 
-const useNextRouting = (config, basePathUrl) => {
-const router = useRouter()
-const { asPath } = router
+export const useNextRouting = (config, basePathUrl) => {
+  const router = useRouter();
+  const { asPath } = router;
 
-const getSearchParamsFromUrl = (url) => {
-return url.match(/\?(.+)/)?.[1] || ""
-}
+  const getSearchParamsFromUrl = (url) => {
+    return url.match(/\?(.+)/)?.[1] || "";
+  };
 
-const routingOptions = {
-// read and write only the query string to search UI
-// as we are leveraging existing stateToUrl and urlToState functions
-// which are based on the query string
-readUrl: () => {
-return getSearchParamsFromUrl(asPath)
-},
-writeUrl: (url, { replaceUrl }) => {
-const method = router[replaceUrl ? "replace" : "push"]
-method(`?${url}`)
-},
-routeChangeHandler: (callback) => {
-const handler = (fullUrl) => {
-if (fullUrl.includes(basePathUrl)) {
-callback(getSearchParamsFromUrl(fullUrl))
-}
-}
-router.events.on("routeChangeComplete", handler)
-return () => {
-router.events.off("routeChangeComplete", handler)
-}
-}
-}
+  const routingOptions = {
+    // read and write only the query string to search UI
+    // as we are leveraging existing stateToUrl and urlToState functions
+    // which are based on the query string
+    readUrl: () => {
+      return getSearchParamsFromUrl(asPath);
+    },
+    writeUrl: (url, { replaceUrl }) => {
+      const method = router[replaceUrl ? "replace" : "push"];
+      const params = Object.fromEntries(new URLSearchParams(url).entries());
+      method({ query: { ...router.query, ...params } }, undefined, {
+        shallow: true
+      });
+    },
+    routeChangeHandler: (callback) => {
+      const handler = (fullUrl) => {
+        if (fullUrl.includes(basePathUrl)) {
+          callback(getSearchParamsFromUrl(fullUrl));
+        }
+      };
+      router.events.on("routeChangeComplete", handler);
+      return () => {
+        router.events.off("routeChangeComplete", handler);
+      };
+    }
+  };
 
-return useMemo(() => {
-return {
-...config,
-routingOptions
-}
-}, [])
-}
-
-````
+  return useMemo(() => {
+    return {
+      ...config,
+      routingOptions
+    };
+  }, [router.isReady]);
+};
+```
 
   </DocTab>
 </DocTabs>


### PR DESCRIPTION
Updating the nextjs documentation to fix a couple of issues:
- if the search is present in a dynamic url, updating the url without the original params will fail. The fix is to extend the params with search ui params. Memo also needs to watch when router `isReady` so params can be provided.

In response to this discuss post: https://discuss.elastic.co/t/integrating-search-ui-with-nextjs-router-dynamic-routes/322248/5
