### PR TITLE
fix: remove vue demo from workspaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "license": "Apache-2.0",
   "workspaces": [
     "packages/*",
-    "examples/*"
+    "examples/sandbox"
   ],
   "scripts": {
     "start": "yarn --cwd examples/sandbox start",


### PR DESCRIPTION
## Description
This updates the project npm workspaces by removing the vue example app. This allowed the vue app to successfully `npm i`.

Now this does mean when running the vue example it will install deps from npm instead of being overridden to the local npm workspace packages, so testing local changes will require updating the dependency in the vue example manually.


## List of changes
- Removes the Vue demo from the project npm workspaces.
## Associated Github Issues
Closes #1019 