### PR TITLE
Update tutorials-elasticsearch.asciidoc

### DIFF
--- a/docs/tutorials-elasticsearch.asciidoc
+++ b/docs/tutorials-elasticsearch.asciidoc
@@ -480,7 +480,7 @@ We are going to do several steps here:
           <Facet key={"2"} field={"actors.keyword"} label={"actors"} />
           <Facet key={"3"} field={"directors.keyword"} label={"directors"} />
           <Facet key={"4"} field={"released"} label={"released"} />
-          <Facet key={"4"} field={"imdbRating"} label={"imdb rating"} />
+          <Facet key={"5"} field={"imdbRating"} label={"imdb rating"} />
         </div>
       }
       bodyContent={<Results shouldTrackClickThrough={true} />}


### PR DESCRIPTION
## Description
Typo line 483,  facet keys need to be unique there are 2 number 4's. Changed the last one to a 5.

resulting in error as such otherwise 

```react-dom.development.js:67 Warning: Encountered two children with the same key, `4`. Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behavior is unsupported and could change in a future version.
at div
...< truncated remaining error msg>

## List of changes
change 4 > 5 for last facet in example in tutorial line 483