### PR TITLE
Fix pagination styling

### DIFF
--- a/packages/react-search-ui-views/src/styles/themes/reference-ui/components/_paging.scss
+++ b/packages/react-search-ui-views/src/styles/themes/reference-ui/components/_paging.scss
@@ -2,9 +2,11 @@
 @include block("paging") {
   > li {
     border: none;
+    background: transparent;
 
     .rc-pagination-item-link {
       border: none;
+      background: transparent;
       font-size: 16px;
       color: $facetLinkColor;
 

--- a/packages/react-search-ui-views/src/styles/themes/reference-ui/components/_paging.scss
+++ b/packages/react-search-ui-views/src/styles/themes/reference-ui/components/_paging.scss
@@ -2,14 +2,27 @@
 @include block("paging") {
   > li {
     border: none;
-    background: transparent;
-    outline: none;
+
+    .rc-pagination-item-link {
+      border: none;
+      font-size: 16px;
+      color: $facetLinkColor;
+
+      &:hover {
+        color: $facetLinkColor;
+        background: $pagingHoverBackground;
+      }
+    }
   }
 
   .rc-pagination-disabled {
-    a {
+    .rc-pagination-item-link {
       color: #ccc;
-      opacity: 0.5;
+      opacity: 0.8;
+
+      &:hover {
+        color: #ccc;
+      }
     }
   }
 
@@ -17,14 +30,6 @@
     a {
       color: $linkColor;
       text-decoration: none;
-    }
-
-    &:hover {
-      background: $pagingHoverBackground;
-      a {
-        color: $linkColor;
-        text-decoration: none;
-      }
     }
   }
 
@@ -43,42 +48,16 @@
         cursor: not-allowed;
       }
     }
-  }
 
-  .rc-pagination-next {
-    &:hover {
-      background: $pagingHoverBackground;
-      a {
-        color: $linkColor;
+    .rc-pagination-jump-prev,
+    .rc-pagination-jump-next {
+      .rc-pagination-item-link {
+        color: $facetLinkColor;
+
+        &:hover {
+          color: $facetLinkColor;
+        }
       }
     }
-  }
-
-  .rc-pagination-jump-next:hover {
-    background: $pagingHoverBackground;
-    a {
-      color: $linkColor;
-    }
-  }
-
-  .rc-pagination-jump-next:hover:after {
-    color: $linkColor;
-    content: "\BB";
-    font-size: 16px;
-    line-height: $lineHeight;
-  }
-
-  .rc-pagination-jump-prev:hover {
-    background: $pagingHoverBackground;
-    a {
-      color: $linkColor;
-    }
-  }
-
-  .rc-pagination-jump-prev:hover:after {
-    color: $linkColor;
-    content: "\AB";
-    font-size: 16px;
-    line-height: $lineHeight;
   }
 }


### PR DESCRIPTION
Fixes #1032

The upgrade of rc-pagination caused a few of the custom pagination styles to break. I have updated the styles and now pagination looks as follows:

<img width="493" alt="Screenshot 2024-03-29 at 12 56 56 AM" src="https://github.com/elastic/search-ui/assets/2715854/e504e1eb-3f4c-4685-82c7-07199cb5ac7a">

I'm not sure if this is exactly what was intended, so let me know if any colors need to be different. I'm also not using any hover color changes. If you want that, either for the prev/next buttons or the page numbers, let me know what color or color variable you want.