### PR TITLE
[DOCS] Cleanup broken links in documentation

### DIFF
--- a/docs/reference/api-react-components-results-per-page.md
+++ b/docs/reference/api-react-components-results-per-page.md
@@ -9,7 +9,9 @@ Shows a dropdown for selecting the number of results to show per page.
 
 Uses [20, 40, 60] as default options. You can use `options` prop to pass custom options.
 
-**Note:** When passing custom options make sure one of the option values match the current `resultsPerPageProp` value, which is 20 by default. To override `resultsPerPage` default value, use the [initial state](/reference/api-react-search-provider.md#api-react-search-provider-initial-state) property.
+:::{note}
+When passing custom options make sure one of the option values match the current `resultsPerPageProp` value, which is 20 by default. To override `resultsPerPage` default value, use the [initial state](/reference/api-react-search-provider.md#api-react-search-provider-initial-state) property.
+:::
 
 ## Example [api-react-components-results-per-page-example]
 

--- a/docs/reference/api-react-components-search-box.md
+++ b/docs/reference/api-react-components-search-box.md
@@ -167,7 +167,9 @@ Autocomplete queries can be customized in the `SearchProvider` configuration, us
 
 "Suggestions" can be generated via multiple methods. They can be derived from common terms and phrases inside of documents, or be "popular" queries generated from actual search queries made by users. This will differ depending on the particular Search API you are using.
 
-**Note**: Elastic App Search currently only supports type "documents", and Elastic Site Search and Workplace Search do not support suggestions. This is purely illustrative in case a Connector is used that does support multiple types.
+:::{note}
+Elastic App Search currently only supports type "documents", and Elastic Site Search and Workplace Search do not support suggestions. This is purely illustrative in case a Connector is used that does support multiple types.
+:::
 
 ```jsx
 <SearchProvider

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -22,8 +22,8 @@ A JavaScript library for the fast development of modern, engaging search experie
 
 - [Elasticsearch](https://codesandbox.io/s/github/elastic/search-ui/tree/main/examples/sandbox?from-embed=&initialpath=/elasticsearch&file=/src/pages/elasticsearch/index.js)
 - [Elastic Site Search (Swiftype)](https://codesandbox.io/s/github/elastic/search-ui/tree/main/examples/sandbox?from-embed=&initialpath=/site-search&file=/src/pages/site-search/index.js)
-- ⚠️ DEPRECATED. [Elastic App Search](https://codesandbox.io/s/github/elastic/search-ui/tree/main/examples/sandbox?from-embed=&initialpath=/app-search&file=/src/pages/app-search/index.js)
-- ⚠️ DEPRECATED. [Elastic Workplace Search](https://codesandbox.io/s/github/elastic/search-ui/tree/main/examples/sandbox?from-embed=&initialpath=/workplace-search&file=/src/pages/workplace-search/index.js)
+- ⚠️ DEPRECATED [Elastic App Search](https://codesandbox.io/s/github/elastic/search-ui/tree/main/examples/sandbox?from-embed=&initialpath=/app-search&file=/src/pages/app-search/index.js)
+- ⚠️ DEPRECATED [Elastic Workplace Search](https://codesandbox.io/s/github/elastic/search-ui/tree/main/examples/sandbox?from-embed=&initialpath=/workplace-search&file=/src/pages/workplace-search/index.js)
 
 ### Examples [overview-examples]
 
@@ -46,8 +46,8 @@ yarn add @elastic/search-ui @elastic/react-search-ui @elastic/react-search-ui-vi
 Get started quickly with Search UI and your favorite Elastic product by following one of the tutorials below:
 
 - [Elasticsearch](/reference/tutorials-elasticsearch.md)
-- [Elastic App Search (⚠️ DEPRECATED)](../../search-ui/docs/⚠️ DEPRECATED)](/reference/tutorials-app-search.md)
-- [Elastic Workplace Search (⚠️ DEPRECATED)](../../search-ui/docs/⚠️ DEPRECATED)](/reference/tutorials-workplace-search.md)
+- ⚠️ DEPRECATED [Elastic App Search](/reference/tutorials-app-search.md)
+- ⚠️ DEPRECATED [Elastic Workplace Search](/reference/tutorials-workplace-search.md)
 
 ## Use Cases 🛠️ [overview-use-cases]
 

--- a/docs/reference/known-issues.md
+++ b/docs/reference/known-issues.md
@@ -1,0 +1,24 @@
+---
+mapped_pages:
+  - https://www.elastic.co/guide/en/search-ui/current/known-issues.html
+
+navigation_title: "Troubleshooting"
+---
+
+# Search known issues [search-known-issues]
+
+% Use the following template to add entries to this page.
+
+% :::{dropdown} Title of known issue
+% **Details** 
+% On [Month/Day/Year], a known issue was discovered that [description of known issue].
+
+% **Workaround** 
+% Workaround description.
+
+% **Resolved**
+% On [Month/Day/Year], this issue was resolved.
+
+:::
+
+* When using the **Elasticsearch connector** Search UI does not render nested objects.

--- a/docs/reference/toc.yml
+++ b/docs/reference/toc.yml
@@ -59,3 +59,4 @@ toc:
           - file: api-connectors-site-search.md
           - file: api-connectors-workplace-search.md
       - file: api-core-plugins-analytics-plugin.md
+  - file: known-issues.md

--- a/docs/reference/tutorials.md
+++ b/docs/reference/tutorials.md
@@ -12,9 +12,9 @@ The first thing you want to consider before implementing your search is the back
 
 Search UI works best with **Elastic App Search** and **Elasticsearch**.
 
-If you’re relatively new to the search problem or Elastic ecosystem, we recommend choosing **https://www.elastic.co/enterprise-search/search-applications[App Search]**. It solves many search problems out-of-box and is generally simpler to start with, althought it’s not as flexible as Elasticsearch.
+If you’re relatively new to the search problem or Elastic ecosystem, we recommend choosing **[App Search](https://www.elastic.co/enterprise-search/search-applications)**. It solves many search problems out-of-box and is generally simpler to start with, althought it’s not as flexible as Elasticsearch.
 
-On the other hand, if you prefer flexibility over simplicity and already familiar with **https://www.elastic.co/elasticsearch[Elasticsearch]**, go with it!
+On the other hand, if you prefer flexibility over simplicity and already familiar with **[Elasticsearch](https://www.elastic.co/elasticsearch)**, go with it!
 
 If you’re still not sure, go with App Search. It’ll help you start quickly, and you can switch to Elasticsearch later if you need to.
 
@@ -22,9 +22,9 @@ If you’re still not sure, go with App Search. It’ll help you start quickly, 
 
 Search UI also works with **Elastic Workplace Search** and **Elastic Site Search**.
 
-Choose **https://www.elastic.co/enterprise-search/workplace-search[Workplace Search]** if it’s critical for you to search data from one of the [supported sources](https://www.elastic.co/guide/en/workplace-search/current/workplace-search-content-sources.html#oauth-first-party-content-sources), like Confluence, Salesforce, Jira or others.
+Choose **[Workplace Search](https://www.elastic.co/enterprise-search/workplace-search)** if it’s critical for you to search data from one of the [supported sources](https://www.elastic.co/guide/en/workplace-search/current/workplace-search-content-sources.html#oauth-first-party-content-sources), like Confluence, Salesforce, Jira or others.
 
-Choose **https://www.elastic.co/enterprise-search/site-search[Site Search]** if you are already using [Swiftype](https://swiftype.com/), these are basically a single product with two names. Otherwise, it’s best to go with the **App Search** connector, since the functionalty of Site Search has already been implemented in the App Search’s web crawler.
+Choose **[Site Search](https://www.elastic.co/enterprise-search/site-search)** if you are already using [Swiftype](https://swiftype.com/), these are basically a single product with two names. Otherwise, it’s best to go with the **App Search** connector, since the functionalty of Site Search has already been implemented in the App Search’s web crawler.
 
 ## Custom connector [tutorials-connectors-custom-connector]
 

--- a/docs/reference/tutorials.md
+++ b/docs/reference/tutorials.md
@@ -14,7 +14,7 @@ Search UI works best with **Elastic App Search** and **Elasticsearch**.
 
 If you’re relatively new to the search problem or Elastic ecosystem, we recommend choosing **[App Search](https://www.elastic.co/enterprise-search/search-applications)**. It solves many search problems out-of-box and is generally simpler to start with, althought it’s not as flexible as Elasticsearch.
 
-On the other hand, if you prefer flexibility over simplicity and already familiar with **[Elasticsearch](https://www.elastic.co/elasticsearch)**, go with it!
+On the other hand, if you prefer flexibility over simplicity and are already familiar with **[Elasticsearch](https://www.elastic.co/elasticsearch)**, go with it!
 
 If you’re still not sure, go with App Search. It’ll help you start quickly, and you can switch to Elasticsearch later if you need to.
 


### PR DESCRIPTION
## Description
- Cleaning up broken links in the documentation and using new v3 syntax for admonitions.
- Restore the known issues page to the Search UI docs from [Docs-content](https://github.com/elastic/docs-content/blob/58e968578d2cf5a0d1f6d51bec25ba3e34eee18e/release-notes/known-issues/search-ui.md?plain=1)

## Associated Github Issues
https://github.com/elastic/search-docs-team/issues/275
