### PR TITLE
[Demo] remove apm init as it is broken

### DIFF
--- a/examples/sandbox/package.json
+++ b/examples/sandbox/package.json
@@ -12,8 +12,6 @@
   "version": "1.20.2",
   "private": true,
   "dependencies": {
-    "@elastic/apm-rum": "^5.12.0",
-    "@elastic/apm-rum-react": "^1.4.2",
     "@elastic/behavioral-analytics-javascript-tracker": "^2.1.3",
     "@elastic/datemath": "^5.0.3",
     "@elastic/eui": "^49.0.0",

--- a/examples/sandbox/src/Router.js
+++ b/examples/sandbox/src/Router.js
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { Switch } from "react-router-dom";
+import { Switch, Route } from "react-router-dom";
 import Root from "./pages/root";
 import Elasticsearch from "./pages/elasticsearch";
 import ElasticsearchWithAnalytics from "./pages/elasticsearch-with-analytics";
@@ -14,54 +14,53 @@ import SearchBarInHeaderSearch from "./pages/search-bar-in-header/search";
 import EcommerceHome from "./pages/ecommerce";
 import EcommerceSearch from "./pages/ecommerce/Search";
 import EcommerceCategory from "./pages/ecommerce/Category";
-import { ApmRoute } from "@elastic/apm-rum-react";
 import ListingPage from "./pages/ecommerce/ListingPage";
 
 export default function Router() {
   return (
     <div className="App">
       <Switch>
-        <ApmRoute exact path="/" component={Root} />
+        <Route exact path="/" component={Root} />
 
         {/* Connectors */}
-        <ApmRoute exact path="/elasticsearch" component={Elasticsearch} />
-        <ApmRoute exact path="/app-search" component={AppSearch} />
-        <ApmRoute exact path="/site-search" component={SiteSearch} />
-        <ApmRoute exact path="/workplace-search" component={WorkplaceSearch} />
-        <ApmRoute exact path="/engines" component={Engines} />
+        <Route exact path="/elasticsearch" component={Elasticsearch} />
+        <Route exact path="/app-search" component={AppSearch} />
+        <Route exact path="/site-search" component={SiteSearch} />
+        <Route exact path="/workplace-search" component={WorkplaceSearch} />
+        <Route exact path="/engines" component={Engines} />
 
         {/* Examples */}
-        <ApmRoute
+        <Route
           exact
           path="/search-as-you-type"
           component={SearchAsYouType}
         />
-        <ApmRoute
+        <Route
           exact
           path="/customizing-styles-and-html"
           component={CustomizingStylesAndHtml}
         />
-        <ApmRoute
+        <Route
           exact
           path="/search-bar-in-header"
           component={SearchBarInHeaderIndex}
         />
-        <ApmRoute
+        <Route
           exact
           path="/search-bar-in-header/search"
           component={SearchBarInHeaderSearch}
         />
-        <ApmRoute
+        <Route
           exact
           path="/elasticsearch-with-analytics"
           component={ElasticsearchWithAnalytics}
         />
 
         {/* Use cases */}
-        <ApmRoute exact path="/ecommerce/" component={EcommerceHome} />
-        <ApmRoute exact path="/ecommerce/search" component={EcommerceSearch} />
-        <ApmRoute exact path="/ecommerce/all" component={ListingPage} />
-        <ApmRoute
+        <Route exact path="/ecommerce/" component={EcommerceHome} />
+        <Route exact path="/ecommerce/search" component={EcommerceSearch} />
+        <Route exact path="/ecommerce/all" component={ListingPage} />
+        <Route
           exact
           path="/ecommerce/category/:category"
           component={EcommerceCategory}

--- a/examples/sandbox/src/index.js
+++ b/examples/sandbox/src/index.js
@@ -2,17 +2,7 @@ import React from "react";
 import ReactDOM from "react-dom";
 import { BrowserRouter } from "react-router-dom";
 import Router from "./Router";
-import { init as initApm } from "@elastic/apm-rum";
 import "./styles.css";
-
-initApm({
-  serviceName: "Search UI Sandbox",
-  serverUrl:
-    "https://68a4e94cc8b640e6a77b3da09dd7df30.apm.us-central1.gcp.cloud.es.io:443",
-  // Set the service version (required for source map feature)
-  serviceVersion: "",
-  environment: process.env.NODE_ENV
-});
 
 ReactDOM.render(
   <BrowserRouter>


### PR DESCRIPTION
## Description
The `initApm()` call is failing and causing the live demo to not load, removing it for now.

## List of changes
- Remove the `initApm()`

## Associated Github Issues
- #1008 