### PR TITLE
[DOCS] Replace hard-coded links to master

### DIFF
--- a/docs/api-connectors-elasticsearch.asciidoc
+++ b/docs/api-connectors-elasticsearch.asciidoc
@@ -156,7 +156,7 @@ The connector will perform a `_search` query and will derive the endpoint path w
 [[api-connectors-elasticsearch-use-an-elasticsearch-api-key]]
 === Use an Elasticsearch api-key
 
-You can restrict access to indices by using an API key. We recommend you create an apiKey that is restricted to the particular index and has read-only authorization. See https://www.elastic.co/guide/en/kibana/master/api-keys.html[Kibana API keys guide]. To use the API key, place it within the Elasticsearch connection configuration.
+You can restrict access to indices by using an API key. We recommend you create an apiKey that is restricted to the particular index and has read-only authorization. See {kibana-ref}/api-keys.html[Kibana API keys guide]. To use the API key, place it within the Elasticsearch connection configuration.
 
 [discrete]
 [[api-connectors-elasticsearch-autocomplete]]

--- a/packages/search-ui-elasticsearch-connector/README.md
+++ b/packages/search-ui-elasticsearch-connector/README.md
@@ -40,12 +40,12 @@ const connector = new ElasticsearchAPIConnector({
 
 **Kind**: global typedef
 
-| Param  | Type                | Default        | Description                                                                                                                                  |
-| ------ | ------------------- | -------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
-| cloud  | <code>Object</code> | { id: string } | Elastic cloud configuration. Can be found in your cloud deployment dashboard.                                                                |
-| host   | <code>string</code> |                | Elasticsearch host.                                                                                                                          |
-| index  | <code>string</code> |                | Index name for where the search documents are contained in                                                                                   |
-| apiKey | <code>string</code> |                | Optional. Credential thats setup within Kibana's UI. see [kibana API keys guide](https://www.elastic.co/guide/en/kibana/main/api-keys.html). |
+| Param  | Type                | Default        | Description                                                                                                                                     |
+| ------ | ------------------- | -------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| cloud  | <code>Object</code> | { id: string } | Elastic cloud configuration. Can be found in your cloud deployment dashboard.                                                                   |
+| host   | <code>string</code> |                | Elasticsearch host.                                                                                                                             |
+| index  | <code>string</code> |                | Index name for where the search documents are contained in                                                                                      |
+| apiKey | <code>string</code> |                | Optional. Credential thats setup within Kibana's UI. see [kibana API keys guide](https://www.elastic.co/guide/en/kibana/current/api-keys.html). |
 
 ## Query Configuration Requirements
 
@@ -69,4 +69,4 @@ To do this, provide the host to be the location of the API. Example `host: "http
 
 ### Use an Elasticsearch api-key
 
-You can restrict access to indices via an api-key. See [kibana API keys guide](https://www.elastic.co/guide/en/kibana/main/api-keys.html)
+You can restrict access to indices via an api-key. See [kibana API keys guide](https://www.elastic.co/guide/en/kibana/current/api-keys.html)


### PR DESCRIPTION
Relates to https://github.com/elastic/docs/pull/3160

## Description

This PR updates links that target the master branch of the documentation, for example links in https://www.elastic.co/guide/en/search-ui/current/api-connectors-elasticsearch.html

The are causing the following documentation build errors when we retire the master documentation:

```
...
INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/search-ui/current/api-connectors-elasticsearch.html contains broken links to:
--
  | INFO:build_docs:   - en/kibana/master/api-keys.html
```

## List of changes

## Associated Github Issues
