### PR TITLE
Declare exports for react styles

### DIFF
--- a/packages/react-search-ui-views/package.json
+++ b/packages/react-search-ui-views/package.json
@@ -71,6 +71,7 @@
     ".": {
       "import": "./lib/esm/index.js",
       "require": "./lib/cjs/index.js"
-    }
+    },
+    "./lib/styles/styles.css": "./lib/styles/styles.css"
   }
 }


### PR DESCRIPTION
Fixes #1044

The styles in the `react-search-ui-views` package are public, so they should be declared as exports.