### PR TITLE
Adds CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @elastic/search-ui-maintainers 


### PR DESCRIPTION
This PR adds a CODEOWNERS file, adds @elastic/search-ui-maintainers as the primary code owner.
