### PR TITLE
Add check for numeric facet value

### DIFF
--- a/packages/react-search-ui-views/src/BooleanFacet.tsx
+++ b/packages/react-search-ui-views/src/BooleanFacet.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { FacetViewProps } from "./types";
+import { helpers } from "@elastic/search-ui";
 
 import { appendClassName } from "./view-helpers";
 
@@ -8,12 +9,13 @@ function BooleanFacet({
   label,
   options,
   onChange,
-  onRemove,
-  values
+  onRemove
 }: FacetViewProps) {
-  const trueOptions = options.find((option) => option.value === "true");
-  if (!trueOptions) return null;
-  const isSelected = values.includes("true");
+  const trueOption = options.find((option) =>
+    helpers.getFilterBooleanValue(option.value)
+  );
+  if (!trueOption) return null;
+  const isSelected = trueOption.selected;
 
   const apply = () => onChange("true");
   const remove = () => onRemove("true");
@@ -38,7 +40,7 @@ function BooleanFacet({
               <span className="sui-boolean-facet__input-text">{label}</span>
             </div>
             <span className="sui-boolean-facet__option-count">
-              {trueOptions.count}
+              {trueOption.count}
             </span>
           </label>
         </div>

--- a/packages/react-search-ui-views/src/__tests__/BooleanFacet.test.tsx
+++ b/packages/react-search-ui-views/src/__tests__/BooleanFacet.test.tsx
@@ -16,6 +16,7 @@ const params: FacetViewProps = {
   options: [
     {
       value: "true",
+      selected: false,
       count: 10
     }
   ],
@@ -48,7 +49,21 @@ it("onRemove is called on click", () => {
     <BooleanFacet
       {...{
         ...params,
-        values: ["true"]
+        options: [{value: "true", count:10, selected: true}],
+      }}
+    />
+  );
+
+  wrapper.find("input").simulate("change");
+  expect(params.onRemove).toHaveBeenCalledTimes(1);
+});
+
+it("onRemove is called on click when value is number", () => {
+  const wrapper = mount(
+    <BooleanFacet
+      {...{
+        ...params,
+        options: [{value: 1, count:10, selected: true}],
       }}
     />
   );

--- a/packages/react-search-ui-views/src/__tests__/BooleanFacet.test.tsx
+++ b/packages/react-search-ui-views/src/__tests__/BooleanFacet.test.tsx
@@ -23,6 +23,10 @@ const params: FacetViewProps = {
   values: []
 };
 
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
 it("renders", () => {
   const wrapper = shallow(<BooleanFacet {...params} />);
   expect(wrapper).toMatchSnapshot();
@@ -49,7 +53,7 @@ it("onRemove is called on click", () => {
     <BooleanFacet
       {...{
         ...params,
-        options: [{value: "true", count:10, selected: true}],
+        options: [{ value: "true", count: 10, selected: true }]
       }}
     />
   );
@@ -63,7 +67,7 @@ it("onRemove is called on click when value is number", () => {
     <BooleanFacet
       {...{
         ...params,
-        options: [{value: 1, count:10, selected: true}],
+        options: [{ value: 1, count: 10, selected: true }]
       }}
     />
   );

--- a/packages/search-ui/src/__tests__/helpers.test.ts
+++ b/packages/search-ui/src/__tests__/helpers.test.ts
@@ -5,6 +5,7 @@ const doFilterValuesMatch = helpers.doFilterValuesMatch;
 const markSelectedFacetValuesFromFilters =
   helpers.markSelectedFacetValuesFromFilters;
 const mergeFilters = helpers.mergeFilters;
+const getFilterBooleanValue = helpers.getFilterBooleanValue;
 
 describe("doFilterValuesMatch", () => {
   describe("when matching simple values", () => {
@@ -107,6 +108,20 @@ describe("doFilterValuesMatch", () => {
       const filterValue2 = {};
       expect(doFilterValuesMatch(filterValue1, filterValue2)).toBe(true);
     });
+  });
+
+  describe("when matching boolean values", () => {
+    it("will match string 'true' with boolean true", () => {
+      expect(doFilterValuesMatch("true", true)).toBe(true);
+    });
+
+    it("will match numeric 1 with boolean true", () => {
+      expect(doFilterValuesMatch(1, "true")).toBe(true);
+    });
+
+    it('will not match string true with numeric 0', () => {
+      expect(doFilterValuesMatch('true', 0)).toBe(false);
+    })
   });
 });
 
@@ -239,5 +254,30 @@ describe("mergeFilters", () => {
       expect(isFilterValueRange(1)).toBe(false);
       expect(isFilterValueRange("1")).toBe(false);
     });
+  });
+});
+
+describe("getFilterBooleanValue", () => {
+  it("handles string values", () => {
+    expect(getFilterBooleanValue("true")).toBe(true);
+    expect(getFilterBooleanValue("false")).toBe(false);
+    expect(getFilterBooleanValue("1")).toBe(false);
+    expect(getFilterBooleanValue("0")).toBe(false);
+  });
+
+  it("handles numeric values", () => {
+    expect(getFilterBooleanValue(1)).toBe(true);
+    expect(getFilterBooleanValue(0)).toBe(false);
+  });
+
+  it("handles actual boolean values", () => {
+    expect(getFilterBooleanValue(true)).toBe(true);
+    expect(getFilterBooleanValue(false)).toBe(false);
+  });
+
+  it("handles edge cases", () => {
+    expect(getFilterBooleanValue("")).toBe(false);
+    expect(getFilterBooleanValue(null)).toBe(false);
+    expect(getFilterBooleanValue(undefined)).toBe(false);
   });
 });

--- a/packages/search-ui/src/helpers.ts
+++ b/packages/search-ui/src/helpers.ts
@@ -95,6 +95,12 @@ export function markSelectedFacetValuesFromFilters(
  * @param {FilterValue} filterValue2
  */
 export function doFilterValuesMatch(filterValue1, filterValue2) {
+  if (filterValue1 === "true" || filterValue2 === "true")
+    // Filter value has "true" value and facet may have 1 or "true"
+    return (
+      getFilterBooleanValue(filterValue1) ===
+      getFilterBooleanValue(filterValue2)
+    );
   if (
     filterValue1 &&
     filterValue1.name &&
@@ -150,3 +156,8 @@ export const serialiseFilter = (filterValues: FilterValue[]) => {
     }, [])
     .join(",");
 };
+
+export const getFilterBooleanValue = (filterValue: FilterValue) =>
+  typeof filterValue === "string"
+    ? filterValue === "true"
+    : Boolean(filterValue);


### PR DESCRIPTION
## Description
The BooleanFacet component does not work correctly with the Elasticsearch connector, because it's use of 0/1 values and true/false.

## Associated Github Issues
https://github.com/elastic/search-ui/issues/851
