### PR TITLE
Missing exports

### DIFF
--- a/packages/react-search-ui-views/package.json
+++ b/packages/react-search-ui-views/package.json
@@ -66,5 +66,11 @@
     "downshift": "^3.2.10",
     "rc-pagination": "^4.0.4",
     "react-select": "^5.0.0"
+  },
+  "exports": {
+    ".": {
+      "import": "./lib/esm/index.js",
+      "require": "./lib/cjs/index.js"
+    }
   }
 }

--- a/packages/react-search-ui/package.json
+++ b/packages/react-search-ui/package.json
@@ -46,5 +46,11 @@
     "react-dom": "^18.2.0",
     "rimraf": "^2.6.3",
     "typescript": "^4.5.4"
+  },
+  "exports": {
+    ".": {
+      "import": "./lib/esm/index.js",
+      "require": "./lib/cjs/index.js"
+    }
   }
 }

--- a/packages/search-ui-analytics-plugin/package.json
+++ b/packages/search-ui-analytics-plugin/package.json
@@ -43,5 +43,11 @@
   },
   "dependencies": {
     "@elastic/behavioral-analytics-tracker-core": "^2.0.5"
+  },
+  "exports": {
+    ".": {
+      "import": "./lib/esm/index.js",
+      "require": "./lib/cjs/index.js"
+    }
   }
 }

--- a/packages/search-ui-app-search-connector/package.json
+++ b/packages/search-ui-app-search-connector/package.json
@@ -40,5 +40,11 @@
   "dependencies": {
     "@elastic/app-search-javascript": "^8.1.2",
     "@elastic/search-ui": "1.21.2"
+  },
+  "exports": {
+    ".": {
+      "import": "./lib/esm/index.js",
+      "require": "./lib/cjs/index.js"
+    }
   }
 }

--- a/packages/search-ui-elasticsearch-connector/package.json
+++ b/packages/search-ui-elasticsearch-connector/package.json
@@ -42,5 +42,11 @@
     "@elastic/elasticsearch": "^8.2.1",
     "@elastic/search-ui": "1.21.2",
     "@searchkit/sdk": "^3.0.0"
+  },
+  "exports": {
+    ".": {
+      "import": "./lib/esm/index.js",
+      "require": "./lib/cjs/index.js"
+    }
   }
 }

--- a/packages/search-ui-engines-connector/package.json
+++ b/packages/search-ui-engines-connector/package.json
@@ -48,5 +48,11 @@
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org/"
+  },
+  "exports": {
+    ".": {
+      "import": "./lib/esm/index.js",
+      "require": "./lib/cjs/index.js"
+    }
   }
 }

--- a/packages/search-ui-site-search-connector/package.json
+++ b/packages/search-ui-site-search-connector/package.json
@@ -39,5 +39,11 @@
   },
   "dependencies": {
     "@elastic/search-ui": "1.21.2"
+  },
+  "exports": {
+    ".": {
+      "import": "./lib/esm/index.js",
+      "require": "./lib/cjs/index.js"
+    }
   }
 }

--- a/packages/search-ui-workplace-search-connector/package.json
+++ b/packages/search-ui-workplace-search-connector/package.json
@@ -41,5 +41,11 @@
   "dependencies": {
     "@elastic/search-ui": "1.21.2",
     "query-string": "^7.1.1"
+  },
+  "exports": {
+    ".": {
+      "import": "./lib/esm/index.js",
+      "require": "./lib/cjs/index.js"
+    }
   }
 }

--- a/packages/search-ui/package.json
+++ b/packages/search-ui/package.json
@@ -44,5 +44,11 @@
     "deep-equal": "^1.0.1",
     "history": "^4.9.0",
     "qs": "^6.7.0"
+  },
+  "exports": {
+    ".": {
+      "import": "./lib/esm/index.js",
+      "require": "./lib/cjs/index.js"
+    }
   }
 }


### PR DESCRIPTION
## Description
On Nuxt3 or Svelte projects, an 500 error is returned with this message :

> SyntaxError: Named export 'SearchDriver' not found. The requested module '@elastic/search-ui' is a CommonJS module, which may not support all module.exports as named exports.


## List of changes
Add correct exports on package.json files to use ESM module on SvelteKit or Nuxt
```
"exports": {
    ".": {
      "import": "./lib/esm/index.js",
      "require": "./lib/cjs/index.js"
    }
  }
}
```

## Associated Github Issues
Resolve #952 #938 #953 