### PR TITLE
Search Applications: Use query_string for search_preview

### DIFF
--- a/packages/search-ui-engines-connector/src/handlers/autocomplete/index.ts
+++ b/packages/search-ui-engines-connector/src/handlers/autocomplete/index.ts
@@ -12,7 +12,7 @@ import Searchkit, {
 } from "@searchkit/sdk";
 import { Transporter } from "../../types";
 import { fieldResponseMapper } from "../common";
-import { getQueryFields, getResultFields } from "../search/Configuration";
+import { getResultFields } from "../search/Configuration";
 
 interface AutocompleteHandlerConfiguration {
   state: RequestState;
@@ -31,7 +31,6 @@ export default async function handleRequest(
     const { hitFields, highlightFields } = getResultFields(
       queryConfig.results.result_fields
     );
-    const queryFields = getQueryFields(queryConfig.results.search_fields);
 
     suggestionConfigurations.push(
       new HitsSuggestor({
@@ -40,7 +39,7 @@ export default async function handleRequest(
           fields: hitFields,
           highlightedFields: highlightFields
         },
-        query: new PrefixQuery({ fields: queryFields }),
+        query: new PrefixQuery({ fields: ["*"] }),
         size: queryConfig.results.resultsPerPage || 5
       })
     );
@@ -55,7 +54,6 @@ export default async function handleRequest(
         const { hitFields, highlightFields } = getResultFields(
           configuration.result_fields
         );
-        const queryFields = getQueryFields(configuration.search_fields);
 
         return new HitsSuggestor({
           identifier: `suggestions-hits-${type}`,
@@ -64,7 +62,7 @@ export default async function handleRequest(
             fields: hitFields,
             highlightedFields: highlightFields
           },
-          query: new PrefixQuery({ fields: queryFields }),
+          query: new PrefixQuery({ fields: ["*"] }),
           size: suggestionsSize
         });
       } else if (

--- a/packages/search-ui-engines-connector/src/handlers/search/Configuration.ts
+++ b/packages/search-ui-engines-connector/src/handlers/search/Configuration.ts
@@ -38,16 +38,6 @@ export function getResultFields(
   return { hitFields, highlightFields };
 }
 
-export function getQueryFields(
-  searchFields: Record<string, SearchFieldConfiguration> = {}
-): string[] {
-  return Object.keys(searchFields).map((fieldKey) => {
-    const fieldConfiguration = searchFields[fieldKey];
-    const weight = `^${fieldConfiguration.weight || 1}`;
-    return fieldKey + weight;
-  });
-}
-
 export function isValidDateString(dateString: unknown): boolean {
   return typeof dateString === "string" && !isNaN(Date.parse(dateString));
 }
@@ -121,8 +111,6 @@ function buildConfiguration({
   const { hitFields, highlightFields } = getResultFields(
     queryConfig.result_fields
   );
-
-  const queryFields = getQueryFields(queryConfig.search_fields);
 
   const filtersConfig: BaseFilter[] = Object.values(
     (state.filters || [])

--- a/packages/search-ui-engines-connector/src/handlers/search/Configuration.ts
+++ b/packages/search-ui-engines-connector/src/handlers/search/Configuration.ts
@@ -237,7 +237,7 @@ function buildConfiguration({
       fields: hitFields,
       highlightedFields: highlightFields
     },
-    query: EngineQuery(queryFields),
+    query: EngineQuery(),
     sortOptions: [sortOption],
     facets,
     filters: filtersConfig

--- a/packages/search-ui-engines-connector/src/handlers/search/Query.ts
+++ b/packages/search-ui-engines-connector/src/handlers/search/Query.ts
@@ -1,15 +1,14 @@
 import { CustomQuery } from "@searchkit/sdk";
 
-export const EngineQuery = (fields) =>
+export const EngineQuery = () =>
   new CustomQuery({
     queryFn: (query) => {
       return {
         bool: {
           must: [
             {
-              combined_fields: {
-                query: query,
-                fields: fields
+              query_string: {
+                query: query
               }
             }
           ]

--- a/packages/search-ui-engines-connector/src/handlers/search/__tests__/Configuration.test.ts
+++ b/packages/search-ui-engines-connector/src/handlers/search/__tests__/Configuration.test.ts
@@ -262,7 +262,7 @@ describe("Search - Configuration", () => {
         })
       );
 
-      expect(EngineQuery).toHaveBeenCalledWith(["title^2", "description^1"]);
+      expect(EngineQuery).toHaveBeenCalled();
 
       expect(RefinementSelectFacet).toHaveBeenCalledTimes(2);
       expect(RefinementSelectFacet).toHaveBeenCalledWith({
@@ -320,7 +320,7 @@ describe("Search - Configuration", () => {
         })
       );
 
-      expect(EngineQuery).toHaveBeenCalledWith(["title^2", "description^1"]);
+      expect(EngineQuery).toHaveBeenCalled();
 
       expect(RefinementSelectFacet).toHaveBeenCalledTimes(2);
       expect(RefinementSelectFacet).toHaveBeenCalledWith({


### PR DESCRIPTION
Uses query_string to get over the difficulty of multiple search analyzers.


https://github.com/elastic/search-ui/assets/49480/51cb8a47-6a7b-4a2b-881f-b1cce1fd7411


