### PR TITLE
Set search-experiences-team as CODEOWNERS of the search-ui

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @elastic/search-ui-maintainers 
+* @elastic/search-experiences-team 


### PR DESCRIPTION
### Description
After cleaning up Elastic teams, it's required to re-assign `search-ui` codeowners to the proper team.

This PR is dedicated to changing @elastic/search-ui-maintainers team to the @elastic/search-experiences-team in the `CODEOWNERS` file