### PR TITLE
Add doc-preview workflow

### DIFF
--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -1,0 +1,23 @@
+name: docs-preview
+on:
+  pull_request_target:
+    types: [opened]
+    paths:
+      - '**.asciidoc'
+      - '**.jpg'
+      - '**.png'
+      - '**.gif'
+
+permissions:
+  pull-requests: write
+
+jobs:
+  doc-preview-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: elastic/docs/.github/actions/docs-preview@master
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          repo: ${{ github.event.repository.name }}
+          preview-path: 'guide/index.html'
+          pr: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
Before submitting this PR:

1. Make sure you are PR'ing from a fork, please do not push branches directly
   to this repository.
2. Ensure you've written sufficient tests for your work.
3. Double check that your changes will not break existing connectors (if
   applicable).
4. Double check that your changes do not break the `react-search-ui-views`
   storybook (if applicable).

## Description

Adds a workflow that will add a comment to each PR that touches a file relevant to the AsciiDoc docs build. The comment will look like:

<img width="937" alt="image" src="https://github.com/user-attachments/assets/fa059867-9a48-4be6-b581-e043cbe47ef9">


## List of changes

Adds workflow file.

## Associated Github Issues

Related to https://github.com/elastic/docs/pull/3140 and #1093 

cc @joemcelroy 