### PR TITLE
Engines Connector: Allow Custom Transporter 

### DIFF
--- a/packages/search-ui-engines-connector/src/handlers/__test__/transporter.test.ts
+++ b/packages/search-ui-engines-connector/src/handlers/__test__/transporter.test.ts
@@ -50,46 +50,4 @@ describe("EngineTransporter", () => {
         expect(response.hits.hits[0]._source.title).toEqual("My title");
       });
   });
-
-  it("perform a request overriding getRoute", () => {
-    const transporter = new EngineTransporter(
-      "http://localhost:9200",
-      "my_engine",
-      "apikey",
-      (host, engineName) => `${host}/internal/${engineName}/search`
-    );
-
-    const body = {
-      query: {
-        match_all: {}
-      }
-    };
-
-    nock("http://localhost:9200", {
-      reqheaders: {
-        authorization: "ApiKey apikey"
-      }
-    })
-      .post("/internal/my_engine/search")
-      .reply(200, () => ({
-        hits: {
-          hits: [
-            {
-              _id: "1",
-              _source: {
-                title: "My title"
-              }
-            }
-          ]
-        }
-      }));
-
-    return transporter
-      .performRequest({
-        body
-      } as SearchRequest)
-      .then((response: SearchResponse) => {
-        expect(response.hits.hits).toHaveLength(1);
-      });
-  });
 });

--- a/packages/search-ui-engines-connector/src/handlers/autocomplete/__tests__/index.test.ts
+++ b/packages/search-ui-engines-connector/src/handlers/autocomplete/__tests__/index.test.ts
@@ -1,5 +1,6 @@
 import type { AutocompleteQueryConfig, RequestState } from "@elastic/search-ui";
 import Searchkit from "@searchkit/sdk";
+import { EngineTransporter } from "../../transporter";
 import handleRequest from "../index";
 
 const mockSearchkitResponse = [
@@ -105,9 +106,11 @@ describe("Autocomplete results", () => {
     const results = await handleRequest({
       state,
       queryConfig,
-      host: "http://localhost:9200",
-      engineName: "test",
-      apiKey: "test"
+      transporter: new EngineTransporter(
+        "http://localhost:9200",
+        "engineName",
+        "test"
+      )
     });
 
     const searchkitRequestInstance = (Searchkit as jest.Mock).mock.results[0]

--- a/packages/search-ui-engines-connector/src/handlers/autocomplete/index.ts
+++ b/packages/search-ui-engines-connector/src/handlers/autocomplete/index.ts
@@ -10,22 +10,20 @@ import Searchkit, {
   PrefixQuery,
   SearchkitConfig
 } from "@searchkit/sdk";
+import { Transporter } from "../../types";
 import { fieldResponseMapper } from "../common";
 import { getQueryFields, getResultFields } from "../search/Configuration";
-import { EngineTransporter } from "../transporter";
 
 interface AutocompleteHandlerConfiguration {
   state: RequestState;
   queryConfig: AutocompleteQueryConfig;
-  host: string;
-  engineName: string;
-  apiKey: string;
+  transporter: Transporter;
 }
 
 export default async function handleRequest(
   configuration: AutocompleteHandlerConfiguration
 ): Promise<AutocompleteResponseState> {
-  const { state, queryConfig, host, engineName, apiKey } = configuration;
+  const { state, queryConfig } = configuration;
 
   const suggestionConfigurations = [];
 
@@ -86,19 +84,14 @@ export default async function handleRequest(
   }
 
   const searchkitConfig: SearchkitConfig = {
-    host,
-    index: engineName,
-    connectionOptions: {
-      apiKey
-    },
+    host: "host",
+    index: "engineName",
     suggestions: suggestionConfigurations
   };
 
-  const transporter = new EngineTransporter(host, engineName, apiKey);
-
   const response = await Searchkit(
     searchkitConfig,
-    transporter
+    configuration.transporter
   ).executeSuggestions(state.searchTerm);
 
   const results: AutocompleteResponseState = response.reduce(

--- a/packages/search-ui-engines-connector/src/handlers/search/Configuration.ts
+++ b/packages/search-ui-engines-connector/src/handlers/search/Configuration.ts
@@ -112,17 +112,11 @@ export function buildBaseFilters(baseFilters: Filter[]): BaseFilters {
 interface BuildConfigurationOptions {
   state: RequestState;
   queryConfig: QueryConfig;
-  host?: string;
-  engineName: string;
-  apiKey?: string;
 }
 
 function buildConfiguration({
   state,
-  queryConfig,
-  host,
-  engineName,
-  apiKey
+  queryConfig
 }: BuildConfigurationOptions): SearchkitConfig {
   const { hitFields, highlightFields } = getResultFields(
     queryConfig.result_fields
@@ -231,10 +225,10 @@ function buildConfiguration({
   const metaHeader = `ent=${LIB_VERSION}-engines-connector,js=${jsVersion},t=${LIB_VERSION}-engines-connector,ft=universal`;
 
   const configuration: SearchkitConfig = {
-    host: host,
-    index: engineName,
+    // overriding the transport and providing the host, index and apiKey to the transport
+    host: "host",
+    index: "engineName",
     connectionOptions: {
-      apiKey: apiKey,
       headers: {
         "x-elastic-client-meta": metaHeader
       }

--- a/packages/search-ui-engines-connector/src/handlers/search/__tests__/Configuration.node.test.ts
+++ b/packages/search-ui-engines-connector/src/handlers/search/__tests__/Configuration.node.test.ts
@@ -41,9 +41,6 @@ describe("Search - Configuration within node context", () => {
       },
       disjunctiveFacets: ["category"]
     };
-    const host = "http://localhost:9200";
-    const index = "test_index";
-    const apiKey = "apiKey";
 
     it("builds configuration", () => {
       const state: RequestState = {
@@ -53,10 +50,7 @@ describe("Search - Configuration within node context", () => {
       const nodeVersion = process.version;
       const configuration = buildConfiguration({
         state,
-        queryConfig,
-        host,
-        engineName: index,
-        apiKey
+        queryConfig
       });
 
       const validHeaderRegex =

--- a/packages/search-ui-engines-connector/src/handlers/search/__tests__/Configuration.test.ts
+++ b/packages/search-ui-engines-connector/src/handlers/search/__tests__/Configuration.test.ts
@@ -214,9 +214,6 @@ describe("Search - Configuration", () => {
         }
       ]
     };
-    const host = "http://localhost:9200";
-    const index = "test_index";
-    const apiKey = "apiKey";
 
     it("builds configuration", () => {
       const state: RequestState = {
@@ -247,17 +244,13 @@ describe("Search - Configuration", () => {
       };
       const x = buildConfiguration({
         state,
-        queryConfig,
-        host,
-        engineName: index,
-        apiKey
+        queryConfig
       });
       expect(x).toEqual(
         expect.objectContaining({
-          host: "http://localhost:9200",
-          index: "test_index",
+          host: "host",
+          index: "engineName",
           connectionOptions: {
-            apiKey: "apiKey",
             headers: {
               "x-elastic-client-meta": `ent=${LIB_VERSION}-engines-connector,js=browser,t=${LIB_VERSION}-engines-connector,ft=universal`
             }
@@ -309,17 +302,13 @@ describe("Search - Configuration", () => {
       expect(
         buildConfiguration({
           state,
-          queryConfig: { ...queryConfig, facets: null },
-          host,
-          engineName: index,
-          apiKey
+          queryConfig: { ...queryConfig, facets: null }
         })
       ).toEqual(
         expect.objectContaining({
-          host: "http://localhost:9200",
-          index: "test_index",
+          host: "host",
+          index: "engineName",
           connectionOptions: {
-            apiKey: "apiKey",
             headers: {
               "x-elastic-client-meta": `ent=${LIB_VERSION}-engines-connector,js=browser,t=${LIB_VERSION}-engines-connector,ft=universal`
             }
@@ -404,18 +393,14 @@ describe("Search - Configuration", () => {
               ]
             }
           }
-        },
-        host,
-        engineName: index,
-        apiKey
+        }
       });
 
       expect(configuration).toEqual(
         expect.objectContaining({
-          host: "http://localhost:9200",
-          index: "test_index",
+          host: "host",
+          index: "engineName",
           connectionOptions: {
-            apiKey: "apiKey",
             headers: {
               "x-elastic-client-meta": `ent=${LIB_VERSION}-engines-connector,js=browser,t=${LIB_VERSION}-engines-connector,ft=universal`
             }

--- a/packages/search-ui-engines-connector/src/handlers/search/__tests__/index.test.ts
+++ b/packages/search-ui-engines-connector/src/handlers/search/__tests__/index.test.ts
@@ -1,8 +1,8 @@
 import type { RequestState, SearchQuery } from "@elastic/search-ui";
 import Searchkit, { SearchkitConfig, SearchkitResponse } from "@searchkit/sdk";
 import type { SearchkitRequest } from "@searchkit/sdk";
-import type { SearchRequest } from "../../../types";
 import handleRequest from "../index";
+import { EngineTransporter } from "../../transporter";
 
 const mockSearchkitResponse: SearchkitResponse = {
   summary: {
@@ -115,9 +115,11 @@ describe("Search results", () => {
     const results = await handleRequest({
       state,
       queryConfig,
-      host: "http://localhost:9200",
-      engineName: "test",
-      apiKey: "test"
+      transporter: new EngineTransporter(
+        "http://localhost:9200",
+        "engineName",
+        "test"
+      )
     });
 
     const instance: SearchkitRequest = searchkitMock.mock.results[0].value;

--- a/packages/search-ui-engines-connector/src/handlers/search/index.ts
+++ b/packages/search-ui-engines-connector/src/handlers/search/index.ts
@@ -4,8 +4,7 @@ import type {
   ResponseState
 } from "@elastic/search-ui";
 import Searchkit from "@searchkit/sdk";
-import { EngineRouteFn } from "../../types";
-import { EngineTransporter } from "../transporter";
+import { Transporter } from "../../types";
 import buildConfiguration, { buildBaseFilters } from "./Configuration";
 import buildRequest from "./Request";
 import buildResponse from "./Response";
@@ -13,32 +12,19 @@ import buildResponse from "./Response";
 interface SearchHandlerConfiguration {
   state: RequestState;
   queryConfig: QueryConfig;
-  host: string;
-  engineName: string;
-  apiKey: string;
-  engineRouteFn?: EngineRouteFn;
+  transporter: Transporter;
 }
 
 export default async function handleRequest(
   configuration: SearchHandlerConfiguration
 ): Promise<ResponseState> {
-  const { state, queryConfig, host, engineName, apiKey } = configuration;
+  const { state, queryConfig } = configuration;
   const searchkitConfig = buildConfiguration({
     state,
-    queryConfig,
-    host,
-    engineName,
-    apiKey
+    queryConfig
   });
 
-  const transporter = new EngineTransporter(
-    host,
-    engineName,
-    configuration.apiKey,
-    configuration.engineRouteFn
-  );
-
-  const request = Searchkit(searchkitConfig, transporter);
+  const request = Searchkit(searchkitConfig, configuration.transporter);
 
   const searchkitVariables = buildRequest(state, queryConfig);
 

--- a/packages/search-ui-engines-connector/src/handlers/transporter.ts
+++ b/packages/search-ui-engines-connector/src/handlers/transporter.ts
@@ -1,30 +1,27 @@
-import type { SearchkitTransporter } from "@searchkit/sdk";
-import { SearchRequest, SearchResponse, EngineRouteFn } from "../types";
+import { SearchRequest, SearchResponse, Transporter } from "../types";
 
-function defaultEngineRoute(host: string, engineName: string): string {
-  return `${host}/api/engines/${engineName}/_search`;
-}
-
-export class EngineTransporter implements SearchkitTransporter {
+export class EngineTransporter implements Transporter {
   constructor(
     private host: string,
     private engineName: string,
-    private apiKey: string,
-    private getRoute: EngineRouteFn = defaultEngineRoute
+    private apiKey: string
   ) {}
 
   async performRequest(requestBody: SearchRequest): Promise<SearchResponse> {
     if (!fetch)
       throw new Error("Fetch is not supported in this browser / environment");
 
-    const response = await fetch(this.getRoute(this.host, this.engineName), {
-      method: "POST",
-      body: JSON.stringify(requestBody),
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `ApiKey ${this.apiKey}`
+    const response = await fetch(
+      `${this.host}/api/engines/${this.engineName}/_search`,
+      {
+        method: "POST",
+        body: JSON.stringify(requestBody),
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `ApiKey ${this.apiKey}`
+        }
       }
-    });
+    );
     const json = await response.json();
     return json;
   }

--- a/packages/search-ui-engines-connector/src/types.ts
+++ b/packages/search-ui-engines-connector/src/types.ts
@@ -3,3 +3,12 @@ import type { estypes } from "@elastic/elasticsearch";
 export type SearchRequest = estypes.SearchRequest;
 export type SearchResponse = estypes.SearchResponse<Record<string, unknown>>;
 export type EngineRouteFn = (host: string, engineName: string) => string;
+export interface Transporter {
+  performRequest(requestBody: SearchRequest): Promise<SearchResponse>;
+}
+
+export type ConnectionOptions = {
+  host: string;
+  engineName: string;
+  apiKey: string;
+};


### PR DESCRIPTION
Adding search preview page in kibana, a few issues came up:
- we need to be able to specify custom headers or use kibana's core http service
- we need to change the url to call the internal proxied API
- we cannot specify an api key. Kibana auth (when made through the core http service) will handle authentication concern.

I decided its best to just allow an instance of a transporter to handle the interaction between the API and Search-UI. This way we can use:
- kibana's core http
- specify configuration thats relevant to the transporter

So within kibana, the configuration will be:

```ts
class InternalEngineTransporter implements Transporter {
  constructor(private http: HttpSetup, private engineName: string) {}

  async performRequest(request: SearchReqest) {
    const url = `/internal/enterprise_search/engines/${this.engineName}/search`;

    const response = await this.http.post<SearchResponse>(url, {
      body: JSON.stringify(request),
    });
    return response;
  }
}

  const transporter = new InternalEngineTransporter(http, engineName);
  const connector = new EnginesAPIConnector(transporter);

``` 