### PR TITLE
Update publish_docs_co.yml with new Org Secrets

### DIFF
--- a/.github/workflows/publish_docs_co.yml
+++ b/.github/workflows/publish_docs_co.yml
@@ -25,7 +25,7 @@ jobs:
       # Docsmobile project dir
       repo: docs.elastic.co
     secrets:
-      VERCEL_GITHUB_TOKEN: ${{ secrets.VERCEL_GITHUB_TOKEN }}
-      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      VERCEL_GITHUB_TOKEN: ${{ secrets.VERCEL_GITHUB_TOKEN_PUBLIC }}
+      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN_PUBLIC }}
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID_PUBLIC }}
       VERCEL_PROJECT_ID_DOCS_CO: ${{ secrets.VERCEL_PROJECT_ID_DOCS_CO }}


### PR DESCRIPTION
We are refactoring our docs org secrets to segment our public from private docs. This PR updates the keys to the new ones.

After this is completed, @gtback will change the following secrets to private internal repos:

```
VERCEL_GITHUB_TOKEN
VERCEL_TOKEN
VERCEL_ORG_ID
```