### PR TITLE
Remove technical preview note for elasticsearch connector

### DIFF
--- a/docs/api-connectors-elasticsearch.asciidoc
+++ b/docs/api-connectors-elasticsearch.asciidoc
@@ -3,12 +3,6 @@
 
 // :keywords: demo
 
-.Technical preview
-[IMPORTANT]
-====
-Elasticsearch connector for Search UI is currently in technical preview
-status. It is not ready for production use.
-====
 
 Search UI provides a way to connect to Elasticsearch directly without needing Enterprise Search. This is useful for when you dont need the features of Enterprise Search, such as relevance tuning.
 

--- a/docs/tutorials-connectors.asciidoc
+++ b/docs/tutorials-connectors.asciidoc
@@ -17,7 +17,7 @@ Search UI works best with **Elastic App Search** and **Elasticsearch**.
 
 If you're relatively new to the search problem or Elastic ecosystem, we recommend choosing **https://www.elastic.co/enterprise-search/search-applications[App Search]**. It solves many search problems out-of-box and is generally simpler to start with, althought it's not as flexible as Elasticsearch.
 
-On the other hand, if you prefer flexibility over simplicity and already familiar with **https://www.elastic.co/elasticsearch[Elasticsearch]**, go with it! Just note that our Elasticsearch connector is still in technical preview and its API might change in the future.
+On the other hand, if you prefer flexibility over simplicity and already familiar with **https://www.elastic.co/elasticsearch[Elasticsearch]**, go with it!
 
 If you're still not sure, go with App Search. It'll help you start quickly, and you can switch to Elasticsearch later if you need to.
 

--- a/docs/tutorials-elasticsearch.asciidoc
+++ b/docs/tutorials-elasticsearch.asciidoc
@@ -4,13 +4,6 @@
 // :description: Build a search experience with Elasticsearch and Search UI
 // :keywords: Tutorial, Elasticsearch, movies
 
-.Technical preview
-[IMPORTANT]
-====
-Elasticsearch connector for Search UI is currently in technical preview
-status. It is not ready for production use.
-====
-
 This tutorial will guide you through the process of creating a Search UI with Elasticsearch directly, using the `elasticsearch-connector`. We will be using a sample movie data-set of around 1000 movies.
 
 Within this tutorial, we assume that you have Node.js installed on your machine.

--- a/packages/search-ui-elasticsearch-connector/README.md
+++ b/packages/search-ui-elasticsearch-connector/README.md
@@ -4,8 +4,6 @@ Part of the [Search UI](https://github.com/elastic/search-ui) project.
 
 This Connector is used to connect Search UI directly to Elasticsearch.
 
-> ⚠️ Elasticsearch connector for Search UI is currently in technical preview status. It is not ready for production use. ⚠️
-
 ## Usage
 
 ```shell


### PR DESCRIPTION
## Description
Remove "Technical preview" not as Elasticsearch connector goes in GA
