### PR TITLE
[DOC] Closing results with />

### DIFF
--- a/docs/api-react-components-result.mdx
+++ b/docs/api-react-components-result.mdx
@@ -95,7 +95,7 @@ const CustomResultView = ({
   </li>
 );
 
-<Results resultView={CustomResultView}>
+<Results resultView={CustomResultView}/>
 ```
 
 The following properties are available in the view:


### PR DESCRIPTION
## Description
Doc Example missing closing `/` for HTML tag.

## List of changes
Replace `>` with `/>` for `<Results resultView={CustomResultView}/>`

## Associated Github Issues
