### PR TITLE
Add persistent prop to filters

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,17 +1,17 @@
 # Working with the docs
 
-The [Search UI docs](https://www.elastic.co/guide/en/search-ui/current/overview.html) are written in [AsciiDoc](https://github.com/elastic/docs?tab=readme-ov-file#asciidoc-guide) and are built using [elastic/docs](https://github.com/elastic/docs).
+The [Search UI docs](https://www.elastic.co/guide/en/search-ui/current/overview.html) are written in [Docs V3](https://elastic.github.io/docs-builder/) and are built using [elastic/docs](https://github.com/elastic/docs).
 
 ## Build the docs locally
 
 Before building the docs locally make sure you have:
 
-- Docker
-- Python 3
-- [elastic/docs](https://github.com/elastic/docs) cloned locally
+- [docs-builder](https://elastic.github.io/docs-builder/contribute/locally/#step-one) install locally
 
-Assuming your local copy of the elastic/docs repo is in the same repo as your local copy of this repo, run this command from inside your local copy of this repo:
+Install `docs-builder` in a parent directory and run
 
 ```
-../docs/build_docs --doc ./docs/index.asciidoc --chunk 3 --open
+../docs-builder serve -p ./docs
 ```
+
+And open: [http://localhost:3000/reference/](http://localhost:3000/reference/)

--- a/docs/reference/api-core-actions.md
+++ b/docs/reference/api-core-actions.md
@@ -40,7 +40,8 @@ This will only result in a single API call.
 addFilter(
   name: string,
   value: FilterValue,
-  type: FilterType = "all"
+  type: FilterType = "all",
+  persistent?: Boolean
 )
 ```
 
@@ -53,8 +54,8 @@ addFilter("states", "Alaska");
 addFilter("isPublished", true);
 addFilter("rating", 1);
 
-addFilter("states", ["Alaska", "California"], "all");
-addFilter("states", ["Alaska", "California"], "any");
+addFilter("states", ["Alaska", "California"], "all", true);
+addFilter("states", ["Alaska", "California"], "any", true);
 
 addFilter("published", {
   name: "published",
@@ -71,11 +72,12 @@ addFilter("rating", {
 
 ### Parameters [api-core-actions-parameters-1]
 
-| Parameters | description                                                                                |
-| ---------- | ------------------------------------------------------------------------------------------ |
-| `name`     | Required. Name of the field                                                                |
-| `value`    | Required. Filter Value. See `FilterValue` type.                                            |
-| `type`     | Optional. Defaults to `all`. How the filter is applied. Can be one of `any`, `all`, `none` |
+| Parameters   | description                                                                                |
+| ------------ | ------------------------------------------------------------------------------------------ |
+| `name`       | Required. Name of the field                                                                |
+| `value`      | Required. Filter Value. See `FilterValue` type.                                            |
+| `type`       | Optional. Defaults to `all`. How the filter is applied. Can be one of `any`, `all`, `none` |
+| `persistent` | Optional. Set true, the facet filter will not be cleared when a new search is performed    |
 
 ## setFilter [api-core-actions-setfilter]
 
@@ -83,7 +85,8 @@ addFilter("rating", {
 setFilter(
   name: string,
   value: FilterValue,
-  type: FilterType = "all"
+  type: FilterType = "all",
+  persistent?: Boolean
 )
 ```
 
@@ -96,8 +99,8 @@ setFilter("states", "Alaska");
 setFilter("isPublished", true);
 setFilter("rating", 1);
 
-setFilter("states", ["Alaska", "California"], "all");
-setFilter("states", ["Alaska", "California"], "any");
+setFilter("states", ["Alaska", "California"], "all", true);
+setFilter("states", ["Alaska", "California"], "any", true);
 
 setFilter("published", {
   name: "published",
@@ -114,11 +117,12 @@ setFilter("rating", {
 
 ### Parameters [api-core-actions-parameters-3]
 
-| Parameters | description                                                                                |
-| ---------- | ------------------------------------------------------------------------------------------ |
-| `name`     | Required. Name of the field                                                                |
-| `value`    | Required. Filter Value. See `FilterValue` type.                                            |
-| `type`     | Optional. Defaults to `all`. How the filter is applied. Can be one of `any`, `all`, `none` |
+| Parameters   | description                                                                                |
+| ------------ | ------------------------------------------------------------------------------------------ |
+| `name`       | Required. Name of the field                                                                |
+| `value`      | Required. Filter Value. See `FilterValue` type.                                            |
+| `type`       | Optional. Defaults to `all`. How the filter is applied. Can be one of `any`, `all`, `none` |
+| `persistent` | Optional. Set true, the facet filter will not be cleared when a new search is performed    |
 
 ## removeFilter [api-core-actions-removefilter]
 

--- a/docs/reference/api-core-configuration.md
+++ b/docs/reference/api-core-configuration.md
@@ -1,5 +1,4 @@
 ---
-navigation_title: "Core API"
 mapped_pages:
   - https://www.elastic.co/guide/en/search-ui/current/api-core-configuration.html
 ---

--- a/docs/reference/api-core-index.md
+++ b/docs/reference/api-core-index.md
@@ -1,0 +1,54 @@
+---
+mapped_pages:
+  - https://www.elastic.co/guide/en/search-ui/current/api-core-index.html
+---
+
+# Core API
+
+Core API is the main set of interfaces and configurations used to set up and manage search functionality in Search UI.
+
+## Core Components
+
+Core API consists of three main parts:
+
+1. [Configuration](/reference/api-core-configuration.md) - configuration of search queries, autocomplete, and event handlers
+2. [State](/reference/api-core-state.md) - application state management, including:
+   - Request State
+   - Response State
+   - Application State
+3. [Actions](/reference/api-core-actions.md) - functions to update the Request State and perform API requests, including:
+   - Search term management
+   - Filter operations
+   - Sorting
+   - Pagination
+   - Analytics tracking
+
+## Key Features
+
+- Search query configuration with support for filters and facets
+- Autocomplete and suggestions configuration
+- Application state management
+- Integration with various search backends through connectors
+- URL state and routing configuration
+
+## Usage Example
+
+```jsx
+import { SearchProvider } from "@elastic/react-search-ui";
+
+const config = {
+  apiConnector: connector,
+  searchQuery: {
+    facets: {
+      states: { type: "value", size: 30 }
+    }
+  },
+  autocompleteQuery: {
+    results: {
+      resultsPerPage: 5
+    }
+  }
+};
+
+<SearchProvider config={config}>{/* Search UI components */}</SearchProvider>;
+```

--- a/docs/reference/api-react-components-facet.md
+++ b/docs/reference/api-react-components-facet.md
@@ -58,16 +58,17 @@ import { MultiCheckboxFacet } from "@elastic/react-search-ui-views";
 
 ## Properties [api-react-components-facet-properties]
 
-| Name         | Description                                                                                                                                                                                                                                                |
-| ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| className    |                                                                                                                                                                                                                                                            |
-| field        | Field name corresponding to this filter. This requires that the corresponding field has been configured in `facets` on the top level Provider.                                                                                                             |
-| filterType   | The type of filter to apply with the selected values. I.e., should "all" of the values match, or just "any" of the values, or "none" of the values. Note: See the example above which describes using "disjunctive" facets in conjunction with filterType. |
-| label        | A static label to show in the facet filter.                                                                                                                                                                                                                |
-| show         | The number of facet filter options to show before concatenating with a "Show more" link.                                                                                                                                                                   |
-| isFilterable | Whether or not to show Facet quick filter.                                                                                                                                                                                                                 |
-| view         | Used to override the default view for this Component. See [View customization](#api-react-components-facet-view-customization) below.                                                                                                                      |
-| \*           | Any other property passed will be passed through and available to use in a Custom View                                                                                                                                                                     |
+| Name           | Description                                                                                                                                                                                                                                                |
+| -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `className`    |                                                                                                                                                                                                                                                            |
+| `field`        | Field name corresponding to this filter. This requires that the corresponding field has been configured in `facets` on the top level Provider.                                                                                                             |
+| `filterType`   | The type of filter to apply with the selected values. I.e., should "all" of the values match, or just "any" of the values, or "none" of the values. Note: See the example above which describes using "disjunctive" facets in conjunction with filterType. |
+| `label`        | A static label to show in the facet filter.                                                                                                                                                                                                                |
+| `show`         | The number of facet filter options to show before concatenating with a "Show more" link.                                                                                                                                                                   |
+| `isFilterable` | Whether or not to show Facet quick filter.                                                                                                                                                                                                                 |
+| `persistent`   | Whether the facet filter should persist across searches. When true, the facet filter will not be cleared when a new search is performed.                                                                                                                   |
+| `view`         | Used to override the default view for this Component. See [View customization](#api-react-components-facet-view-customization) below.                                                                                                                      |
+| `*`            | Any other property passed will be passed through and available to use in a Custom View                                                                                                                                                                     |
 
 ## View customization [api-react-components-facet-view-customization]
 
@@ -75,20 +76,20 @@ A complete guide to view customization can be found in the [Customization: Compo
 
 The following properties are available in the view:
 
-| Name              | Description                                                                                                                                                    |
-| ----------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| className         | Passed through from main component.                                                                                                                            |
-| label             | Type: `string`. Passed through from main component.                                                                                                            |
-| onMoreClick       | Type: `() => void`. Used for a "Show more" link. Call this to show more options.                                                                               |
-| onRemove          | Type: `(value: FieldValue) => void`. Call this when a user removes a facet filter selection. Pass the `value` from the corresponding selection from `options`. |
-| onChange          | Type: `(value: FieldValue) => void`. Call this when a user changes a facet filter selection. Pass the `value` from the corresponding selection from `options`. |
-| onSelect          | Type: `(value: FieldValue) => void`. Call this when a user adds a facet filter selection. Pass the `value` from the corresponding selection from `options`.    |
-| options           | Type: `FacetValue[]`. The options to show available for selection for this facet. `selected` property will be true if this values is selected.                 |
-| showMore          | Type: `boolean`. Whether or not to show a "Show more" link. If there are no more options available to show, then this will be `false`.                         |
-| values            | Type: `FilterValue[]`. A list of all the selected values. This can also be deduced be inspected the `selected` properties of the `options`.                    |
-| showSearch        | Type: `boolean`. Whether or not the compopnent is `isFilterable`. This would indicates that a filter search box should be shown.                               |
-| onSearch          | Type: `(value: string) => void`. Call this to filter down the facet options shown. Used if there is a search box shown in relation to `showSearch`.            |
-| searchPlaceholder | Type: `string`. The placeholder fo show in the filter search box when `showSearch` is true.                                                                    |
+| Name                | Description                                                                                                                                                    |
+| ------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `className`         | Passed through from main component.                                                                                                                            |
+| `label`             | Type: `string`. Passed through from main component.                                                                                                            |
+| `onMoreClick`       | Type: `() => void`. Used for a "Show more" link. Call this to show more options.                                                                               |
+| `onRemove`          | Type: `(value: FieldValue) => void`. Call this when a user removes a facet filter selection. Pass the `value` from the corresponding selection from `options`. |
+| `onChange`          | Type: `(value: FieldValue) => void`. Call this when a user changes a facet filter selection. Pass the `value` from the corresponding selection from `options`. |
+| `onSelect`          | Type: `(value: FieldValue) => void`. Call this when a user adds a facet filter selection. Pass the `value` from the corresponding selection from `options`.    |
+| `options`           | Type: `FacetValue[]`. The options to show available for selection for this facet. `selected` property will be true if this values is selected.                 |
+| `showMore`          | Type: `boolean`. Whether or not to show a "Show more" link. If there are no more options available to show, then this will be `false`.                         |
+| `values`            | Type: `FilterValue[]`. A list of all the selected values. This can also be deduced be inspected the `selected` properties of the `options`.                    |
+| `showSearch`        | Type: `boolean`. Whether or not the compopnent is `isFilterable`. This would indicates that a filter search box should be shown.                               |
+| `onSearch`          | Type: `(value: string) => void`. Call this to filter down the facet options shown. Used if there is a search box shown in relation to `showSearch`.            |
+| `searchPlaceholder` | Type: `string`. The placeholder fo show in the filter search box when `showSearch` is true.                                                                    |
 
 See [MultiCheckboxFacet.tsx](https://github.com/elastic/search-ui/blob/main/packages/react-search-ui-views/src/MultiCheckboxFacet.tsx) for an example.
 

--- a/docs/reference/toc.yml
+++ b/docs/reference/toc.yml
@@ -34,8 +34,9 @@ toc:
       - file: guides-nextjs-integration.md
   - file: api-reference.md
     children:
-      - file: api-core-configuration.md
+      - file: api-core-index.md
         children:
+          - file: api-core-configuration.md
           - file: api-core-state.md
           - file: api-core-actions.md
       - file: api-react-search-provider.md

--- a/examples/sandbox/src/pages/elasticsearch-basic/index.jsx
+++ b/examples/sandbox/src/pages/elasticsearch-basic/index.jsx
@@ -250,11 +250,13 @@ export default function App() {
                         label="States"
                         filterType="any"
                         isFilterable={true}
+                        persistent
                       />
                       <Facet
                         field="world_heritage_site.keyword"
                         label="World Heritage Site"
                         view={BooleanFacet}
+                        persistent
                       />
                       <Facet
                         field="visitors"

--- a/packages/react-search-ui-views/src/types/index.ts
+++ b/packages/react-search-ui-views/src/types/index.ts
@@ -93,6 +93,7 @@ export type FacetContainerProps = BaseContainerProps & {
   isFilterable?: boolean;
   field: string;
   label: string;
+  persistent?: boolean;
 } & FacetContainerContext;
 
 // From SO https://stackoverflow.com/a/59071783

--- a/packages/react-search-ui/src/containers/Facet.tsx
+++ b/packages/react-search-ui/src/containers/Facet.tsx
@@ -25,7 +25,8 @@ export class FacetContainer extends Component<
   static defaultProps = {
     filterType: "all",
     isFilterable: false,
-    show: 5
+    show: 5,
+    persistent: false
   };
 
   constructor(props) {
@@ -66,6 +67,7 @@ export class FacetContainer extends Component<
       setFilter,
       view,
       isFilterable,
+      persistent,
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       a11yNotify,
       ...rest
@@ -127,10 +129,10 @@ export class FacetContainer extends Component<
         removeFilter(field, value, filterType);
       },
       onChange: (value) => {
-        setFilter(field, value, filterType);
+        setFilter(field, value, filterType, persistent);
       },
       onSelect: (value) => {
-        addFilter(field, value, filterType);
+        addFilter(field, value, filterType, persistent);
       },
       options: facetValues.slice(0, more),
       showMore: facetValues.length > more,

--- a/packages/react-search-ui/src/containers/__tests__/Facet.test.tsx
+++ b/packages/react-search-ui/src/containers/__tests__/Facet.test.tsx
@@ -476,13 +476,13 @@ describe("search facets", () => {
 
     wrapper.find<FacetViewProps>(View).prop("onSelect")("field1value2");
 
-    expect(params.addFilter).toHaveBeenCalledWith(
+    expect(mockSearchParams.addFilter).toHaveBeenCalledWith(
       "field1",
       "field1value2",
       "all",
       true
     );
-    expect(params.setFilter).not.toHaveBeenCalled();
+    expect(mockSearchParams.setFilter).not.toHaveBeenCalled();
   });
 
   it("should not clear persistent filters on change", () => {
@@ -492,12 +492,12 @@ describe("search facets", () => {
 
     wrapper.find<FacetViewProps>(View).prop("onChange")("field1value2");
 
-    expect(params.setFilter).toHaveBeenCalledWith(
+    expect(mockSearchParams.setFilter).toHaveBeenCalledWith(
       "field1",
       "field1value2",
       "all",
       true
     );
-    expect(params.addFilter).not.toHaveBeenCalled();
+    expect(mockSearchParams.addFilter).not.toHaveBeenCalled();
   });
 });

--- a/packages/react-search-ui/src/containers/__tests__/Facet.test.tsx
+++ b/packages/react-search-ui/src/containers/__tests__/Facet.test.tsx
@@ -446,4 +446,36 @@ describe("search facets", () => {
 
     expect(newWrapper.find(View).prop("showSearch")).toEqual(false);
   });
+
+  it("should not clear persistent filters on select", () => {
+    const wrapper = subject({
+      persistent: true
+    });
+
+    wrapper.find<FacetViewProps>(View).prop("onSelect")("field1value2");
+
+    expect(params.addFilter).toHaveBeenCalledWith(
+      "field1",
+      "field1value2",
+      "all",
+      true
+    );
+    expect(params.setFilter).not.toHaveBeenCalled();
+  });
+
+  it("should not clear persistent filters on change", () => {
+    const wrapper = subject({
+      persistent: true
+    });
+
+    wrapper.find<FacetViewProps>(View).prop("onChange")("field1value2");
+
+    expect(params.setFilter).toHaveBeenCalledWith(
+      "field1",
+      "field1value2",
+      "all",
+      true
+    );
+    expect(params.addFilter).not.toHaveBeenCalled();
+  });
 });

--- a/packages/search-ui/src/__tests__/actions/addFilter.test.ts
+++ b/packages/search-ui/src/__tests__/actions/addFilter.test.ts
@@ -31,7 +31,7 @@ describe("#addFilter", () => {
         current: null
       }
     }: SubjectArguments = {},
-    persistent
+    persistent?: boolean
   ) {
     const { driver, updatedStateAfterAction } = setupDriver({
       initialState

--- a/packages/search-ui/src/__tests__/actions/addFilter.test.ts
+++ b/packages/search-ui/src/__tests__/actions/addFilter.test.ts
@@ -30,13 +30,14 @@ describe("#addFilter", () => {
         filters: initialFilters,
         current: null
       }
-    }: SubjectArguments = {}
+    }: SubjectArguments = {},
+    persistent
   ) {
     const { driver, updatedStateAfterAction } = setupDriver({
       initialState
     });
 
-    driver.addFilter(name, value, type);
+    driver.addFilter(name, value, type, persistent);
     jest.runAllTimers();
     return updatedStateAfterAction.state;
   }
@@ -257,6 +258,22 @@ describe("#addFilter", () => {
       { field: "test", values: ["value"], type: "all" },
       { field: "test", values: ["value"], type: "none" },
       { field: "test", values: ["value", "value1"], type: "any" }
+    ]);
+  });
+
+  it("Will add a persistent filter", () => {
+    expect(
+      subject(
+        "test",
+        "value",
+        "any",
+        {
+          initialFilters: [{ field: "test", values: ["value"], type: "all" }]
+        },
+        true
+      ).filters
+    ).toEqual([
+      { field: "test", values: ["value"], type: "all", persistent: true }
     ]);
   });
 });

--- a/packages/search-ui/src/__tests__/actions/setFilter.test.ts
+++ b/packages/search-ui/src/__tests__/actions/setFilter.test.ts
@@ -27,7 +27,7 @@ describe("#setFilter", () => {
         filters: initialFilters
       }
     }: SubjectArguments = {},
-    persistent
+    persistent?: boolean
   ) {
     const { driver, updatedStateAfterAction } = setupDriver({
       initialState

--- a/packages/search-ui/src/__tests__/actions/setFilter.test.ts
+++ b/packages/search-ui/src/__tests__/actions/setFilter.test.ts
@@ -26,13 +26,14 @@ describe("#setFilter", () => {
       initialState = {
         filters: initialFilters
       }
-    }: SubjectArguments = {}
+    }: SubjectArguments = {},
+    persistent
   ) {
     const { driver, updatedStateAfterAction } = setupDriver({
       initialState
     });
 
-    driver.setFilter(name, value, type);
+    driver.setFilter(name, value, type, persistent);
     jest.runAllTimers();
     return updatedStateAfterAction.state;
   }
@@ -156,6 +157,22 @@ describe("#setFilter", () => {
       { field: "test", values: ["value"], type: "all" },
       { field: "test", values: ["value"], type: "none" },
       { field: "test", values: ["value1"], type: "any" }
+    ]);
+  });
+
+  it("Will add a persistent filter", () => {
+    expect(
+      subject(
+        "test",
+        "value",
+        "any",
+        {
+          initialFilters: [{ field: "test", values: ["value"], type: "all" }]
+        },
+        true
+      ).filters
+    ).toEqual([
+      { field: "test", values: ["value"], type: "all", persistent: true }
     ]);
   });
 });

--- a/packages/search-ui/src/__tests__/actions/setSearchTerm.test.ts
+++ b/packages/search-ui/src/__tests__/actions/setSearchTerm.test.ts
@@ -99,6 +99,30 @@ describe("#setSearchTerm", () => {
     ]);
   });
 
+  it("Does not clear persistent filters when 'shouldClearFilters' is set to true", () => {
+    const state = subject("test", {
+      initialState: {
+        filters: [
+          {
+            field: "filter1",
+            values: ["value1"],
+            type: "all",
+            persistent: true
+          }
+        ]
+      },
+      shouldClearFilters: false
+    }).state;
+    expect(state.filters).toEqual([
+      {
+        field: "filter1",
+        values: ["value1"],
+        type: "all",
+        persistent: true
+      }
+    ]);
+  });
+
   it("Does not update other Search Parameter values", () => {
     const initialState: RequestState = {
       resultsPerPage: 60,

--- a/packages/search-ui/src/actions/addFilter.ts
+++ b/packages/search-ui/src/actions/addFilter.ts
@@ -10,11 +10,13 @@ import { FilterType, FilterValue, RequestState } from "../types";
  * @param name String field name to filter on
  * @param value String field value to filter on
  * @param type String (Optional) type of filter to apply
+ * @param persistent Boolean (Optional) whether to preserve the filter on new search
  */
 export default function addFilter(
   name: string,
   value: FilterValue,
-  type: FilterType = "all"
+  type: FilterType = "all",
+  persistent?: boolean
 ): void {
   // eslint-disable-next-line no-console
   if (this.debug) console.log("Search UI: Action", "addFilter", ...arguments);
@@ -37,7 +39,7 @@ export default function addFilter(
     current: 1,
     filters: [
       ...allOtherFilters,
-      { field: name, values: newFilterValues, type }
+      { field: name, values: newFilterValues, type, persistent }
     ]
   });
 

--- a/packages/search-ui/src/actions/setFilter.ts
+++ b/packages/search-ui/src/actions/setFilter.ts
@@ -10,11 +10,13 @@ import { FilterType, FilterValue, RequestState } from "../types";
  * @param name String field name to filter on
  * @param value FilterValue to apply
  * @param type String (Optional) type of filter to apply
+ * @param persistent boolean (Optional) whether to preserve the filter on new search
  */
 export default function setFilter(
   name: string,
   value: FilterValue,
-  type: FilterType = "all"
+  type: FilterType = "all",
+  persistent?: boolean
 ) {
   // eslint-disable-next-line no-console
   if (this.debug) console.log("Search UI: Action", "setFilter", ...arguments);
@@ -32,7 +34,8 @@ export default function setFilter(
       {
         field: name,
         values: filterValue,
-        type
+        type,
+        persistent
       }
     ]
   });

--- a/packages/search-ui/src/actions/setSearchTerm.ts
+++ b/packages/search-ui/src/actions/setSearchTerm.ts
@@ -11,6 +11,7 @@
  * results?
  * @param options.refresh Boolean Refresh search results?
  * @param options.debounce Length to debounce API calls
+ * @param options.shouldClearFilters Boolean Clear all filters after search?
  */
 
 type SetSearchTermOptions = {
@@ -40,13 +41,18 @@ export default function setSearchTerm(
   this._setState({ searchTerm });
 
   if (refresh) {
+    // If shouldClearFilters is true, clear all filters except persistent filters
+    const filters = shouldClearFilters
+      ? this.state.filters.filter((filter) => filter.persistent)
+      : this.state.filters;
+
     this.debounceManager.runWithDebounce(
       debounce,
       "_updateSearchResults",
       this._updateSearchResults,
       {
         current: 1,
-        ...(shouldClearFilters && { filters: [] })
+        filters
       }
     );
   }

--- a/packages/search-ui/src/test/sharedTests.js
+++ b/packages/search-ui/src/test/sharedTests.js
@@ -1,6 +1,6 @@
 /* eslint-disable jest/no-export */
 
-import { doesStateHaveResponseData } from "../test/helpers";
+import { doesStateHaveResponseData } from "./helpers";
 
 export function itResetsCurrent(fn) {
   const state = fn();

--- a/packages/search-ui/src/types/index.ts
+++ b/packages/search-ui/src/types/index.ts
@@ -45,6 +45,7 @@ export type Filter = {
   field: string;
   type: FilterType;
   values: FilterValue[];
+  persistent?: boolean;
 };
 
 export type RequestState = {


### PR DESCRIPTION
## Description
Added the ability to preserve selected filters when performing a new search. This provides more flexibility in managing filter states, especially in cases where certain filters need to persist between search queries.

## List of changes
- Added new persistent parameter to the Facet component: `<Facet field="states" label="States" persistent={true} />`
- Added persistent parameter to setFilter and addFilter actions
```
  setFilter("states", "Alaska", "all", true);
   addFilter("states", ["Alaska", "California"], "all", true);
```
- Updated documentation to reflect new functionality:
    - Added description of persistent parameter in Facet component documentation
    - Added description of persistent parameter in setFilter and addFilter actions documentation
    - Updated usage examples in documentation

## Associated Github Issues
- #89 
