### PR TITLE
Add inital AsciiDoc index page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ package-lock.json
 packages/**/src/version.ts
 packages/**/lib/*
 coverage
+html_docs

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -1,0 +1,7 @@
+:doctype: book
+
+= Search UI
+
+⚠️ This is a work in progress. ⚠️
+
+For the current Search UI documentation, refer to https://www.elastic.co/docs/current/search-ui/overview[elastic.co/docs/current/search-ui].


### PR DESCRIPTION
## Description

Adds a placeholder AsciiDoc index file to be used in a new Search UI book.

This is part of an effort to move the [current Search UI docs](https://www.elastic.co/docs/current/search-ui/overview) to AsciiDoc. There is a bit of a 🐔 / 🥚 problem with this process:

* This PR must be merged before the elastic/docs PR that adds the Search UI book (https://github.com/elastic/docs/pull/3140).
* The elastic/docs PR adds a stub Search UI book with the `index.asciidoc` file as the only page. This stub book will _not_ be indexable by search engines. 
* After that elastic/docs PR is merged, I will open a PR in this repo to add all the AsciiDoc content. That PR will include a preview that the docs and search teams can use to validate the AsciiDoc version of the Search UI docs.
* After that PR is merged and the full Search UI book is live, I'll open _another_ PR in the elastic/docs repo to remove `noindex` so the book will start being indexed by search engines.

## List of changes

* `index.asciidoc`: Placeholder index file to set us up for creating AsciiDoc previews of the new Search UI book.
* `.gitignore`: Adds `html_docs`, which is a directory that may be generated when you build the docs locally.

## Associated Github Issues

Related to https://github.com/elastic/docs/pull/3140