### PR TITLE
Adjust read-only key permission example

### DIFF
--- a/docs/tutorials-elasticsearch.mdx
+++ b/docs/tutorials-elasticsearch.mdx
@@ -42,7 +42,7 @@ Notice here we are only giving read privileges for this api key. You will need t
 ```json
 {
   "superuser": {
-    "cluster": ["all"],
+    "cluster": [""],
     "indices": [
       {
         "names": ["my-example-movies"],


### PR DESCRIPTION
## Description

Adjusts the example of a read-only API key on this page: https://www.elastic.co/docs/current/search-ui/tutorials/elasticsearch#setting-up-a-read-only-api-key

There is no need to allow this key to read all clusters. The "all" permission allows this key to read cluster health, for example, which is not needed. Ideally API keys do not have any more permissions than they really require.

## List of changes

- Docs update


