### PR TITLE
fix: issue 1062 - filters applied more than once

### DIFF
--- a/packages/search-ui-elasticsearch-connector/src/handlers/search/Request.ts
+++ b/packages/search-ui-elasticsearch-connector/src/handlers/search/Request.ts
@@ -16,7 +16,7 @@ export function getFilters(
   baseFilters: Filter[] = []
 ): MixedFilter[] {
   return filters.reduce((acc, f) => {
-    const isBaseFilter = baseFilters.includes(f);
+    const isBaseFilter = baseFilters.find((base) => base.field === f.field);
     if (isBaseFilter) return acc;
 
     const subFilters = f.values.map((v) => {

--- a/packages/search-ui-elasticsearch-connector/src/handlers/search/__tests__/Request.test.ts
+++ b/packages/search-ui-elasticsearch-connector/src/handlers/search/__tests__/Request.test.ts
@@ -148,7 +148,13 @@ describe("Search - Request", () => {
         type: "any" as const
       };
 
-      expect(getFilters([filter1], [filter1])).toEqual([]);
+      const baseFilter1 = {
+        field: "test",
+        values: ["test", "test2"],
+        type: "any" as const
+      };
+
+      expect(getFilters([filter1], [baseFilter1])).toEqual([]);
     });
 
     it("should exclude the baseFilters and return the only UI filter", () => {


### PR DESCRIPTION
The test uses the same array twice so the check for filters.includes() works.  In the real world the baseFilter and the filter are different.  So I have updated the test and changed the check to use basefilters.find().

Before submitting this PR:

1. Make sure you are PR'ing from a fork, please do not push branches directly
   to this repository.
2. Ensure you've written sufficient tests for your work.
3. Double check that your changes will not break existing connectors (if
   applicable).
4. Double check that your changes do not break the `react-search-ui-views`
   storybook (if applicable).

## Description
This PR addresses the problem with filters being applied more than once.  There is a test for this but it is broken as it uses the same value in two arrays to check for inclusion.  I have updated the test and the code in getFilters.

## List of changes

Updated the test to fix the assumption of two values.
Changed the code in getFilters to use a find rather than includes which will check for the filter.field equality

## Associated Github Issues

fixes #1062 