### PR TITLE
fix: Issue 996 - falsy values in search results

### DIFF
--- a/packages/search-ui-elasticsearch-connector/src/handlers/common.ts
+++ b/packages/search-ui-elasticsearch-connector/src/handlers/common.ts
@@ -14,8 +14,8 @@ export function fieldResponseMapper(
       return {
         ...acc,
         [key]: {
-          ...(fields[key] ? { raw: fields[key] } : {}),
-          ...(highlights[key] ? { snippet: highlights[key] } : {})
+          ...(key in fields ? { raw: fields[key] } : {}),
+          ...(key in highlights ? { snippet: highlights[key] } : {})
         }
       };
     },

--- a/packages/search-ui-elasticsearch-connector/src/handlers/search/__tests__/Response.test.ts
+++ b/packages/search-ui-elasticsearch-connector/src/handlers/search/__tests__/Response.test.ts
@@ -24,7 +24,13 @@ describe("Search - Response", () => {
           id: "test",
           fields: {
             title: "hello",
-            description: "test"
+            description: "test",
+            boolean_f: false,
+            boolean_t: true,
+            number_f: 0,
+            number_t: 1,
+            string_f: "",
+            string_t: "badger"
           },
           highlight: {
             title: "hello",
@@ -85,6 +91,12 @@ describe("Search - Response", () => {
                 "_id": "test",
               },
             },
+            "boolean_f": Object {
+              "raw": false,
+            },
+            "boolean_t": Object {
+              "raw": true,
+            },
             "description": Object {
               "raw": "test",
             },
@@ -93,6 +105,18 @@ describe("Search - Response", () => {
             },
             "id": Object {
               "raw": "test",
+            },
+            "number_f": Object {
+              "raw": 0,
+            },
+            "number_t": Object {
+              "raw": 1,
+            },
+            "string_f": Object {
+              "raw": "",
+            },
+            "string_t": Object {
+              "raw": "badger",
             },
             "title": Object {
               "raw": "hello",


### PR DESCRIPTION
## Description

Update the elasticsearch connector to fix mishandled falsy values

Any field which evaluates to false is returned as an empty object. This change fixes this to return the expected { raw: field value } construct.

## List of changes

Changes the mapping of fields to check for existence rather than truth.

## Associated Github Issues

#996 