### PR TITLE
Engines Connector

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -115,6 +115,22 @@
       },
       "console": "integratedTerminal",
       "sourceMaps": true
+    },
+    {
+      "name": "Jest engines-connector",
+      "type": "node",
+      "request": "launch",
+      "program": "${workspaceRoot}/node_modules/jest/bin/jest.js",
+      "stopOnEntry": false,
+      "args": ["--runInBand", "--forceExit", "--detectOpenHandles", "--watch"],
+      "cwd": "${workspaceRoot}/packages/search-ui-engines-connector",
+      "preLaunchTask": null,
+      "runtimeExecutable": null,
+      "env": {
+        "NODE_ENV": "test"
+      },
+      "console": "integratedTerminal",
+      "sourceMaps": true
     }
   ]
 }

--- a/examples/sandbox/package.json
+++ b/examples/sandbox/package.json
@@ -23,6 +23,7 @@
     "@elastic/search-ui-elasticsearch-connector": "1.18.3",
     "@elastic/search-ui-site-search-connector": "1.18.3",
     "@elastic/search-ui-workplace-search-connector": "1.18.3",
+    "@elastic/search-ui-engines-connector": "1.18.3",
     "@emotion/react": "^11.8.1",
     "autoprefixer": "^10.4.7",
     "moment": "^2.24.0",

--- a/examples/sandbox/src/Router.js
+++ b/examples/sandbox/src/Router.js
@@ -2,6 +2,7 @@ import * as React from "react";
 import { Switch } from "react-router-dom";
 import Root from "./pages/root";
 import Elasticsearch from "./pages/elasticsearch";
+import Engines from "./pages/engines";
 import AppSearch from "./pages/app-search";
 import SiteSearch from "./pages/site-search";
 import WorkplaceSearch from "./pages/workplace-search";
@@ -26,6 +27,7 @@ export default function Router() {
         <ApmRoute exact path="/app-search" component={AppSearch} />
         <ApmRoute exact path="/site-search" component={SiteSearch} />
         <ApmRoute exact path="/workplace-search" component={WorkplaceSearch} />
+        <ApmRoute exact path="/engines" component={Engines} />
 
         {/* Examples */}
         <ApmRoute

--- a/examples/sandbox/src/pages/engines/index.js
+++ b/examples/sandbox/src/pages/engines/index.js
@@ -1,0 +1,163 @@
+import React from "react";
+import "@elastic/eui/dist/eui_theme_light.css";
+
+import EnginesAPIConnector from "@elastic/search-ui-engines-connector";
+
+import {
+  ErrorBoundary,
+  Facet,
+  SearchProvider,
+  SearchBox,
+  Results,
+  PagingInfo,
+  ResultsPerPage,
+  Paging,
+  Sorting,
+  WithSearch
+} from "@elastic/react-search-ui";
+import { Layout } from "@elastic/react-search-ui-views";
+import "@elastic/react-search-ui-views/lib/styles/styles.css";
+
+const connector = new EnginesAPIConnector({
+  host: "http://localhost:3002",
+  engineName: "puggles",
+  apiKey: "QTJDMHhJVUJENHg5WEJWcXlrWVQ6dXFlcF9QRWdRWHl2Rm9iSndka1Rndw=="
+});
+
+const config = {
+  debug: true,
+  alwaysSearchOnInitialLoad: true,
+  apiConnector: connector,
+  hasA11yNotifications: true,
+  autocompleteQuery: {
+    results: {
+      search_fields: {
+        name: {}
+      },
+      resultsPerPage: 5,
+      result_fields: {
+        name: {
+          snippet: {
+            size: 100,
+            fallback: true
+          }
+        }
+      }
+    }
+  },
+  searchQuery: {
+    filters: [],
+    search_fields: {
+      name: {
+        weight: 3
+      }
+    },
+    result_fields: {
+      id: { raw: {} },
+      name: { raw: {}, snippet: { size: 100, fallback: true } },
+      color: { raw: {} },
+      age: { raw: {} }
+    },
+    disjunctiveFacets: ["color", "age"],
+    facets: {
+      color: { type: "value" },
+      age: {
+        type: "range",
+        ranges: [
+          { to: 2, name: "New born" },
+          { from: 2, to: 3, name: "Puppy" },
+          { from: 3, to: 13, name: "Mid" },
+          { from: 14, name: "senior" }
+        ]
+      }
+    }
+  }
+};
+
+const SORT_OPTIONS = [
+  {
+    name: "Relevance",
+    value: []
+  },
+  {
+    name: "Youngest",
+    value: [
+      {
+        field: "age",
+        direction: "asc"
+      }
+    ]
+  },
+  {
+    name: "Oldest",
+    value: [
+      {
+        field: "age",
+        direction: "desc"
+      }
+    ]
+  }
+];
+
+export default function App() {
+  return (
+    <SearchProvider config={config}>
+      <WithSearch
+        mapContextToProps={({ wasSearched }) => ({
+          wasSearched
+        })}
+      >
+        {({ wasSearched }) => {
+          return (
+            <div className="App">
+              <ErrorBoundary>
+                <Layout
+                  header={
+                    <SearchBox
+                      debounceLength={0}
+                      autocompleteResults={{
+                        linkTarget: "_blank",
+                        sectionTitle: "Results",
+                        titleField: "name",
+                        urlField: "name"
+                      }}
+                    />
+                  }
+                  sideContent={
+                    <div>
+                      {wasSearched && (
+                        <Sorting label={"Sort by"} sortOptions={SORT_OPTIONS} />
+                      )}
+                      <Facet
+                        field="color"
+                        label="Color"
+                        filterType="any"
+                        isFilterable={true}
+                      />
+                      <Facet
+                        field="age"
+                        label="Age"
+                        filterType="any"
+                        isFilterable={true}
+                      />
+                    </div>
+                  }
+                  bodyContent={
+                    <Results titleField="name" shouldTrackClickThrough={true} />
+                  }
+                  bodyHeader={
+                    <React.Fragment>
+                      {wasSearched && <PagingInfo />}
+                      {wasSearched && <ResultsPerPage />}
+                    </React.Fragment>
+                  }
+                  bodyFooter={<Paging />}
+                />
+              </ErrorBoundary>
+            </div>
+          );
+        }}
+      </WithSearch>
+    </SearchProvider>
+  );
+}

--- a/packages/search-ui-elasticsearch-connector/src/handlers/autocomplete/index.ts
+++ b/packages/search-ui-elasticsearch-connector/src/handlers/autocomplete/index.ts
@@ -107,21 +107,21 @@ export default async function handleRequest(
   );
 
   const results: AutocompleteResponseState = response.reduce(
-    (sum, suggestion) => {
+    (acc, suggestion) => {
       const { identifier } = suggestion;
 
       if (identifier === "hits-suggestions") {
         return {
-          ...sum,
+          ...acc,
           autocompletedResults: suggestion.hits.map(fieldResponseMapper)
         };
       } else if (identifier.startsWith("suggestions-completion-")) {
         const name = identifier.replace("suggestions-completion-", "");
 
         return {
-          ...sum,
+          ...acc,
           autocompletedSuggestions: {
-            ...sum.autocompletedSuggestions,
+            ...acc.autocompletedSuggestions,
             [name]: suggestion.suggestions.map((suggestion) => {
               return {
                 suggestion: suggestion
@@ -135,9 +135,9 @@ export default async function handleRequest(
           name
         ] as ResultSuggestionConfiguration;
         return {
-          ...sum,
+          ...acc,
           autocompletedSuggestions: {
-            ...sum.autocompletedSuggestions,
+            ...acc.autocompletedSuggestions,
             [name]: suggestion.hits.map((hit) => ({
               queryType: config.queryType,
               result: fieldResponseMapper(hit)

--- a/packages/search-ui-elasticsearch-connector/src/handlers/search/Configuration.ts
+++ b/packages/search-ui-elasticsearch-connector/src/handlers/search/Configuration.ts
@@ -32,12 +32,12 @@ export function getResultFields(
 } {
   const hitFields = Object.keys(resultFields);
 
-  const highlightFields = Object.keys(resultFields).reduce((sum, fieldKey) => {
+  const highlightFields = Object.keys(resultFields).reduce((acc, fieldKey) => {
     const fieldConfiguration = resultFields[fieldKey];
     if (fieldConfiguration.snippet) {
-      sum.push(fieldKey);
+      acc.push(fieldKey);
     }
-    return sum;
+    return acc;
   }, []);
 
   return { hitFields, highlightFields };
@@ -67,14 +67,14 @@ export function isRangeFilter(
 }
 
 export function buildBaseFilters(baseFilters: Filter[]): BaseFilters {
-  const filters = (baseFilters || []).reduce((sum, filter) => {
+  const filters = (baseFilters || []).reduce((acc, filter) => {
     const boolType = {
       all: "filter",
       any: "should",
       none: "must_not"
     }[filter.type];
     return [
-      ...sum,
+      ...acc,
       {
         bool: {
           [boolType]: filter.values.map((value: FilterValue) => {
@@ -144,9 +144,9 @@ function buildConfiguration({
   const filtersConfig: BaseFilter[] = Object.values(
     (state.filters || [])
       .filter((f) => !queryConfig.facets[f.field]) //exclude all filters that are defined as facets
-      .reduce((sum, f) => {
+      .reduce((acc, f) => {
         return {
-          ...sum,
+          ...acc,
           [f.field]: new SKFilter({
             field: f.field,
             identifier: f.field,
@@ -157,11 +157,11 @@ function buildConfiguration({
   );
 
   const facets = Object.keys(queryConfig.facets || {}).reduce(
-    (sum, facetKey) => {
+    (acc, facetKey) => {
       const facetConfiguration = queryConfig.facets[facetKey];
       const isDisJunctive = queryConfig.disjunctiveFacets?.includes(facetKey);
       if (facetConfiguration.type === "value") {
-        sum.push(
+        acc.push(
           new RefinementSelectFacet({
             identifier: facetKey,
             field: facetKey,
@@ -175,7 +175,7 @@ function buildConfiguration({
         facetConfiguration.type === "range" &&
         !facetConfiguration.center
       ) {
-        sum.push(
+        acc.push(
           new MultiQueryOptionsFacet({
             identifier: facetKey,
             field: facetKey,
@@ -200,7 +200,7 @@ function buildConfiguration({
         facetConfiguration.type === "range" &&
         facetConfiguration.center
       ) {
-        sum.push(
+        acc.push(
           new GeoDistanceOptionsFacet({
             identifier: facetKey,
             field: facetKey,
@@ -219,7 +219,7 @@ function buildConfiguration({
         );
       }
 
-      return sum;
+      return acc;
     },
     []
   );

--- a/packages/search-ui-elasticsearch-connector/src/handlers/search/Request.ts
+++ b/packages/search-ui-elasticsearch-connector/src/handlers/search/Request.ts
@@ -16,7 +16,7 @@ export function getFilters(
   baseFilters: Filter[] = []
 ): MixedFilter[] {
   return filters.reduce((acc, f) => {
-    const isBaseFilter = baseFilters.find((bf) => bf === f);
+    const isBaseFilter = baseFilters.includes(f);
     if (isBaseFilter) return acc;
 
     const subFilters = f.values.map((v) => {

--- a/packages/search-ui-engines-connector/LICENSE.txt
+++ b/packages/search-ui-engines-connector/LICENSE.txt
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2019 Elasticsearch B.V.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/search-ui-engines-connector/NOTICE.txt
+++ b/packages/search-ui-engines-connector/NOTICE.txt
@@ -1,0 +1,3 @@
+Elastic Search UI.
+
+Copyright 2012-2019 Elasticsearch B.V.

--- a/packages/search-ui-engines-connector/README.md
+++ b/packages/search-ui-engines-connector/README.md
@@ -1,0 +1,45 @@
+# search-ui-engines-connector
+
+Part of the [Search UI](https://github.com/elastic/search-ui) project.
+
+This Connector is used to connect Search UI to Elasticsearch Engines.
+
+## Usage
+
+```shell
+npm install --save @elastic/search-ui-engines-connector
+```
+
+```js
+import EnginesConnector from "@elastic/search-ui-engines-connector";
+
+const connector = new EnginesConnector({
+  host: "https://my-engines-demo.ent.us-east4.gcp.elastic-cloud.com/",
+  engineName: "puggles",
+  apiKey: "QTJDMHhJVUJENHg5WETWcXlrWVQ6dXFlcF9QRWdRWHl2Rm9iSndka1Rndw=="
+});
+```
+
+## EnginesConnector
+
+**Kind**: global class
+
+### new ElasticsearchAPIConnector(options)
+
+| Param   | Type                             |
+| ------- | -------------------------------- |
+| options | [<code>Options</code>](#Options) |
+
+## Options
+
+**Kind**: global typedef
+
+| Param      | Type                | Default | Description                                                     |
+| ---------- | ------------------- | ------- | --------------------------------------------------------------- |
+| host       | <code>string</code> |         | Engines Host.                                                   |
+| engineName | <code>string</code> |         | The name of the engine to search                                |
+| apiKey     | <code>string</code> |         | API Key for the engine. Can be found within the Engine view UI. |
+
+## Query Configuration Requirements
+
+- `search_fields` object is required with all fields you want to search by.

--- a/packages/search-ui-engines-connector/bin/build-js
+++ b/packages/search-ui-engines-connector/bin/build-js
@@ -1,0 +1,6 @@
+# clear directory
+# Builds ESM JavaScript
+./node_modules/.bin/tsc  
+
+# Builds CJS JavaScript
+./node_modules/.bin/tsc  -p tsconfig-cjs.json

--- a/packages/search-ui-engines-connector/bin/watch-js
+++ b/packages/search-ui-engines-connector/bin/watch-js
@@ -1,0 +1,2 @@
+./node_modules/.bin/tsc  --watch &
+./node_modules/.bin/tsc  -p tsconfig-cjs.json --watch &

--- a/packages/search-ui-engines-connector/jest.config.js
+++ b/packages/search-ui-engines-connector/jest.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  preset: "ts-jest/presets/js-with-ts-esm",
+  testPathIgnorePatterns: ["./lib"],
+  testEnvironment: "jsdom"
+};

--- a/packages/search-ui-engines-connector/package.json
+++ b/packages/search-ui-engines-connector/package.json
@@ -37,12 +37,12 @@
   "devDependencies": {
     "rimraf": "^2.6.3",
     "typescript": "^4.5.4",
-    "nock": "^13.3.0"
+    "nock": "^13.3.0",
+    "cross-fetch": "^3.1.4",
+    "@elastic/elasticsearch": "^8.6.0"
   },
   "dependencies": {
-    "@elastic/elasticsearch": "^8.6.0",
     "@elastic/search-ui": "1.18.3",
-    "@searchkit/sdk": "^3.0.0",
-    "cross-fetch": "^3.1.4"
+    "@searchkit/sdk": "^3.0.0"
   }
 }

--- a/packages/search-ui-engines-connector/package.json
+++ b/packages/search-ui-engines-connector/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "@elastic/search-ui-engines-connector",
+  "version": "1.18.3",
+  "description": "A Search UI connector for Engines",
+  "homepage": "https://docs.elastic.co/search-ui",
+  "license": "Apache-2.0",
+  "main": "lib/cjs/index.js",
+  "module": "lib/esm/index.js",
+  "types": "lib/esm/index.d.ts",
+  "sideEffects": false,
+  "directories": {
+    "lib": "lib",
+    "test": "__tests__"
+  },
+  "files": [
+    "lib"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/elastic/search-ui.git",
+    "directory": "packages/search-ui-engine-connector"
+  },
+  "scripts": {
+    "test-ci": "jest --runInBand",
+    "test": "jest",
+    "clean": "rimraf lib",
+    "watch-js": "./bin/watch-js",
+    "build-js": "./bin/build-js",
+    "prebuild": "node -p \"'export const LIB_VERSION = ' + JSON.stringify(require('./package.json').version) + ';'\" > src/version.ts",
+    "build": "npm run clean && npm run build-js",
+    "watch": "npm run build && npm run watch-js",
+    "prepare": "npm run build"
+  },
+  "bugs": {
+    "url": "https://github.com/elastic/search-ui/issues"
+  },
+  "devDependencies": {
+    "rimraf": "^2.6.3",
+    "typescript": "^4.5.4",
+    "nock": "^13.3.0"
+  },
+  "dependencies": {
+    "@elastic/elasticsearch": "^8.6.0",
+    "@elastic/search-ui": "1.18.3",
+    "@searchkit/sdk": "^3.0.0",
+    "cross-fetch": "^3.1.4"
+  }
+}

--- a/packages/search-ui-engines-connector/src/handlers/__test__/transporter.test.ts
+++ b/packages/search-ui-engines-connector/src/handlers/__test__/transporter.test.ts
@@ -1,0 +1,53 @@
+import { EngineTransporter } from "../transporter";
+import nock from "nock";
+import type { SearchRequest, SearchResponse } from "../../types";
+import "cross-fetch/polyfill";
+
+describe("EngineTransporter", () => {
+  it("is a class", () => {
+    expect(typeof EngineTransporter).toEqual("function");
+  });
+
+  it("perform a request", () => {
+    const transporter = new EngineTransporter(
+      "http://localhost:9200",
+      "my_engine",
+      "apikey"
+    );
+
+    const body = {
+      query: {
+        match_all: {}
+      }
+    };
+
+    nock("http://localhost:9200", {
+      reqheaders: {
+        authorization: "ApiKey apikey"
+      }
+    })
+      .post("/api/engines/my_engine/_search")
+      .reply(200, () => ({
+        hits: {
+          hits: [
+            {
+              _id: "1",
+              _source: {
+                title: "My title"
+              }
+            }
+          ]
+        }
+      }));
+
+    return transporter
+      .performRequest({
+        body
+      } as SearchRequest)
+      .then((response: SearchResponse) => {
+        expect(response.hits.hits).toHaveLength(1);
+        expect(response.hits.hits[0]._id).toEqual("1");
+        expect(response.hits.hits[0]._source.title).toEqual("My title");
+      });
+  });
+});

--- a/packages/search-ui-engines-connector/src/handlers/autocomplete/__tests__/index.test.ts
+++ b/packages/search-ui-engines-connector/src/handlers/autocomplete/__tests__/index.test.ts
@@ -1,0 +1,172 @@
+import type { AutocompleteQueryConfig, RequestState } from "@elastic/search-ui";
+import Searchkit from "@searchkit/sdk";
+import handleRequest from "../index";
+
+const mockSearchkitResponse = [
+  {
+    identifier: "suggestions-completion-results",
+    suggestions: ["sweaters", "sweatpants"]
+  },
+  {
+    identifier: "suggestions-hits-popularQueries",
+    hits: [
+      {
+        id: "acadia",
+        fields: {
+          query: "hello"
+        },
+        highlight: {
+          query: "hello"
+        },
+        rawHit: {
+          _id: "test"
+        }
+      }
+    ]
+  },
+  {
+    identifier: "hits-suggestions",
+    hits: [
+      {
+        id: "test",
+        fields: {
+          title: "hello",
+          description: "test"
+        },
+        highlight: {
+          title: "hello"
+        },
+        rawHit: {
+          _id: "test"
+        }
+      }
+    ]
+  }
+];
+
+jest.mock("@searchkit/sdk", () => {
+  const originalModule = jest.requireActual("@searchkit/sdk");
+  return {
+    __esModule: true, // Use it when dealing with esModules
+    ...originalModule,
+    default: jest.fn((config) => {
+      const sk = originalModule.default(config);
+      sk.executeSuggestions = jest.fn(() => mockSearchkitResponse);
+      return sk;
+    })
+  };
+});
+
+const state: RequestState = {
+  searchTerm: "test"
+};
+const queryConfig: AutocompleteQueryConfig = {
+  results: {
+    resultsPerPage: 5,
+    search_fields: {
+      title: {
+        weight: 2
+      }
+    },
+    result_fields: {
+      title: {
+        snippet: {
+          size: 100,
+          fallback: true
+        }
+      },
+      nps_link: {
+        raw: {}
+      }
+    }
+  },
+  suggestions: {
+    types: {
+      results: {
+        fields: ["title"]
+      },
+      popularQueries: {
+        queryType: "results",
+        search_fields: {
+          title: {}
+        },
+        result_fields: {
+          title: {
+            raw: {}
+          }
+        }
+      }
+    }
+  }
+};
+
+describe("Autocomplete results", () => {
+  it("success", async () => {
+    const results = await handleRequest({
+      state,
+      queryConfig,
+      host: "http://localhost:9200",
+      engineName: "test",
+      apiKey: "test"
+    });
+
+    const searchkitRequestInstance = (Searchkit as jest.Mock).mock.results[0]
+      .value;
+    expect(searchkitRequestInstance.executeSuggestions).toBeCalledWith("test");
+
+    expect(results).toMatchInlineSnapshot(`
+      Object {
+        "autocompletedResults": Array [
+          Object {
+            "_meta": Object {
+              "id": "test",
+              "rawHit": Object {
+                "_id": "test",
+              },
+            },
+            "description": Object {
+              "raw": "test",
+            },
+            "id": Object {
+              "raw": "test",
+            },
+            "title": Object {
+              "raw": "hello",
+              "snippet": "hello",
+            },
+          },
+        ],
+        "autocompletedSuggestions": Object {
+          "popularQueries": Array [
+            Object {
+              "queryType": "results",
+              "result": Object {
+                "_meta": Object {
+                  "id": "test",
+                  "rawHit": Object {
+                    "_id": "test",
+                  },
+                },
+                "id": Object {
+                  "raw": "acadia",
+                },
+                "query": Object {
+                  "raw": "hello",
+                  "snippet": "hello",
+                },
+              },
+            },
+          ],
+          "results": Array [
+            Object {
+              "suggestion": "sweaters",
+            },
+            Object {
+              "suggestion": "sweatpants",
+            },
+          ],
+        },
+      }
+    `);
+  });
+});

--- a/packages/search-ui-engines-connector/src/handlers/autocomplete/index.ts
+++ b/packages/search-ui-engines-connector/src/handlers/autocomplete/index.ts
@@ -102,21 +102,21 @@ export default async function handleRequest(
   ).executeSuggestions(state.searchTerm);
 
   const results: AutocompleteResponseState = response.reduce(
-    (sum, suggestion) => {
+    (acc, suggestion) => {
       const { identifier } = suggestion;
 
       if (identifier === "hits-suggestions") {
         return {
-          ...sum,
+          ...acc,
           autocompletedResults: suggestion.hits.map(fieldResponseMapper)
         };
       } else if (identifier.startsWith("suggestions-completion-")) {
         const name = identifier.replace("suggestions-completion-", "");
 
         return {
-          ...sum,
+          ...acc,
           autocompletedSuggestions: {
-            ...sum.autocompletedSuggestions,
+            ...acc.autocompletedSuggestions,
             [name]: suggestion.suggestions.map((suggestion) => {
               return {
                 suggestion: suggestion
@@ -130,9 +130,9 @@ export default async function handleRequest(
           name
         ] as ResultSuggestionConfiguration;
         return {
-          ...sum,
+          ...acc,
           autocompletedSuggestions: {
-            ...sum.autocompletedSuggestions,
+            ...acc.autocompletedSuggestions,
             [name]: suggestion.hits.map((hit) => ({
               queryType: config.queryType,
               result: fieldResponseMapper(hit)

--- a/packages/search-ui-engines-connector/src/handlers/autocomplete/index.ts
+++ b/packages/search-ui-engines-connector/src/handlers/autocomplete/index.ts
@@ -1,0 +1,150 @@
+import type {
+  AutocompleteQueryConfig,
+  AutocompleteResponseState,
+  RequestState,
+  ResultSuggestionConfiguration
+} from "@elastic/search-ui";
+import Searchkit, {
+  CompletionSuggester,
+  HitsSuggestor,
+  PrefixQuery,
+  SearchkitConfig
+} from "@searchkit/sdk";
+import { fieldResponseMapper } from "../common";
+import { getQueryFields, getResultFields } from "../search/Configuration";
+import { EngineTransporter } from "../transporter";
+
+interface AutocompleteHandlerConfiguration {
+  state: RequestState;
+  queryConfig: AutocompleteQueryConfig;
+  host: string;
+  engineName: string;
+  apiKey: string;
+}
+
+export default async function handleRequest(
+  configuration: AutocompleteHandlerConfiguration
+): Promise<AutocompleteResponseState> {
+  const { state, queryConfig, host, engineName, apiKey } = configuration;
+
+  const suggestionConfigurations = [];
+
+  if (queryConfig.results) {
+    const { hitFields, highlightFields } = getResultFields(
+      queryConfig.results.result_fields
+    );
+    const queryFields = getQueryFields(queryConfig.results.search_fields);
+
+    suggestionConfigurations.push(
+      new HitsSuggestor({
+        identifier: "hits-suggestions",
+        hits: {
+          fields: hitFields,
+          highlightedFields: highlightFields
+        },
+        query: new PrefixQuery({ fields: queryFields }),
+        size: queryConfig.results.resultsPerPage || 5
+      })
+    );
+  }
+
+  if (queryConfig.suggestions && queryConfig.suggestions.types) {
+    const configs = Object.keys(queryConfig.suggestions.types).map((type) => {
+      const configuration = queryConfig.suggestions.types[type];
+      const suggestionsSize = queryConfig.suggestions.size || 5;
+
+      if (configuration.queryType === "results") {
+        const { hitFields, highlightFields } = getResultFields(
+          configuration.result_fields
+        );
+        const queryFields = getQueryFields(configuration.search_fields);
+
+        return new HitsSuggestor({
+          identifier: `suggestions-hits-${type}`,
+          index: configuration.index,
+          hits: {
+            fields: hitFields,
+            highlightedFields: highlightFields
+          },
+          query: new PrefixQuery({ fields: queryFields }),
+          size: suggestionsSize
+        });
+      } else if (
+        !configuration.queryType ||
+        configuration.queryType === "suggestions"
+      ) {
+        const { fields } = configuration;
+
+        return new CompletionSuggester({
+          identifier: `suggestions-completion-${type}`,
+          field: fields[0],
+          size: suggestionsSize
+        });
+      }
+    });
+    suggestionConfigurations.push(...configs);
+  }
+
+  const searchkitConfig: SearchkitConfig = {
+    host,
+    index: engineName,
+    connectionOptions: {
+      apiKey
+    },
+    suggestions: suggestionConfigurations
+  };
+
+  const transporter = new EngineTransporter(host, engineName, apiKey);
+
+  const response = await Searchkit(
+    searchkitConfig,
+    transporter
+  ).executeSuggestions(state.searchTerm);
+
+  const results: AutocompleteResponseState = response.reduce(
+    (sum, suggestion) => {
+      const { identifier } = suggestion;
+
+      if (identifier === "hits-suggestions") {
+        return {
+          ...sum,
+          autocompletedResults: suggestion.hits.map(fieldResponseMapper)
+        };
+      } else if (identifier.startsWith("suggestions-completion-")) {
+        const name = identifier.replace("suggestions-completion-", "");
+
+        return {
+          ...sum,
+          autocompletedSuggestions: {
+            ...sum.autocompletedSuggestions,
+            [name]: suggestion.suggestions.map((suggestion) => {
+              return {
+                suggestion: suggestion
+              };
+            })
+          }
+        };
+      } else if (identifier.startsWith("suggestions-hits-")) {
+        const name = identifier.replace("suggestions-hits-", "");
+        const config = queryConfig.suggestions.types[
+          name
+        ] as ResultSuggestionConfiguration;
+        return {
+          ...sum,
+          autocompletedSuggestions: {
+            ...sum.autocompletedSuggestions,
+            [name]: suggestion.hits.map((hit) => ({
+              queryType: config.queryType,
+              result: fieldResponseMapper(hit)
+            }))
+          }
+        };
+      }
+    },
+    {
+      autocompletedSuggestions: {}
+    }
+  );
+
+  return results;
+}

--- a/packages/search-ui-engines-connector/src/handlers/common.ts
+++ b/packages/search-ui-engines-connector/src/handlers/common.ts
@@ -1,0 +1,30 @@
+import type { AutocompletedResult, SearchResult } from "@elastic/search-ui";
+import { SearchkitHit } from "@searchkit/sdk";
+
+export function fieldResponseMapper(
+  item: SearchkitHit
+): SearchResult | AutocompletedResult {
+  const fields = item.fields;
+  const highlights = item.highlight || {};
+  const combinedFieldKeys = [
+    ...new Set(Object.keys(fields).concat(Object.keys(highlights)))
+  ];
+  return combinedFieldKeys.reduce(
+    (acc, key) => {
+      return {
+        ...acc,
+        [key]: {
+          ...(fields[key] ? { raw: fields[key] } : {}),
+          ...(highlights[key] ? { snippet: highlights[key] } : {})
+        }
+      };
+    },
+    {
+      id: { raw: item.id },
+      _meta: {
+        id: item.rawHit._id,
+        rawHit: item.rawHit
+      }
+    }
+  );
+}

--- a/packages/search-ui-engines-connector/src/handlers/search/Configuration.ts
+++ b/packages/search-ui-engines-connector/src/handlers/search/Configuration.ts
@@ -1,0 +1,256 @@
+import type {
+  FieldConfiguration,
+  Filter,
+  FilterValue,
+  FilterValueRange,
+  QueryConfig,
+  RequestState,
+  SearchFieldConfiguration
+} from "@elastic/search-ui";
+import {
+  BaseFilter,
+  BaseFilters,
+  Filter as SKFilter,
+  GeoDistanceOptionsFacet,
+  MultiMatchQuery,
+  MultiQueryOptionsFacet,
+  RefinementSelectFacet,
+  SearchkitConfig
+} from "@searchkit/sdk";
+import { LIB_VERSION } from "../../version";
+import { EngineQuery } from "./Query";
+
+export function getResultFields(
+  resultFields: Record<string, FieldConfiguration>
+): {
+  hitFields: string[];
+  highlightFields: string[];
+} {
+  const hitFields = Object.keys(resultFields);
+
+  const highlightFields = Object.keys(resultFields).reduce((sum, fieldKey) => {
+    const fieldConfiguration = resultFields[fieldKey];
+    if (fieldConfiguration.snippet) {
+      sum.push(fieldKey);
+    }
+    return sum;
+  }, []);
+
+  return { hitFields, highlightFields };
+}
+
+export function getQueryFields(
+  searchFields: Record<string, SearchFieldConfiguration> = {}
+): string[] {
+  return Object.keys(searchFields).map((fieldKey) => {
+    const fieldConfiguration = searchFields[fieldKey];
+    const weight = `^${fieldConfiguration.weight || 1}`;
+    return fieldKey + weight;
+  });
+}
+
+export function isValidDateString(dateString: unknown): boolean {
+  return typeof dateString === "string" && !isNaN(Date.parse(dateString));
+}
+
+export function isRangeFilter(
+  filterValue: FilterValue
+): filterValue is FilterValueRange {
+  return (
+    typeof filterValue === "object" &&
+    ("from" in filterValue || "to" in filterValue)
+  );
+}
+
+export function buildBaseFilters(baseFilters: Filter[]): BaseFilters {
+  const filters = (baseFilters || []).reduce((sum, filter) => {
+    const boolType = {
+      all: "filter",
+      any: "should",
+      none: "must_not"
+    }[filter.type];
+    return [
+      ...sum,
+      {
+        bool: {
+          [boolType]: filter.values.map((value: FilterValue) => {
+            if (isRangeFilter(value)) {
+              return {
+                range: {
+                  [filter.field]: {
+                    ...("from" in value
+                      ? {
+                          from: isValidDateString(value.from)
+                            ? value.from
+                            : Number(value.from)
+                        }
+                      : {}),
+                    ...("to" in value
+                      ? {
+                          to: isValidDateString(value.to)
+                            ? value.to
+                            : Number(value.to)
+                        }
+                      : {})
+                  }
+                }
+              };
+            }
+            return {
+              term: {
+                [filter.field]: value
+              }
+            };
+          })
+        }
+      }
+    ];
+  }, []);
+
+  return filters;
+}
+
+interface BuildConfigurationOptions {
+  state: RequestState;
+  queryConfig: QueryConfig;
+  host?: string;
+  engineName: string;
+  apiKey?: string;
+}
+
+function buildConfiguration({
+  state,
+  queryConfig,
+  host,
+  engineName,
+  apiKey
+}: BuildConfigurationOptions): SearchkitConfig {
+  const { hitFields, highlightFields } = getResultFields(
+    queryConfig.result_fields
+  );
+
+  const queryFields = getQueryFields(queryConfig.search_fields);
+
+  const filtersConfig: BaseFilter[] = Object.values(
+    (state.filters || [])
+      .filter((f) => !queryConfig.facets[f.field]) //exclude all filters that are defined as facets
+      .reduce((sum, f) => {
+        return {
+          ...sum,
+          [f.field]: new SKFilter({
+            field: f.field,
+            identifier: f.field,
+            label: f.field
+          })
+        };
+      }, {})
+  );
+
+  const facets = Object.keys(queryConfig.facets || {}).reduce(
+    (sum, facetKey) => {
+      const facetConfiguration = queryConfig.facets[facetKey];
+      const isDisJunctive = queryConfig.disjunctiveFacets?.includes(facetKey);
+      if (facetConfiguration.type === "value") {
+        sum.push(
+          new RefinementSelectFacet({
+            identifier: facetKey,
+            field: facetKey,
+            label: facetKey,
+            size: facetConfiguration.size || 20,
+            multipleSelect: isDisJunctive,
+            order: facetConfiguration.sort || "count"
+          })
+        );
+      } else if (
+        facetConfiguration.type === "range" &&
+        !facetConfiguration.center
+      ) {
+        sum.push(
+          new MultiQueryOptionsFacet({
+            identifier: facetKey,
+            field: facetKey,
+            label: facetKey,
+            multipleSelect: isDisJunctive,
+            options: facetConfiguration.ranges.map((range) => {
+              return {
+                label: range.name,
+                ...(typeof range.from === "number" ? { min: range.from } : {}),
+                ...(typeof range.to === "number" ? { max: range.to } : {}),
+                ...(isValidDateString(range.from)
+                  ? { dateMin: range.from.toString() }
+                  : {}),
+                ...(isValidDateString(range.to)
+                  ? { dateMax: range.to.toString() }
+                  : {})
+              };
+            })
+          })
+        );
+      } else if (
+        facetConfiguration.type === "range" &&
+        facetConfiguration.center
+      ) {
+        sum.push(
+          new GeoDistanceOptionsFacet({
+            identifier: facetKey,
+            field: facetKey,
+            label: facetKey,
+            multipleSelect: isDisJunctive,
+            origin: facetConfiguration.center,
+            unit: facetConfiguration.unit,
+            ranges: facetConfiguration.ranges.map((range) => {
+              return {
+                label: range.name,
+                ...(range.from ? { from: Number(range.from) } : {}),
+                ...(range.to ? { to: Number(range.to) } : {})
+              };
+            })
+          })
+        );
+      }
+
+      return sum;
+    },
+    []
+  );
+
+  const sortOption =
+    state.sortList?.length > 0
+      ? {
+          id: "selectedOption",
+          label: "selectedOption",
+          field: state.sortList.reduce((acc, s) => {
+            acc.push({
+              [s.field]: s.direction
+            });
+            return acc;
+          }, [])
+        }
+      : { id: "selectedOption", label: "selectedOption", field: "_score" };
+
+  const jsVersion = typeof window !== "undefined" ? "browser" : process.version;
+  const metaHeader = `ent=${LIB_VERSION}-engines-connector,js=${jsVersion},t=${LIB_VERSION}-engines-connector,ft=universal`;
+
+  const configuration: SearchkitConfig = {
+    host: host,
+    index: engineName,
+    connectionOptions: {
+      apiKey: apiKey,
+      headers: {
+        "x-elastic-client-meta": metaHeader
+      }
+    },
+    hits: {
+      fields: hitFields,
+      highlightedFields: highlightFields
+    },
+    query: EngineQuery(queryFields),
+    sortOptions: [sortOption],
+    facets,
+    filters: filtersConfig
+  };
+
+  return configuration;
+}
+
+export default buildConfiguration;

--- a/packages/search-ui-engines-connector/src/handlers/search/Configuration.ts
+++ b/packages/search-ui-engines-connector/src/handlers/search/Configuration.ts
@@ -28,12 +28,12 @@ export function getResultFields(
 } {
   const hitFields = Object.keys(resultFields);
 
-  const highlightFields = Object.keys(resultFields).reduce((sum, fieldKey) => {
+  const highlightFields = Object.keys(resultFields).reduce((acc, fieldKey) => {
     const fieldConfiguration = resultFields[fieldKey];
     if (fieldConfiguration.snippet) {
-      sum.push(fieldKey);
+      acc.push(fieldKey);
     }
-    return sum;
+    return acc;
   }, []);
 
   return { hitFields, highlightFields };
@@ -63,14 +63,14 @@ export function isRangeFilter(
 }
 
 export function buildBaseFilters(baseFilters: Filter[]): BaseFilters {
-  const filters = (baseFilters || []).reduce((sum, filter) => {
+  const filters = (baseFilters || []).reduce((acc, filter) => {
     const boolType = {
       all: "filter",
       any: "should",
       none: "must_not"
     }[filter.type];
     return [
-      ...sum,
+      ...acc,
       {
         bool: {
           [boolType]: filter.values.map((value: FilterValue) => {
@@ -134,9 +134,9 @@ function buildConfiguration({
   const filtersConfig: BaseFilter[] = Object.values(
     (state.filters || [])
       .filter((f) => !queryConfig.facets[f.field]) //exclude all filters that are defined as facets
-      .reduce((sum, f) => {
+      .reduce((acc, f) => {
         return {
-          ...sum,
+          ...acc,
           [f.field]: new SKFilter({
             field: f.field,
             identifier: f.field,
@@ -147,11 +147,11 @@ function buildConfiguration({
   );
 
   const facets = Object.keys(queryConfig.facets || {}).reduce(
-    (sum, facetKey) => {
+    (acc, facetKey) => {
       const facetConfiguration = queryConfig.facets[facetKey];
       const isDisJunctive = queryConfig.disjunctiveFacets?.includes(facetKey);
       if (facetConfiguration.type === "value") {
-        sum.push(
+        acc.push(
           new RefinementSelectFacet({
             identifier: facetKey,
             field: facetKey,
@@ -165,7 +165,7 @@ function buildConfiguration({
         facetConfiguration.type === "range" &&
         !facetConfiguration.center
       ) {
-        sum.push(
+        acc.push(
           new MultiQueryOptionsFacet({
             identifier: facetKey,
             field: facetKey,
@@ -190,7 +190,7 @@ function buildConfiguration({
         facetConfiguration.type === "range" &&
         facetConfiguration.center
       ) {
-        sum.push(
+        acc.push(
           new GeoDistanceOptionsFacet({
             identifier: facetKey,
             field: facetKey,
@@ -209,7 +209,7 @@ function buildConfiguration({
         );
       }
 
-      return sum;
+      return acc;
     },
     []
   );

--- a/packages/search-ui-engines-connector/src/handlers/search/Query.ts
+++ b/packages/search-ui-engines-connector/src/handlers/search/Query.ts
@@ -1,0 +1,19 @@
+import { CustomQuery } from "@searchkit/sdk";
+
+export const EngineQuery = (fields) =>
+  new CustomQuery({
+    queryFn: (query) => {
+      return {
+        bool: {
+          must: [
+            {
+              combined_fields: {
+                query: query,
+                fields: fields
+              }
+            }
+          ]
+        }
+      };
+    }
+  });

--- a/packages/search-ui-engines-connector/src/handlers/search/Request.ts
+++ b/packages/search-ui-engines-connector/src/handlers/search/Request.ts
@@ -16,7 +16,7 @@ export function getFilters(
   baseFilters: Filter[] = []
 ): MixedFilter[] {
   return filters.reduce((acc, f) => {
-    const isBaseFilter = baseFilters.find((bf) => bf === f);
+    const isBaseFilter = baseFilters.includes(f);
     if (isBaseFilter) return acc;
 
     const subFilters = f.values.map((v) => {

--- a/packages/search-ui-engines-connector/src/handlers/search/Request.ts
+++ b/packages/search-ui-engines-connector/src/handlers/search/Request.ts
@@ -1,0 +1,58 @@
+import type { Filter, QueryConfig, RequestState } from "@elastic/search-ui";
+import { MixedFilter } from "@searchkit/sdk";
+import { helpers } from "@elastic/search-ui";
+import { isValidDateString } from "./Configuration";
+
+export interface SearchkitVariables {
+  query: string;
+  filters: MixedFilter[];
+  from: number;
+  size: number;
+  sort: string;
+}
+
+export function getFilters(
+  filters: Filter[] = [],
+  baseFilters: Filter[] = []
+): MixedFilter[] {
+  return filters.reduce((acc, f) => {
+    const isBaseFilter = baseFilters.find((bf) => bf === f);
+    if (isBaseFilter) return acc;
+
+    const subFilters = f.values.map((v) => {
+      if (helpers.isFilterValueRange(v)) {
+        return {
+          identifier: f.field,
+          ...(isValidDateString(v.from)
+            ? { dateMin: v.from }
+            : { min: v.from }),
+          ...(isValidDateString(v.to) ? { dateMax: v.to } : { max: v.to })
+        };
+      }
+
+      return {
+        identifier: f.field,
+        value: v
+      };
+    });
+
+    return [...acc, ...subFilters];
+  }, []);
+}
+
+function SearchRequest(
+  state: RequestState,
+  queryConfig: QueryConfig
+): SearchkitVariables {
+  return {
+    query: state.searchTerm,
+    filters: state.filters
+      ? getFilters(state.filters, queryConfig.filters)
+      : [],
+    from: (state.current - 1) * state.resultsPerPage,
+    size: state.resultsPerPage,
+    sort: state.sortList?.length > 0 ? "selectedOption" : null
+  };
+}
+
+export default SearchRequest;

--- a/packages/search-ui-engines-connector/src/handlers/search/Response.ts
+++ b/packages/search-ui-engines-connector/src/handlers/search/Response.ts
@@ -1,0 +1,39 @@
+import type { ResponseState } from "@elastic/search-ui";
+import { SearchkitResponse } from "@searchkit/sdk";
+import { fieldResponseMapper } from "../common";
+
+function SearchResponse(results: SearchkitResponse): ResponseState {
+  const facets = (results.facets || []).reduce((acc, facet) => {
+    return {
+      ...acc,
+      [facet.identifier]: [
+        {
+          data: facet.entries.map((e) => ({
+            value: e.label,
+            count: e.count
+          })),
+          type: "value"
+        }
+      ]
+    };
+  }, {});
+
+  const pageEnd = (results.hits.page.pageNumber + 1) * results.hits.page.size;
+
+  const response: ResponseState = {
+    resultSearchTerm: results.summary.query,
+    totalPages: results.hits.page.totalPages,
+    pagingStart: results.hits.page.pageNumber * results.hits.page.size + 1,
+    pagingEnd:
+      pageEnd > results.summary.total ? results.summary.total : pageEnd,
+    wasSearched: false,
+    totalResults: results.summary.total,
+    facets,
+    results: results.hits.items.map(fieldResponseMapper),
+    requestId: null,
+    rawResponse: null
+  };
+  return response;
+}
+
+export default SearchResponse;

--- a/packages/search-ui-engines-connector/src/handlers/search/__tests__/Configuration.node.test.ts
+++ b/packages/search-ui-engines-connector/src/handlers/search/__tests__/Configuration.node.test.ts
@@ -1,0 +1,76 @@
+/**
+ * @jest-environment node
+ */
+
+import type { QueryConfig, RequestState } from "@elastic/search-ui";
+import buildConfiguration from "../Configuration";
+jest.mock("@searchkit/sdk");
+
+import { LIB_VERSION } from "../../../version";
+
+describe("Search - Configuration within node context", () => {
+  describe("buildConfiguration", () => {
+    const queryConfig: QueryConfig = {
+      search_fields: {
+        title: {
+          weight: 2
+        },
+        description: {}
+      },
+      result_fields: {
+        title: {
+          snippet: {}
+        },
+        description: {
+          snippet: {}
+        },
+        url: {
+          raw: {}
+        }
+      },
+      facets: {
+        category: {
+          type: "value",
+          size: 20
+        },
+        type: {
+          type: "value",
+          size: 20,
+          sort: "value"
+        }
+      },
+      disjunctiveFacets: ["category"]
+    };
+    const host = "http://localhost:9200";
+    const index = "test_index";
+    const apiKey = "apiKey";
+
+    it("builds configuration", () => {
+      const state: RequestState = {
+        searchTerm: "test"
+      };
+
+      const nodeVersion = process.version;
+      const configuration = buildConfiguration({
+        state,
+        queryConfig,
+        host,
+        engineName: index,
+        apiKey
+      });
+
+      const validHeaderRegex =
+        // eslint-disable-next-line no-useless-escape
+        /^[a-z]{1,}=[a-z0-9\.\-]{1,}(?:,[a-z]{1,}=[a-z0-9\.\-]+)*$/;
+      expect(
+        configuration.connectionOptions.headers["x-elastic-client-meta"]
+      ).toMatch(validHeaderRegex);
+
+      expect(
+        configuration.connectionOptions.headers["x-elastic-client-meta"]
+      ).toEqual(
+        `ent=${LIB_VERSION}-engines-connector,js=${nodeVersion},t=${LIB_VERSION}-engines-connector,ft=universal`
+      );
+    });
+  });
+});

--- a/packages/search-ui-engines-connector/src/handlers/search/__tests__/Configuration.test.ts
+++ b/packages/search-ui-engines-connector/src/handlers/search/__tests__/Configuration.test.ts
@@ -1,0 +1,511 @@
+import type {
+  FieldConfiguration,
+  QueryConfig,
+  RequestState
+} from "@elastic/search-ui";
+import buildConfiguration, {
+  buildBaseFilters,
+  getResultFields
+} from "../Configuration";
+jest.mock("@searchkit/sdk");
+import {
+  RefinementSelectFacet,
+  MultiQueryOptionsFacet,
+  GeoDistanceOptionsFacet,
+  Filter
+} from "@searchkit/sdk";
+
+import { EngineQuery } from "../Query";
+
+jest.mock("../Query", () => {
+  return {
+    EngineQuery: jest.fn()
+  };
+});
+
+import { LIB_VERSION } from "../../../version";
+
+describe("Search - Configuration", () => {
+  describe("getResultFields", () => {
+    it("empty configuration", () => {
+      const resultFields: Record<string, FieldConfiguration> = {};
+
+      expect(getResultFields(resultFields)).toEqual({
+        hitFields: [],
+        highlightFields: []
+      });
+    });
+
+    it("group fields by configuration", () => {
+      const resultFields: Record<string, FieldConfiguration> = {
+        title: {
+          raw: {},
+          snippet: {}
+        },
+        description: {
+          snippet: {}
+        },
+        url: {
+          raw: {}
+        }
+      };
+
+      expect(getResultFields(resultFields)).toEqual({
+        hitFields: ["title", "description", "url"],
+        highlightFields: ["title", "description"]
+      });
+    });
+  });
+
+  it("buildBaseFilters", () => {
+    const queryConfig: QueryConfig = {
+      filters: [
+        {
+          field: "provider.id.keyword",
+          type: "any",
+          values: [
+            "00000174-b680-e5d9-b8fb-15ae80000000",
+            "0000014d-91eb-0b07-8ac7-287f80000000"
+          ]
+        },
+        {
+          field: "kind.keyword",
+          type: "none",
+          values: ["Instrument", "Watercraft"]
+        },
+        {
+          field: "attribute_facets.keyword",
+          type: "all",
+          values: ["Part of Collection", "Access Restriction(s)"]
+        },
+        {
+          field: "rangeFilterExample",
+          type: "all",
+          values: [
+            {
+              from: 0,
+              to: 1000,
+              name: "Small"
+            }
+          ]
+        }
+      ]
+    };
+
+    expect(buildBaseFilters(queryConfig.filters)).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "bool": Object {
+            "should": Array [
+              Object {
+                "term": Object {
+                  "provider.id.keyword": "00000174-b680-e5d9-b8fb-15ae80000000",
+                },
+              },
+              Object {
+                "term": Object {
+                  "provider.id.keyword": "0000014d-91eb-0b07-8ac7-287f80000000",
+                },
+              },
+            ],
+          },
+        },
+        Object {
+          "bool": Object {
+            "must_not": Array [
+              Object {
+                "term": Object {
+                  "kind.keyword": "Instrument",
+                },
+              },
+              Object {
+                "term": Object {
+                  "kind.keyword": "Watercraft",
+                },
+              },
+            ],
+          },
+        },
+        Object {
+          "bool": Object {
+            "filter": Array [
+              Object {
+                "term": Object {
+                  "attribute_facets.keyword": "Part of Collection",
+                },
+              },
+              Object {
+                "term": Object {
+                  "attribute_facets.keyword": "Access Restriction(s)",
+                },
+              },
+            ],
+          },
+        },
+        Object {
+          "bool": Object {
+            "filter": Array [
+              Object {
+                "range": Object {
+                  "rangeFilterExample": Object {
+                    "from": 0,
+                    "to": 1000,
+                  },
+                },
+              },
+            ],
+          },
+        },
+      ]
+    `);
+
+    expect(buildBaseFilters(undefined)).toEqual([]);
+  });
+
+  describe("buildConfiguration", () => {
+    const queryConfig: QueryConfig = {
+      search_fields: {
+        title: {
+          weight: 2
+        },
+        description: {}
+      },
+      result_fields: {
+        title: {
+          snippet: {}
+        },
+        description: {
+          snippet: {}
+        },
+        url: {
+          raw: {}
+        }
+      },
+      facets: {
+        category: {
+          type: "value",
+          size: 20
+        },
+        type: {
+          type: "value",
+          size: 20,
+          sort: "value"
+        }
+      },
+      disjunctiveFacets: ["category"],
+      filters: [
+        {
+          field: "provider.id.keyword",
+          type: "any",
+          values: [
+            "00000174-b680-e5d9-b8fb-15ae80000000",
+            "0000014d-91eb-0b07-8ac7-287f80000000"
+          ]
+        },
+        {
+          field: "kind.keyword",
+          type: "none",
+          values: ["Instrument", "Watercraft"]
+        },
+        {
+          field: "attribute_facets.keyword",
+          type: "all",
+          values: ["Part of Collection", "Access Restriction(s)"]
+        }
+      ]
+    };
+    const host = "http://localhost:9200";
+    const index = "test_index";
+    const apiKey = "apiKey";
+
+    it("builds configuration", () => {
+      const state: RequestState = {
+        searchTerm: "test",
+        filters: [
+          {
+            field: "providerid.keyword",
+            values: [
+              {
+                name: "precio",
+                from: 10,
+                to: 100
+              }
+            ],
+            type: "all"
+          },
+          {
+            field: "date.keyword",
+            values: [
+              {
+                name: "date",
+                from: "2021-01-01"
+              }
+            ],
+            type: "all"
+          }
+        ]
+      };
+      const x = buildConfiguration({
+        state,
+        queryConfig,
+        host,
+        engineName: index,
+        apiKey
+      });
+      expect(x).toEqual(
+        expect.objectContaining({
+          host: "http://localhost:9200",
+          index: "test_index",
+          connectionOptions: {
+            apiKey: "apiKey",
+            headers: {
+              "x-elastic-client-meta": `ent=${LIB_VERSION}-engines-connector,js=browser,t=${LIB_VERSION}-engines-connector,ft=universal`
+            }
+          },
+          hits: {
+            fields: ["title", "description", "url"],
+            highlightedFields: ["title", "description"]
+          }
+        })
+      );
+
+      expect(EngineQuery).toHaveBeenCalledWith(["title^2", "description^1"]);
+
+      expect(RefinementSelectFacet).toHaveBeenCalledTimes(2);
+      expect(RefinementSelectFacet).toHaveBeenCalledWith({
+        identifier: "category",
+        field: "category",
+        label: "category",
+        size: 20,
+        multipleSelect: true,
+        order: "count"
+      });
+      expect(RefinementSelectFacet).toHaveBeenCalledWith({
+        identifier: "type",
+        field: "type",
+        label: "type",
+        size: 20,
+        multipleSelect: false,
+        order: "value"
+      });
+      expect(Filter).toHaveBeenCalledWith({
+        field: "providerid.keyword",
+        identifier: "providerid.keyword",
+        label: "providerid.keyword"
+      });
+      expect(Filter).toHaveBeenCalledWith({
+        field: "date.keyword",
+        identifier: "date.keyword",
+        label: "date.keyword"
+      });
+      expect(Filter).toBeCalledTimes(2);
+    });
+
+    it("works without facet configuration", () => {
+      const state: RequestState = {
+        searchTerm: "test"
+      };
+
+      expect(
+        buildConfiguration({
+          state,
+          queryConfig: { ...queryConfig, facets: null },
+          host,
+          engineName: index,
+          apiKey
+        })
+      ).toEqual(
+        expect.objectContaining({
+          host: "http://localhost:9200",
+          index: "test_index",
+          connectionOptions: {
+            apiKey: "apiKey",
+            headers: {
+              "x-elastic-client-meta": `ent=${LIB_VERSION}-engines-connector,js=browser,t=${LIB_VERSION}-engines-connector,ft=universal`
+            }
+          },
+          hits: {
+            fields: ["title", "description", "url"],
+            highlightedFields: ["title", "description"]
+          }
+        })
+      );
+
+      expect(EngineQuery).toHaveBeenCalledWith(["title^2", "description^1"]);
+
+      expect(RefinementSelectFacet).toHaveBeenCalledTimes(2);
+      expect(RefinementSelectFacet).toHaveBeenCalledWith({
+        identifier: "category",
+        field: "category",
+        label: "category",
+        size: 20,
+        multipleSelect: true,
+        order: "count"
+      });
+      expect(RefinementSelectFacet).toHaveBeenCalledWith({
+        identifier: "type",
+        field: "type",
+        label: "type",
+        size: 20,
+        multipleSelect: false,
+        order: "value"
+      });
+    });
+
+    it("Range facets Configuration", () => {
+      const state: RequestState = {
+        searchTerm: "test"
+      };
+
+      const configuration = buildConfiguration({
+        state,
+        queryConfig: {
+          ...queryConfig,
+          disjunctiveFacets: [
+            ...queryConfig.disjunctiveFacets,
+            "date_established"
+          ],
+          facets: {
+            acres: {
+              type: "range",
+              ranges: [
+                { from: -1, name: "Any" },
+                { from: 0, to: 1000, name: "Small" },
+                { from: 1001, to: 100000, name: "Medium" },
+                { from: 100001, name: "Large" }
+              ]
+            },
+            location: {
+              center: "37.7749, -122.4194",
+              type: "range",
+              unit: "mi",
+              ranges: [
+                { from: 0, to: 100, name: "Nearby" },
+                { from: 100, to: 500, name: "A longer drive" },
+                { from: 500, name: "Perhaps fly?" }
+              ]
+            },
+            date_established: {
+              type: "range",
+              ranges: [
+                {
+                  from: "1952-03-14T10:34:22.464Z",
+                  name: "Within the last 50 years"
+                },
+                {
+                  from: "1922-03-14T10:34:22.464Z",
+                  to: "1952-03-14T10:34:22.464Z",
+                  name: "50 - 100 years ago"
+                },
+                {
+                  to: "1922-03-14T10:34:22.464Z",
+                  name: "More than 100 years ago"
+                }
+              ]
+            }
+          }
+        },
+        host,
+        engineName: index,
+        apiKey
+      });
+
+      expect(configuration).toEqual(
+        expect.objectContaining({
+          host: "http://localhost:9200",
+          index: "test_index",
+          connectionOptions: {
+            apiKey: "apiKey",
+            headers: {
+              "x-elastic-client-meta": `ent=${LIB_VERSION}-engines-connector,js=browser,t=${LIB_VERSION}-engines-connector,ft=universal`
+            }
+          },
+          hits: {
+            fields: ["title", "description", "url"],
+            highlightedFields: ["title", "description"]
+          }
+        })
+      );
+
+      const validHeaderRegex =
+        // eslint-disable-next-line no-useless-escape
+        /^[a-z]{1,}=[a-z0-9\.\-]{1,}(?:,[a-z]{1,}=[a-z0-9\.\-]+)*$/;
+      expect(
+        configuration.connectionOptions.headers["x-elastic-client-meta"]
+      ).toMatch(validHeaderRegex);
+
+      expect(GeoDistanceOptionsFacet).toHaveBeenCalledTimes(1);
+      expect(GeoDistanceOptionsFacet).toHaveBeenCalledWith({
+        field: "location",
+        identifier: "location",
+        label: "location",
+        multipleSelect: false,
+        origin: "37.7749, -122.4194",
+        ranges: [
+          {
+            label: "Nearby",
+            to: 100
+          },
+          {
+            from: 100,
+            label: "A longer drive",
+            to: 500
+          },
+          {
+            from: 500,
+            label: "Perhaps fly?"
+          }
+        ],
+        unit: "mi"
+      });
+      expect(MultiQueryOptionsFacet).toHaveBeenCalledTimes(2);
+      expect(MultiQueryOptionsFacet).toHaveBeenCalledWith({
+        field: "acres",
+        identifier: "acres",
+        label: "acres",
+        multipleSelect: false,
+        options: [
+          {
+            label: "Any",
+            min: -1
+          },
+          {
+            label: "Small",
+            max: 1000,
+            min: 0
+          },
+          {
+            label: "Medium",
+            max: 100000,
+            min: 1001
+          },
+          {
+            label: "Large",
+            min: 100001
+          }
+        ]
+      });
+      expect(MultiQueryOptionsFacet).toHaveBeenCalledWith({
+        field: "date_established",
+        identifier: "date_established",
+        label: "date_established",
+        multipleSelect: true,
+        options: [
+          {
+            dateMin: "1952-03-14T10:34:22.464Z",
+            label: "Within the last 50 years"
+          },
+          {
+            dateMax: "1952-03-14T10:34:22.464Z",
+            dateMin: "1922-03-14T10:34:22.464Z",
+            label: "50 - 100 years ago"
+          },
+          {
+            dateMax: "1922-03-14T10:34:22.464Z",
+            label: "More than 100 years ago"
+          }
+        ]
+      });
+    });
+  });
+});

--- a/packages/search-ui-engines-connector/src/handlers/search/__tests__/Request.test.ts
+++ b/packages/search-ui-engines-connector/src/handlers/search/__tests__/Request.test.ts
@@ -1,0 +1,181 @@
+import type { QueryConfig, RequestState } from "@elastic/search-ui";
+import SearchRequest, { getFilters } from "../Request";
+import { helpers } from "@elastic/search-ui";
+import type { MixedFilter } from "@searchkit/sdk";
+
+describe("Search - Request", () => {
+  const requestState: RequestState = {
+    searchTerm: "test",
+    current: 1,
+    resultsPerPage: 10,
+    sortList: [{ field: "test", direction: "asc" }],
+    filters: [
+      {
+        field: "test",
+        values: ["test", "test2"],
+        type: "any"
+      }
+    ]
+  };
+
+  const queryConfig: QueryConfig = {};
+
+  it("should transform SearchUI RequestState into Searchkit State", () => {
+    expect(SearchRequest(requestState, queryConfig)).toEqual({
+      query: "test",
+      filters: [
+        {
+          identifier: "test",
+          value: "test"
+        },
+        {
+          identifier: "test",
+          value: "test2"
+        }
+      ],
+      from: 0,
+      size: 10,
+      sort: "selectedOption"
+    });
+  });
+
+  it("sort should be null when no sort option selected", () => {
+    expect(
+      SearchRequest(
+        {
+          ...requestState,
+          sortList: []
+        },
+        queryConfig
+      ).sort
+    ).toBeNull();
+  });
+
+  it("page from should be adjusted on second page", () => {
+    expect(
+      SearchRequest(
+        {
+          ...requestState,
+          resultsPerPage: 100,
+          current: 2 // second page
+        },
+        queryConfig
+      )
+    ).toEqual(
+      expect.objectContaining({
+        from: 100,
+        size: 100
+      })
+    );
+  });
+
+  describe("getFilters()", () => {
+    it("should return empty array when no filters", () => {
+      expect(getFilters([])).toEqual([]);
+    });
+
+    it("should return multiple searchkit filters", () => {
+      expect(
+        getFilters([
+          {
+            field: "test",
+            values: ["test", "test2"],
+            type: "any"
+          }
+        ])
+      ).toEqual([
+        {
+          identifier: "test",
+          value: "test"
+        },
+        {
+          identifier: "test",
+          value: "test2"
+        }
+      ]);
+    });
+
+    it("should handle range filters", () => {
+      expect(
+        getFilters([
+          {
+            field: "test",
+            values: [
+              {
+                name: "precio",
+                from: 10,
+                to: 100
+              }
+            ],
+            type: "any"
+          }
+        ])
+      ).toEqual([
+        {
+          identifier: "test",
+          min: 10,
+          max: 100
+        }
+      ] as MixedFilter[]);
+    });
+
+    it("should handle date range filters", () => {
+      expect(
+        getFilters([
+          {
+            field: "test",
+            values: [
+              {
+                name: "precio",
+                from: "2020-01-01"
+              }
+            ],
+            type: "any"
+          }
+        ])
+      ).toEqual([
+        {
+          identifier: "test",
+          dateMin: "2020-01-01"
+        }
+      ] as MixedFilter[]);
+    });
+
+    it("should return no searchkit filters when filter is part of basefilter", () => {
+      const filter1 = {
+        field: "test",
+        values: ["test", "test2"],
+        type: "any" as const
+      };
+
+      expect(getFilters([filter1], [filter1])).toEqual([]);
+    });
+
+    it("should exclude the baseFilters and return the only UI filter", () => {
+      const baseFilters = [
+        {
+          field: "test",
+          values: ["test", "test2"],
+          type: "any" as const
+        }
+      ];
+
+      const uiFilters = [
+        {
+          field: "test2",
+          values: ["test2", "test3"],
+          type: "any" as const
+        }
+      ];
+
+      // done at searchdriver level
+      const stateFilters = helpers.mergeFilters(uiFilters, baseFilters);
+
+      // verify getFilters exclude base filters
+      expect(getFilters(stateFilters, baseFilters)).toEqual([
+        { identifier: "test2", value: "test2" },
+        { identifier: "test2", value: "test3" }
+      ]);
+    });
+  });
+});

--- a/packages/search-ui-engines-connector/src/handlers/search/__tests__/Response.test.ts
+++ b/packages/search-ui-engines-connector/src/handlers/search/__tests__/Response.test.ts
@@ -1,0 +1,158 @@
+import type { ResponseState } from "@elastic/search-ui";
+import { SearchkitResponse } from "@searchkit/sdk";
+import SearchResponse from "../Response";
+
+describe("Search - Response", () => {
+  const searchkitResponse: SearchkitResponse = {
+    summary: {
+      query: "test",
+      total: 100,
+      appliedFilters: [],
+      disabledFilters: [],
+      sortOptions: []
+    },
+    hits: {
+      page: {
+        pageNumber: 0,
+        size: 10,
+        totalPages: 10,
+        total: 100,
+        from: 0
+      },
+      items: [
+        {
+          id: "test",
+          fields: {
+            title: "hello",
+            description: "test"
+          },
+          highlight: {
+            title: "hello",
+            fieldOnlyHighlight: "test"
+          },
+          rawHit: {
+            _id: "test"
+          }
+        }
+      ]
+    },
+    facets: [
+      {
+        identifier: "test",
+        display: "RefinementList",
+        label: "test",
+        type: "value",
+        entries: [
+          { label: "labeltest", count: 10 },
+          { label: "label2", count: 20 }
+        ]
+      }
+    ]
+  };
+
+  it("should transform Searchkit ResponseState into SearchUI ResponseState", () => {
+    const response: ResponseState = SearchResponse(searchkitResponse);
+
+    expect(response).toMatchInlineSnapshot(`
+      Object {
+        "facets": Object {
+          "test": Array [
+            Object {
+              "data": Array [
+                Object {
+                  "count": 10,
+                  "value": "labeltest",
+                },
+                Object {
+                  "count": 20,
+                  "value": "label2",
+                },
+              ],
+              "type": "value",
+            },
+          ],
+        },
+        "pagingEnd": 10,
+        "pagingStart": 1,
+        "rawResponse": null,
+        "requestId": null,
+        "resultSearchTerm": "test",
+        "results": Array [
+          Object {
+            "_meta": Object {
+              "id": "test",
+              "rawHit": Object {
+                "_id": "test",
+              },
+            },
+            "description": Object {
+              "raw": "test",
+            },
+            "fieldOnlyHighlight": Object {
+              "snippet": "test",
+            },
+            "id": Object {
+              "raw": "test",
+            },
+            "title": Object {
+              "raw": "hello",
+              "snippet": "hello",
+            },
+          },
+        ],
+        "totalPages": 10,
+        "totalResults": 100,
+        "wasSearched": false,
+      }
+    `);
+  });
+
+  it("should transform Searchkit ResponseState Paging correctly", () => {
+    let response: ResponseState = SearchResponse({
+      ...searchkitResponse,
+      hits: {
+        ...searchkitResponse.hits,
+        page: {
+          ...searchkitResponse.hits.page,
+          pageNumber: 1,
+          size: 10
+        }
+      },
+      summary: {
+        ...searchkitResponse.summary,
+        total: 100
+      }
+    });
+
+    expect(response.pagingStart).toBe(11);
+    expect(response.pagingEnd).toBe(20);
+
+    response = SearchResponse({
+      ...searchkitResponse,
+      hits: {
+        ...searchkitResponse.hits,
+        page: {
+          ...searchkitResponse.hits.page,
+          pageNumber: 1,
+          size: 10
+        }
+      },
+      summary: {
+        ...searchkitResponse.summary,
+        total: 9
+      }
+    });
+
+    expect(response.pagingStart).toBe(11);
+    expect(response.pagingEnd).toBe(9);
+  });
+
+  it("should transform Searchkit ResponseState when no facets are configured", () => {
+    const response: ResponseState = SearchResponse({
+      ...searchkitResponse,
+      facets: null
+    });
+
+    expect(response.facets).toEqual({});
+  });
+});

--- a/packages/search-ui-engines-connector/src/handlers/search/__tests__/index.test.ts
+++ b/packages/search-ui-engines-connector/src/handlers/search/__tests__/index.test.ts
@@ -1,0 +1,200 @@
+import type { RequestState, SearchQuery } from "@elastic/search-ui";
+import Searchkit, { SearchkitConfig, SearchkitResponse } from "@searchkit/sdk";
+import type { SearchkitRequest } from "@searchkit/sdk";
+import type { SearchRequest } from "../../../types";
+import handleRequest from "../index";
+
+const mockSearchkitResponse: SearchkitResponse = {
+  summary: {
+    query: "test",
+    total: 100,
+    appliedFilters: [],
+    disabledFilters: [],
+    sortOptions: []
+  },
+  hits: {
+    page: {
+      pageNumber: 0,
+      size: 10,
+      totalPages: 10,
+      total: 100,
+      from: 0
+    },
+    items: [
+      {
+        id: "test",
+        fields: {
+          title: "hello",
+          description: "test"
+        },
+        highlight: {
+          title: "hello"
+        },
+        rawHit: {
+          _id: "test"
+        }
+      }
+    ]
+  },
+  facets: [
+    {
+      identifier: "another_field.keyword",
+      display: "RefinementList",
+      label: "another_field",
+      entries: [
+        { label: "label1", count: 10 },
+        { label: "label2", count: 20 }
+      ],
+      type: "RefinmentList"
+    },
+    {
+      identifier: "world_heritage_site.keyword",
+      display: "RefinementList",
+      label: "world heritage site",
+      entries: [
+        { label: "label3", count: 10 },
+        { label: "label4", count: 20 }
+      ],
+      type: "RefinmentList"
+    }
+  ]
+};
+
+jest.mock("@searchkit/sdk", () => {
+  const originalModule = jest.requireActual("@searchkit/sdk");
+  return {
+    __esModule: true, // Use it when dealing with esModules
+    ...originalModule,
+    default: jest.fn((config: SearchkitConfig) => {
+      const sk = originalModule.default(config);
+      sk.execute = jest.fn(() => mockSearchkitResponse);
+      return sk;
+    })
+  };
+});
+
+describe("Search results", () => {
+  const searchkitMock = Searchkit as jest.Mock;
+
+  beforeEach(() => {
+    searchkitMock.mockClear();
+  });
+
+  const state: RequestState = {
+    searchTerm: "test",
+    resultsPerPage: 10,
+    current: 1
+  };
+  const queryConfig: SearchQuery = {
+    result_fields: {
+      title: {
+        snippet: {
+          size: 100,
+          fallback: true
+        }
+      },
+      nps_link: {
+        raw: {}
+      }
+    },
+    facets: {
+      "world_heritage_site.keyword": { type: "value" },
+      "another_field.keyword": { type: "value" }
+    },
+    disjunctiveFacets: ["another_field.keyword"],
+    filters: [
+      {
+        type: "none",
+        field: "world_heritage_site.keyword",
+        values: ["label3"]
+      }
+    ]
+  };
+
+  it("success", async () => {
+    const results = await handleRequest({
+      state,
+      queryConfig,
+      host: "http://localhost:9200",
+      engineName: "test",
+      apiKey: "test"
+    });
+
+    const instance: SearchkitRequest = searchkitMock.mock.results[0].value;
+    expect(instance.execute).toBeCalledWith(
+      { facets: true, hits: { from: 0, includeRawHit: true, size: 10 } },
+      [
+        {
+          bool: {
+            must_not: [{ term: { "world_heritage_site.keyword": "label3" } }]
+          }
+        }
+      ]
+    );
+
+    expect(results).toMatchInlineSnapshot(`
+      Object {
+        "facets": Object {
+          "another_field.keyword": Array [
+            Object {
+              "data": Array [
+                Object {
+                  "count": 10,
+                  "value": "label1",
+                },
+                Object {
+                  "count": 20,
+                  "value": "label2",
+                },
+              ],
+              "type": "value",
+            },
+          ],
+          "world_heritage_site.keyword": Array [
+            Object {
+              "data": Array [
+                Object {
+                  "count": 10,
+                  "value": "label3",
+                },
+                Object {
+                  "count": 20,
+                  "value": "label4",
+                },
+              ],
+              "type": "value",
+            },
+          ],
+        },
+        "pagingEnd": 10,
+        "pagingStart": 1,
+        "rawResponse": null,
+        "requestId": null,
+        "resultSearchTerm": "test",
+        "results": Array [
+          Object {
+            "_meta": Object {
+              "id": "test",
+              "rawHit": Object {
+                "_id": "test",
+              },
+            },
+            "description": Object {
+              "raw": "test",
+            },
+            "id": Object {
+              "raw": "test",
+            },
+            "title": Object {
+              "raw": "hello",
+              "snippet": "hello",
+            },
+          },
+        ],
+        "totalPages": 10,
+        "totalResults": 100,
+        "wasSearched": false,
+      }
+    `);
+  });
+});

--- a/packages/search-ui-engines-connector/src/handlers/search/index.ts
+++ b/packages/search-ui-engines-connector/src/handlers/search/index.ts
@@ -1,0 +1,62 @@
+import type {
+  QueryConfig,
+  RequestState,
+  ResponseState
+} from "@elastic/search-ui";
+import Searchkit from "@searchkit/sdk";
+import { EngineTransporter } from "../transporter";
+import buildConfiguration, { buildBaseFilters } from "./Configuration";
+import buildRequest from "./Request";
+import buildResponse from "./Response";
+
+interface SearchHandlerConfiguration {
+  state: RequestState;
+  queryConfig: QueryConfig;
+  host: string;
+  engineName: string;
+  apiKey: string;
+}
+
+export default async function handleRequest(
+  configuration: SearchHandlerConfiguration
+): Promise<ResponseState> {
+  const { state, queryConfig, host, engineName, apiKey } = configuration;
+  const searchkitConfig = buildConfiguration({
+    state,
+    queryConfig,
+    host,
+    engineName,
+    apiKey
+  });
+
+  const transporter = new EngineTransporter(
+    host,
+    engineName,
+    configuration.apiKey
+  );
+
+  const request = Searchkit(searchkitConfig, transporter);
+
+  const searchkitVariables = buildRequest(state, queryConfig);
+
+  const baseFilters = buildBaseFilters(queryConfig.filters);
+
+  const results = await request
+    .query(searchkitVariables.query)
+    .setFilters(searchkitVariables.filters)
+    .setSortBy(searchkitVariables.sort)
+    .execute(
+      {
+        facets:
+          queryConfig.facets && Object.keys(queryConfig.facets).length > 0,
+        hits: {
+          from: searchkitVariables.from,
+          size: searchkitVariables.size,
+          includeRawHit: true
+        }
+      },
+      baseFilters
+    );
+
+  return buildResponse(results);
+}

--- a/packages/search-ui-engines-connector/src/handlers/transporter.ts
+++ b/packages/search-ui-engines-connector/src/handlers/transporter.ts
@@ -1,0 +1,29 @@
+import type { SearchkitTransporter } from "@searchkit/sdk";
+import { SearchRequest, SearchResponse } from "../types";
+
+export class EngineTransporter implements SearchkitTransporter {
+  constructor(
+    private host: string,
+    private engineName: string,
+    private apiKey: string
+  ) {}
+
+  async performRequest(requestBody: SearchRequest): Promise<SearchResponse> {
+    if (!fetch)
+      throw new Error("Fetch is not supported in this browser / environment");
+
+    const response = await fetch(
+      this.host + `/api/engines/${this.engineName}/_search`,
+      {
+        method: "POST",
+        body: JSON.stringify(requestBody),
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `ApiKey ${this.apiKey}`
+        }
+      }
+    );
+    const json = await response.json();
+    return json;
+  }
+}

--- a/packages/search-ui-engines-connector/src/index.ts
+++ b/packages/search-ui-engines-connector/src/index.ts
@@ -1,0 +1,67 @@
+import type {
+  QueryConfig,
+  RequestState,
+  ResponseState,
+  AutocompleteResponseState,
+  APIConnector,
+  AutocompleteQueryConfig
+} from "@elastic/search-ui";
+
+import handleSearchRequest from "./handlers/search";
+import handleAutocompleteRequest from "./handlers/autocomplete";
+
+type ConnectionOptions = {
+  host: string;
+  engineName: string;
+  apiKey: string;
+};
+
+export * from "./types";
+
+class EngineConnector implements APIConnector {
+  constructor(private config: ConnectionOptions) {
+    if (!config.host) {
+      throw new Error("Engine Host must be provided.");
+    }
+    if (!config.engineName) {
+      throw new Error("Engine Name must be provided.");
+    }
+    if (!config.apiKey) {
+      throw new Error("API Key must be provided.");
+    }
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  onResultClick(): void {}
+
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  onAutocompleteResultClick(): void {}
+
+  async onSearch(
+    state: RequestState,
+    queryConfig: QueryConfig
+  ): Promise<ResponseState> {
+    return handleSearchRequest({
+      state,
+      queryConfig,
+      host: this.config.host,
+      engineName: this.config.engineName,
+      apiKey: this.config.apiKey
+    });
+  }
+
+  async onAutocomplete(
+    state: RequestState,
+    queryConfig: AutocompleteQueryConfig
+  ): Promise<AutocompleteResponseState> {
+    return handleAutocompleteRequest({
+      state,
+      queryConfig,
+      host: this.config.host,
+      engineName: this.config.engineName,
+      apiKey: this.config.apiKey
+    });
+  }
+}
+
+export default EngineConnector;

--- a/packages/search-ui-engines-connector/src/types.ts
+++ b/packages/search-ui-engines-connector/src/types.ts
@@ -1,0 +1,4 @@
+import type { estypes } from "@elastic/elasticsearch";
+
+export type SearchRequest = estypes.SearchRequest;
+export type SearchResponse = estypes.SearchResponse<Record<string, unknown>>;

--- a/packages/search-ui-engines-connector/tsconfig-cjs.json
+++ b/packages/search-ui-engines-connector/tsconfig-cjs.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "CommonJS",
+    "outDir": "./lib/cjs"
+  }
+}

--- a/packages/search-ui-engines-connector/tsconfig.json
+++ b/packages/search-ui-engines-connector/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "es2015",
+    "declaration": true,
+    "outDir": "lib/esm",
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "esModuleInterop": true,
+    "module": "es2020",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true
+  },
+  "exclude": ["node_modules"],
+  "include": ["src/**/*.ts", "src/**/*.js"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1636,6 +1636,14 @@
     "@elastic/transport" "^8.2.0"
     tslib "^2.4.0"
 
+"@elastic/elasticsearch@^8.6.0":
+  version "8.6.0"
+  resolved "https://registry.yarnpkg.com/@elastic/elasticsearch/-/elasticsearch-8.6.0.tgz#c474f49808deee64b5bc5b8f938bf78f4468cb94"
+  integrity sha512-mN5EbbgSp1rfRmQ/5Hv7jqAK8xhGJxCg7G84xje8hSefE59P+HPPCv/+DgesCUSJdZpwXIo0DwOWHfHvktxxLw==
+  dependencies:
+    "@elastic/transport" "^8.3.1"
+    tslib "^2.4.0"
+
 "@elastic/eui@^49.0.0":
   version "49.0.0"
   resolved "https://registry.yarnpkg.com/@elastic/eui/-/eui-49.0.0.tgz#03c097679a3ab035eb70dc135c12ec726dbd218e"
@@ -1692,6 +1700,18 @@
     secure-json-parse "^2.4.0"
     tslib "^2.4.0"
     undici "^5.1.1"
+
+"@elastic/transport@^8.3.1":
+  version "8.3.1"
+  resolved "https://registry.yarnpkg.com/@elastic/transport/-/transport-8.3.1.tgz#e7569d7df35b03108ea7aa886113800245faa17f"
+  integrity sha512-jv/Yp2VLvv5tSMEOF8iGrtL2YsYHbpf4s+nDsItxUTLFTzuJGpnsB/xBlfsoT2kAYEnWHiSJuqrbRcpXEI/SEQ==
+  dependencies:
+    debug "^4.3.4"
+    hpagent "^1.0.0"
+    ms "^2.1.3"
+    secure-json-parse "^2.4.0"
+    tslib "^2.4.0"
+    undici "^5.5.1"
 
 "@emotion/babel-plugin@^11.7.1":
   version "11.7.2"
@@ -6064,6 +6084,13 @@ builtins@^1.0.3:
   resolved "https://registry.yarnpkg.com/builtins/-/builtins-1.0.3.tgz#cb94faeb61c8696451db36534e1422f94f0aee88"
   integrity sha1-y5T662HIaWRR2zZTThQi+U8K7og=
 
+busboy@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/busboy/-/busboy-1.6.0.tgz#966ea36a9502e43cdb9146962523b92f531f6893"
+  integrity sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==
+  dependencies:
+    streamsearch "^1.1.0"
+
 byline@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/byline/-/byline-5.0.0.tgz#741c5216468eadc457b03410118ad77de8c1ddb1"
@@ -7052,6 +7079,13 @@ create-react-class@^15.6.2:
   dependencies:
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
+
+cross-fetch@^3.1.4:
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.5.tgz#e1389f44d9e7ba767907f7af8454787952ab534f"
+  integrity sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==
+  dependencies:
+    node-fetch "2.6.7"
 
 cross-spawn@6.0.5, cross-spawn@^6.0.5:
   version "6.0.5"
@@ -12797,6 +12831,16 @@ no-case@^3.0.4:
     lower-case "^2.0.2"
     tslib "^2.0.3"
 
+nock@^13.3.0:
+  version "13.3.0"
+  resolved "https://registry.yarnpkg.com/nock/-/nock-13.3.0.tgz#b13069c1a03f1ad63120f994b04bfd2556925768"
+  integrity sha512-HHqYQ6mBeiMc+N038w8LkMpDCRquCHWeNmN3v6645P3NhN2+qXOBqvPqo7Rt1VyCMzKhJ733wZqw5B7cQVFNPg==
+  dependencies:
+    debug "^4.1.0"
+    json-stringify-safe "^5.0.1"
+    lodash "^4.17.21"
+    propagate "^2.0.0"
+
 node-dir@^0.1.10:
   version "0.1.17"
   resolved "https://registry.yarnpkg.com/node-dir/-/node-dir-0.1.17.tgz#5f5665d93351335caabef8f1c554516cf5f1e4e5"
@@ -12811,7 +12855,7 @@ node-emoji@^1.10.0:
   dependencies:
     lodash "^4.17.21"
 
-node-fetch@^2.2.0, node-fetch@^2.6.1, node-fetch@^2.6.7:
+node-fetch@2.6.7, node-fetch@^2.2.0, node-fetch@^2.6.1, node-fetch@^2.6.7:
   version "2.6.7"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
   integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
@@ -14628,6 +14672,11 @@ prop-types@^15.5.4, prop-types@^15.5.7, prop-types@^15.5.8, prop-types@^15.5.9, 
     loose-envify "^1.4.0"
     object-assign "^4.1.1"
     react-is "^16.13.1"
+
+propagate@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/propagate/-/propagate-2.0.1.tgz#40cdedab18085c792334e64f0ac17256d38f9a45"
+  integrity sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==
 
 property-information@^5.0.0, property-information@^5.3.0:
   version "5.6.0"
@@ -16763,6 +16812,11 @@ stream-shift@^1.0.0:
   resolved "https://registry.yarnpkg.com/stream-shift/-/stream-shift-1.0.1.tgz#d7088281559ab2778424279b0877da3c392d5a3d"
   integrity sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==
 
+streamsearch@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/streamsearch/-/streamsearch-1.1.0.tgz#404dd1e2247ca94af554e841a8ef0eaa238da764"
+  integrity sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==
+
 strict-uri-encode@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz#b9c7330c7042862f6b142dc274bbcc5866ce3546"
@@ -17706,6 +17760,13 @@ undici@^5.1.1:
   version "5.9.1"
   resolved "https://registry.yarnpkg.com/undici/-/undici-5.9.1.tgz#fc9fd85dd488f965f153314a63d9426a11f3360b"
   integrity sha512-6fB3a+SNnWEm4CJbgo0/CWR8RGcOCQP68SF4X0mxtYTq2VNN8T88NYrWVBAeSX+zb7bny2dx2iYhP3XHi00omg==
+
+undici@^5.5.1:
+  version "5.15.0"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-5.15.0.tgz#cb8437c43718673a8be59df0fdd4856ff6689283"
+  integrity sha512-wCAZJDyjw9Myv+Ay62LAoB+hZLPW9SmKbQkbHIhMw/acKSlpn7WohdMUc/Vd4j1iSMBO0hWwU8mjB7a5p5bl8g==
+  dependencies:
+    busboy "^1.6.0"
 
 unherit@^1.0.4:
   version "1.1.3"


### PR DESCRIPTION
This is a fork of the Elasticsearch connector with some key differences:
- Overrides the default Query Processor for Searchkit to use a single `combined_fields` query.
- The connector configuration is `apiKey`, `engineName` and `host`. All three are needed. We do not allow to add custom headers.
- Changed the client meta headers to `engine-connector`

Updated the tests. 