### PR TITLE
Module support updates.

### DIFF
--- a/examples/vue/package.json
+++ b/examples/vue/package.json
@@ -30,7 +30,7 @@
     "@vitejs/plugin-vue-jsx": "^1.3.10",
     "@vue/eslint-config-prettier": "^7.0.0",
     "eslint": "^8.5.0",
-    "eslint-plugin-vue": "^9.0.0",
+    "eslint-plugin-vue": "^9.26.0",
     "prettier": "^2.5.1",
     "vite": "^2.9.12"
   }

--- a/packages/react-search-ui-views/package.json
+++ b/packages/react-search-ui-views/package.json
@@ -59,7 +59,7 @@
     "react-dom": "^17.0.2",
     "rimraf": "^2.6.3",
     "sass": "^1.49.9",
-    "typescript": "^4.5.4"
+    "typescript": "^4.9.3"
   },
   "dependencies": {
     "@elastic/search-ui": "1.21.4",

--- a/packages/react-search-ui-views/package.json
+++ b/packages/react-search-ui-views/package.json
@@ -70,8 +70,11 @@
   "exports": {
     ".": {
       "import": "./lib/esm/index.js",
-      "require": "./lib/cjs/index.js"
+      "require": "./lib/cjs/index.js",
+      "types": "./lib/esm/index.d.ts"
     },
-    "./lib/styles/styles.css": "./lib/styles/styles.css"
+    "./lib/styles/styles.css": "./lib/styles/styles.css",
+    "./package": "./package.json",
+    "./package.json": "./package.json"
   }
 }

--- a/packages/react-search-ui-views/src/Autocomplete.tsx
+++ b/packages/react-search-ui-views/src/Autocomplete.tsx
@@ -55,12 +55,12 @@ export type SearchBoxAutocompleteViewProps = {
   autocompletedSuggestions: AutocompletedSuggestions;
   autocompletedSuggestionsCount: number;
   autocompleteSuggestions?: boolean | AutocompleteSuggestion;
-  getItemProps: ({
-    key: string,
-    index: number,
-    item: AutocompletedSuggestion
+  getItemProps: (value: {
+    key: string;
+    index: number;
+    item: AutocompletedSuggestion;
   }) => any;
-  getMenuProps: ({ className: string }) => any;
+  getMenuProps: (value: { className: string }) => any;
   className?: string;
 };
 
@@ -121,7 +121,7 @@ function Autocomplete({
                               );
                             }
                             const suggestionValue =
-                              suggestion.result[displayField]?.raw;
+                              suggestion.result[displayField]?.raw?.toString();
 
                             return (
                               <li

--- a/packages/react-search-ui-views/src/index.tsx
+++ b/packages/react-search-ui-views/src/index.tsx
@@ -14,3 +14,4 @@ export { default as SingleLinksFacet } from "./SingleLinksFacet";
 export { default as Sorting } from "./Sorting";
 export { Layout } from "./layouts";
 export * from "./types";
+export * as ViewHelpers from "./view-helpers";

--- a/packages/react-search-ui/package.json
+++ b/packages/react-search-ui/package.json
@@ -45,7 +45,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "rimraf": "^2.6.3",
-    "typescript": "^4.5.4"
+    "typescript": "^4.9.3"
   },
   "exports": {
     ".": {

--- a/packages/react-search-ui/package.json
+++ b/packages/react-search-ui/package.json
@@ -50,7 +50,10 @@
   "exports": {
     ".": {
       "import": "./lib/esm/index.js",
-      "require": "./lib/cjs/index.js"
-    }
+      "require": "./lib/cjs/index.js",
+      "types": "./lib/esm/index.d.ts"
+    },
+    "./package": "./package.json",
+    "./package.json": "./package.json"
   }
 }

--- a/packages/search-ui-analytics-plugin/package.json
+++ b/packages/search-ui-analytics-plugin/package.json
@@ -34,7 +34,7 @@
     "url": "https://github.com/elastic/search-ui/issues"
   },
   "devDependencies": {
-    "typescript": "^4.5.4"
+    "typescript": "^4.9.3"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/search-ui-analytics-plugin/package.json
+++ b/packages/search-ui-analytics-plugin/package.json
@@ -34,7 +34,6 @@
     "url": "https://github.com/elastic/search-ui/issues"
   },
   "devDependencies": {
-    "@elastic/search-ui": "1.21.4",
     "typescript": "^4.5.4"
   },
   "publishConfig": {
@@ -42,12 +41,16 @@
     "registry": "https://registry.npmjs.org/"
   },
   "dependencies": {
-    "@elastic/behavioral-analytics-tracker-core": "^2.0.5"
+    "@elastic/behavioral-analytics-tracker-core": "^2.0.5",
+    "@elastic/search-ui": "^1.21.4"
   },
   "exports": {
     ".": {
       "import": "./lib/esm/index.js",
-      "require": "./lib/cjs/index.js"
-    }
+      "require": "./lib/cjs/index.js",
+      "types": "./lib/esm/index.d.ts"
+    },
+    "./package": "./package.json",
+    "./package.json": "./package.json"
   }
 }

--- a/packages/search-ui-app-search-connector/package.json
+++ b/packages/search-ui-app-search-connector/package.json
@@ -44,7 +44,10 @@
   "exports": {
     ".": {
       "import": "./lib/esm/index.js",
-      "require": "./lib/cjs/index.js"
-    }
+      "require": "./lib/cjs/index.js",
+      "types": "./lib/esm/index.d.ts"
+    },
+    "./package": "./package.json",
+    "./package.json": "./package.json"
   }
 }

--- a/packages/search-ui-app-search-connector/package.json
+++ b/packages/search-ui-app-search-connector/package.json
@@ -35,7 +35,7 @@
   },
   "devDependencies": {
     "rimraf": "^2.6.3",
-    "typescript": "^4.5.4"
+    "typescript": "^4.9.3"
   },
   "dependencies": {
     "@elastic/app-search-javascript": "^8.1.2",

--- a/packages/search-ui-elasticsearch-connector/package.json
+++ b/packages/search-ui-elasticsearch-connector/package.json
@@ -46,7 +46,10 @@
   "exports": {
     ".": {
       "import": "./lib/esm/index.js",
-      "require": "./lib/cjs/index.js"
-    }
+      "require": "./lib/cjs/index.js",
+      "types": "./lib/esm/index.d.ts"
+    },
+    "./package": "./package.json",
+    "./package.json": "./package.json"
   }
 }

--- a/packages/search-ui-elasticsearch-connector/package.json
+++ b/packages/search-ui-elasticsearch-connector/package.json
@@ -36,7 +36,7 @@
   },
   "devDependencies": {
     "rimraf": "^2.6.3",
-    "typescript": "^4.5.4"
+    "typescript": "^4.9.3"
   },
   "dependencies": {
     "@elastic/elasticsearch": "^8.2.1",

--- a/packages/search-ui-engines-connector/package.json
+++ b/packages/search-ui-engines-connector/package.json
@@ -52,7 +52,10 @@
   "exports": {
     ".": {
       "import": "./lib/esm/index.js",
-      "require": "./lib/cjs/index.js"
-    }
+      "require": "./lib/cjs/index.js",
+      "types": "./lib/esm/index.d.ts"
+    },
+    "./package": "./package.json",
+    "./package.json": "./package.json"
   }
 }

--- a/packages/search-ui-engines-connector/package.json
+++ b/packages/search-ui-engines-connector/package.json
@@ -39,7 +39,7 @@
     "cross-fetch": "^3.1.4",
     "nock": "^13.3.0",
     "rimraf": "^2.6.3",
-    "typescript": "^4.5.4"
+    "typescript": "^4.9.3"
   },
   "dependencies": {
     "@elastic/search-ui": "1.21.4",

--- a/packages/search-ui-site-search-connector/package.json
+++ b/packages/search-ui-site-search-connector/package.json
@@ -35,7 +35,7 @@
   },
   "devDependencies": {
     "rimraf": "^2.6.3",
-    "typescript": "^4.5.4"
+    "typescript": "^4.9.3"
   },
   "dependencies": {
     "@elastic/search-ui": "1.21.4"

--- a/packages/search-ui-site-search-connector/package.json
+++ b/packages/search-ui-site-search-connector/package.json
@@ -43,7 +43,10 @@
   "exports": {
     ".": {
       "import": "./lib/esm/index.js",
-      "require": "./lib/cjs/index.js"
-    }
+      "require": "./lib/cjs/index.js",
+      "types": "./lib/esm/index.d.ts"
+    },
+    "./package": "./package.json",
+    "./package.json": "./package.json"
   }
 }

--- a/packages/search-ui-workplace-search-connector/package.json
+++ b/packages/search-ui-workplace-search-connector/package.json
@@ -45,7 +45,10 @@
   "exports": {
     ".": {
       "import": "./lib/esm/index.js",
-      "require": "./lib/cjs/index.js"
-    }
+      "require": "./lib/cjs/index.js",
+      "types": "./lib/esm/index.d.ts"
+    },
+    "./package": "./package.json",
+    "./package.json": "./package.json"
   }
 }

--- a/packages/search-ui-workplace-search-connector/package.json
+++ b/packages/search-ui-workplace-search-connector/package.json
@@ -36,7 +36,7 @@
   },
   "devDependencies": {
     "rimraf": "^2.6.3",
-    "typescript": "^4.5.4"
+    "typescript": "^4.9.3"
   },
   "dependencies": {
     "@elastic/search-ui": "1.21.4",

--- a/packages/search-ui/package.json
+++ b/packages/search-ui/package.json
@@ -37,7 +37,7 @@
     "@types/history": "^4.7.11",
     "@types/qs": "^6.9.7",
     "rimraf": "^2.6.3",
-    "typescript": "^4.5.4"
+    "typescript": "^4.9.3"
   },
   "dependencies": {
     "date-fns": "^1.30.1",

--- a/packages/search-ui/package.json
+++ b/packages/search-ui/package.json
@@ -48,7 +48,10 @@
   "exports": {
     ".": {
       "import": "./lib/esm/index.js",
-      "require": "./lib/cjs/index.js"
-    }
+      "require": "./lib/cjs/index.js",
+      "types": "./lib/esm/index.d.ts"
+    },
+    "./package": "./package.json",
+    "./package.json": "./package.json"
   }
 }

--- a/packages/search-ui/src/types/index.ts
+++ b/packages/search-ui/src/types/index.ts
@@ -84,6 +84,7 @@ export interface AutocompletedSuggestion {
   suggestion?: string;
   data?: any;
   queryType?: "suggestion";
+  index?: number;
 }
 
 export interface AutocompletedResultSuggestion {

--- a/yarn.lock
+++ b/yarn.lock
@@ -16989,10 +16989,15 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^4.5.4, typescript@^4.5.5:
+typescript@^4.5.5:
   version "4.5.5"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.5.tgz#d8c953832d28924a9e3d37c73d729c846c5896f3"
   integrity sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==
+
+typescript@^4.9.3:
+  version "4.9.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
+  integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
 
 uglify-js@^3.1.4:
   version "3.15.1"


### PR DESCRIPTION
## Description
Updates to `package.json` `exports` to include types and package.json
Additionally updated to TS v4.9 as during investigation we found that module support was not fully available in TS until v4.7

## List of changes
- Added `"types": "./lib/esm/index.d.ts"` to `"exports"` configs
- Updates TS to v4.9.3
- Misc. type and dep fixes

## Associated Github Issues
#1046