### PR TITLE
Fix closing bracket and adjust path to access searchFields

### DIFF
--- a/docs/api-connectors-elasticsearch.mdx
+++ b/docs/api-connectors-elasticsearch.mdx
@@ -345,7 +345,7 @@ const connector = new ElasticsearchAPIConnector(
     if (!requestState.searchTerm) return requestBody;
 
     // transforming the query before sending to Elasticsearch using the requestState and queryConfig
-    const searchFields = queryConfig.searchQuery.search_fields
+    const searchFields = queryConfig.search_fields
 
     requestBody.query = {
       multi_match: {
@@ -353,7 +353,7 @@ const connector = new ElasticsearchAPIConnector(
         fields: Object.keys(searchFields).map((fieldName) => {
           const weight = searchFields[fieldName].weight || 1;
           return `${fieldName}^${weight}`;
-        }
+        })
       }
     };
 


### PR DESCRIPTION
## Description
Fix doc example for the custom es query.
## List of changes
In order for the example to work with the config from this [tutorial](https://docs.elastic.co/search-ui/tutorials/elasticsearch#step-5-configure-search-ui), I have to:
- add the closing bracket for `map((fieldName)...` and
- adjust `const searchFields = queryConfig.searchQuery.search_fields` to `const searchFields = queryConfig.search_fields`

## Associated Github Issues
