### PR TITLE
Use deep filter comparison to identify duplicate state and config filters

### DIFF
--- a/packages/search-ui-elasticsearch-connector/src/handlers/search/Request.ts
+++ b/packages/search-ui-elasticsearch-connector/src/handlers/search/Request.ts
@@ -16,7 +16,7 @@ export function getFilters(
   baseFilters: Filter[] = []
 ): MixedFilter[] {
   return filters.reduce((acc, f) => {
-    const isBaseFilter = baseFilters.includes(f);
+    const isBaseFilter = baseFilters.find(bf => helpers.doFilterValuesMatch(f, bf));
     if (isBaseFilter) return acc;
 
     const subFilters = f.values.map((v) => {


### PR DESCRIPTION
## Description

This should address #936

## List of changes

add deep filter comparison for query config filters and state filters deduplication logic

## Associated Github Issues

 #936
