### PR TITLE
fix: Issue 1060 - date ranges - relative dates

### DIFF
--- a/packages/search-ui-elasticsearch-connector/src/handlers/search/Configuration.ts
+++ b/packages/search-ui-elasticsearch-connector/src/handlers/search/Configuration.ts
@@ -53,8 +53,24 @@ export function getQueryFields(
   });
 }
 
+// A naive regex to match elastic date math expressions. Note is can match on invalid start dates like 2020-99-99T99:00:00||+1y/d
+const elasticRelativeDateRegex =
+  /^(?:now|\d{4}-\d{2}-\d{2}(?:T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z?)?\|\|)(?:[+-]\d[yMwdhHms])?(?:\/[yMwdhHms])?$/;
+
+export function isDateMathString(dateString: string): boolean {
+  if (dateString.match(elasticRelativeDateRegex)) {
+    return true;
+  }
+
+  return false;
+}
+
 export function isValidDateString(dateString: unknown): boolean {
-  return typeof dateString === "string" && !isNaN(Date.parse(dateString));
+  return (
+    typeof dateString === "string" &&
+    (isDateMathString(dateString) || !isNaN(Date.parse(dateString)))
+  );
+  // return typeof dateString === "string" && !isNaN(Date.parse(dateString));
 }
 
 export function isRangeFilter(

--- a/packages/search-ui-elasticsearch-connector/src/handlers/search/__tests__/Configuration.test.ts
+++ b/packages/search-ui-elasticsearch-connector/src/handlers/search/__tests__/Configuration.test.ts
@@ -5,7 +5,8 @@ import type {
 } from "@elastic/search-ui";
 import buildConfiguration, {
   buildBaseFilters,
-  getResultFields
+  getResultFields,
+  isValidDateString
 } from "../Configuration";
 jest.mock("@searchkit/sdk");
 import {
@@ -560,6 +561,38 @@ describe("Search - Configuration", () => {
           }
         ]
       });
+    });
+  });
+
+  describe("Relative dates", () => {
+    const checks = [
+      ["now+1d/d", true],
+      ["now/d", true],
+      ["now-1y/d", true],
+      ["now+1y/y", true],
+      ["now+1y", true],
+      ["2021-01-01||+1y/d", true],
+      ["2021-01-01T00:00:00Z||+1d/d", true],
+      ["not a date||-1y", false]
+    ];
+
+    test.each(checks)("given %p, returns %p", (dt, expected) => {
+      const result = isValidDateString(dt);
+      expect(result).toEqual(expected);
+    });
+  });
+
+  describe("Absolute dates", () => {
+    const checks = [
+      ["2021-01-01", true],
+      ["2024-01-01T00:00:00Z", true],
+      ["2021-01-01 00:00", true],
+      ["Not a date", false]
+    ];
+
+    test.each(checks)("given %p, returns %p", (dt, expected) => {
+      const result = isValidDateString(dt);
+      expect(result).toEqual(expected);
     });
   });
 });


### PR DESCRIPTION
Implement a check for date maths

Before submitting this PR:

1. Make sure you are PR'ing from a fork, please do not push branches directly
   to this repository.
2. Ensure you've written sufficient tests for your work.
3. Double check that your changes will not break existing connectors (if
   applicable).
4. Double check that your changes do not break the `react-search-ui-views`
   storybook (if applicable).

## Description

Date range filters could reasonably be expected to support date math.  (https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-daterange-aggregation.html)

Currently the check used isValidDateString only checks for a valid absolute date.

## List of changes

Added a new method which is based on a regex to spot relative dates.  If it's not a relative date then will continue to behave the sam way.

Added tests to check for the date being correctly processed.



## Associated Github Issues

https://github.com/elastic/search-ui/issues/1060

