### PR TITLE
[docs] Fix image paths for docs-assembler

### DIFF
--- a/docs/reference/guides-analyzing-performance.md
+++ b/docs/reference/guides-analyzing-performance.md
@@ -7,10 +7,8 @@ mapped_pages:
 
 Search UI allows you to analyze the performance and track errors on your search page by using [Elastic Real User Monitoring](https://www.elastic.co/observability/real-user-monitoring) (RUM).
 
-:::{image} images/dashboard.png
-:alt: RUM dashboard
-:class: screenshot
-:::
+% TO DO: Use `:class: screenshot`
+![RUM dashboard](images/dashboard.png)
 
 APM RUM captures the following information:
 
@@ -50,10 +48,8 @@ The setup process consists of three steps:
    - If you already have Integrations server enabled, go to the next step.
    - If don’t — click "Add capacity" and choose the size of the server.
 
-:::{image} images/integrations-server.png
-:alt: Integrations Server
-:class: screenshot
-:::
+% TO DO: Use `:class: screenshot`
+![Integrations Server](images/integrations-server.png)
 
 ### Checking server status [guides-analyzing-performance-checking-server-status]
 
@@ -62,10 +58,8 @@ The setup process consists of three steps:
 3. On the Observability overview page, find and click the button "Install RUM Agent".
 4. In the tab "Elastic APM in Fleet" find "Check APM Server status" button and click it. You should see a confirmation that APM Server is working.
 
-:::{image} images/server-status.png
-:alt: Server status
-:class: screenshot
-:::
+% TO DO: Use `:class: screenshot`
+![Server status](images/server-status.png)
 
 ### Adding APM RUM to your application [guides-analyzing-performance-adding-apm-rum-to-your-application]
 
@@ -76,10 +70,8 @@ The setup process consists of three steps:
 5. Add the APM RUM dependency to your application: `npm install @elastic/apm-rum`.
 6. Check that the events are sent by opening your browser dev tools and looking at the network tab. You should see the events request being sent after each search request.
 
-:::{image} images/events-request.png
-:alt: Server status
-:class: screenshot
-:::
+% TO DO: Use `:class: screenshot`
+![Server status](images/events-request.png)
 
 If you’re using Search UI in a React application, it’s recommended to also use the React integraton of APM RUM for more detailed analysis. Follow this guide for setting it up: [apm-agent-rum-js://reference/react-integration.md](apm-agent-rum-js://reference/react-integration.md)
 

--- a/docs/reference/solutions-ecommerce-autocomplete.md
+++ b/docs/reference/solutions-ecommerce-autocomplete.md
@@ -7,17 +7,13 @@ mapped_pages:
 
 When you start typing in a search box on ecommerce sites like Amazon or Best Buy, you might have seen a dropdown showing suggestions to try next. This is called autocomplete.
 
-:::{image} images/query-suggestions-amazon.png
-:alt: Search suggestions on Amazon
-:class: screenshot
-:::
+% TO DO: Use `:class: screenshot`
+![Search suggestions on Amazon](images/query-suggestions-amazon.png)
 
 On some of the more popular ecommerce sites, you may see suggestions in the form of search suggestions, product categories, and products.
 
-:::{image} images/federated-search-products.png
-:alt: Multiple Search Suggestions
-:class: screenshot
-:::
+% TO DO: Use `:class: screenshot`
+![Multiple Search Suggestions](images/federated-search-products.png)
 
 This article will discuss how to implement an autocomplete search box that provides multiple options on your ecommerce site.
 
@@ -99,10 +95,8 @@ Term Suggestions help the customer quickly type in the search term. The suggesti
 
 To configure the SearchBox to provide suggestions based on keywords, you need to pass a `config` object to the `SearchProvider` component and configure the `Searchbox autocompleteSuggestions` to be true.
 
-:::{image} images/query-suggestions-es-shop.png
-:alt: Search suggestions with Search UI
-:class: screenshot
-:::
+% TO DO: Use `:class: screenshot`
+![Search suggestions with Search UI](images/query-suggestions-es-shop.png)
 
 Example Code
 
@@ -146,10 +140,8 @@ const config = {
 
 With this feature, products will be presented as suggestions to the customer. When the customer clicks on the product suggestion, they will be navigated straight to the product’s detail page.
 
-:::{image} images/query-results-es-shop.png
-:alt: Search suggestions with Search UI
-:class: screenshot
-:::
+% TO DO: Use `:class: screenshot`
+![Search suggestions with Search UI](images/query-results-es-shop.png)
 
 First, we specify the `autocompleteQuery.results` configuration:
 
@@ -338,10 +330,8 @@ const config = {
 :::::::
 Now, when you type `was` in the SearchBox, the autocomplete view will display the popular queries:
 
-:::{image} images/query-suggestions-popular-queries.png
-:alt: Suggestions from another index
-:class: screenshot
-:::
+% TO DO: Use `:class: screenshot`
+![Suggestions from another index](images/query-suggestions-popular-queries.png)
 
 If you want to display more fields from the index, you can use the `result_fields` configuration and implement a custom `autocompleteView` to display these fields.
 
@@ -349,10 +339,8 @@ If you want to display more fields from the index, you can use the `result_field
 
 Combining the suggestion configurations above allows you to display suggestions from multiple sources simultaneously.
 
-:::{image} images/query-suggestions-multiple-sources.png
-:alt: Suggestions from multiple sources
-:class: screenshot
-:::
+% TO DO: Use `:class: screenshot`
+![Suggestions from multiple sources](images/query-suggestions-multiple-sources.png)
 
 To do this, extend the `autocompleteQuery` configuration to specify multiple sources. For example, in the screenshot above, we customized the `autocompleteView` CSS to display the popular queries and the results from the `autocompleteSuggestions` configuration side by side and hide the section titles.
 

--- a/docs/reference/solutions-ecommerce-carousel.md
+++ b/docs/reference/solutions-ecommerce-carousel.md
@@ -11,10 +11,8 @@ In this example, we show a carousel of products within the "TVs" category using 
 
 You can adjust the number of results returned via the `resultsPerPage` configuration.
 
-:::{image} images/carousel.png
-:alt: carousel
-:class: screenshot
-:::
+% TO DO: Use `:class: screenshot`
+![carousel](images/carousel.png)
 
 :::::::{tab-set}
 

--- a/docs/reference/solutions-ecommerce-category-page.md
+++ b/docs/reference/solutions-ecommerce-category-page.md
@@ -7,10 +7,8 @@ mapped_pages:
 
 This is a category page:
 
-:::{image} images/category-page.png
-:alt: Category page
-:class: screenshot
-:::
+% TO DO: Use `:class: screenshot`
+![Category page](images/category-page.png)
 
 At first glance, the category page looks very similar to a search page — they display a list of products and have facets to help users refine the results. But while the search page is made for "searching" the entire catalog by typing a query, the category page is made for "exploring" a small subset of products with the help of filters.
 
@@ -83,10 +81,8 @@ That’s it! The new category page has a good URL and only shows results that ma
 
 ## Facets [solutions-ecommerce-category-page-facets]
 
-:::{image} images/facets.png
-:alt: Facets
-:class: screenshot
-:::
+% TO DO: Use `:class: screenshot`
+![Facets](images/facets.png)
 
 Facets are the essential part of the category page. Since category pages typically don’t have a search box, facets become the primary tool for finding the products.
 
@@ -297,10 +293,8 @@ import { BooleanFacet, SingleLinksFacet } from "@elastic/react-search-ui-views";
 
 And the resulting UI:
 
-:::{image} images/facet-views.png
-:alt: Facet views
-:class: screenshot
-:::
+% TO DO: Use `:class: screenshot`
+![Facet views](images/facet-views.png)
 
 You might need a facet that Search UI doesn’t offer, for example, a dedicated color-picker. With Search UI, you can build a custom facet that will work like a native one. Refer to the [Creating custom components guide](/reference/guides-creating-own-components.md) to learn how.
 

--- a/docs/reference/solutions-ecommerce-product-detail-page.md
+++ b/docs/reference/solutions-ecommerce-product-detail-page.md
@@ -5,19 +5,15 @@ mapped_pages:
 
 # Product Detail Page [solutions-ecommerce-product-detail-page]
 
-:::{image} images/product-detail-page.png
-:alt: Product detail page
-:class: screenshot
-:::
+% TO DO: Use `:class: screenshot`
+![Product detail page](images/product-detail-page.png)
 
 You can put many things on a product detail page: image, description, specs. They are all describing the product itself.
 
 But a critical piece that often gets overlooked is cross-sell recommendations.
 
-:::{image} images/cross-sell-recommendations.png
-:alt: Cross-sell recommendations
-:class: screenshot
-:::
+% TO DO: Use `:class: screenshot`
+![Cross-sell recommendations](images/cross-sell-recommendations.png)
 
 These are the lists of products located under the product description. They often come under such headings:
 

--- a/docs/reference/solutions-ecommerce-search-page.md
+++ b/docs/reference/solutions-ecommerce-search-page.md
@@ -135,10 +135,8 @@ Once the grouping is enabled, the variants will be available via the `_group` fi
 
 ## Sorting [solutions-ecommerce-search-page-sorting]
 
-:::{image} images/sorting.png
-:alt: Sorting component
-:class: screenshot
-:::
+% TO DO: Use `:class: screenshot`
+![Sorting component](images/sorting.png)
 
 Adding sorting is simple — just use our `<Sorting/>` component, like so:
 

--- a/docs/reference/tutorials-app-search.md
+++ b/docs/reference/tutorials-app-search.md
@@ -22,15 +22,11 @@ First we need to setup App Search, which is a part of [Elastic Enterprise Search
 
 Once your deployment has been created, navigate to Enterprise Search in Kibana. You should be able to see a link to Enterprise Search from the home menu.
 
-:::{image} images/kibana-home.png
-:alt: search-ui
-:class: screenshot
-:::
+% TO DO: Use `:class: screenshot`
+![search-ui](images/kibana-home.png)
 
-:::{image} images/ent-search-home.png
-:alt: search-ui
-:class: screenshot
-:::
+% TO DO: Use `:class: screenshot`
+![search-ui](images/ent-search-home.png)
 
 In the next step, we’ll navigate to App Search and create an engine that will hold our US national parks documents.
 
@@ -38,19 +34,15 @@ In the next step, we’ll navigate to App Search and create an engine that will 
 
 Select "Try a sample engine", which creates a engine loaded with useful sample data. The sample engine will be pre-loaded with the US national parks dataset that we’ll need for our search experience. Easy!
 
-:::{image} images/create-engine.png
-:alt: search-ui
-:class: screenshot
-:::
+% TO DO: Use `:class: screenshot`
+![search-ui](images/create-engine.png)
 
 ### Configure Schema [tutorials-app-search-configure-schema]
 
 Once our sample engine has been created, the next step is to inspect our engine’s schema. By default, App Search will choose the field type "text" for each field, but we can manually configure the field types to match the type of data each field represents — text, date, geolocation, or number. **For the sample engine, the fields have been pre-configured for us.**
 
-:::{image} images/configure-schema.png
-:alt: search-ui
-:class: screenshot
-:::
+% TO DO: Use `:class: screenshot`
+![search-ui](images/configure-schema.png)
 
 If you inspect the schema, you’ll notice that a number of fields have been changed from their default `text` field type:
 
@@ -69,10 +61,8 @@ API keys are used to access the engine. By default, there are two key types avai
 - private-key: This is the key that is used to read and write to the engine.
 - search-key: This is the key that has read only access to the engine.
 
-:::{image} images/credentials.png
-:alt: search-ui
-:class: screenshot
-:::
+% TO DO: Use `:class: screenshot`
+![search-ui](images/credentials.png)
 
 For this example, we are going to use the search-key. By default the search-key has been created. To use it, we must copy the key. Keep this key safe, we will be using it later on.
 
@@ -212,10 +202,8 @@ yarn start
 
 You should now have a working, basic search experience that looks similar to the example below:
 
-:::{image} images/initial-cra.png
-:alt: search-ui
-:class: screenshot
-:::
+% TO DO: Use `:class: screenshot`
+![search-ui](images/initial-cra.png)
 
 ## Configure Search UI [tutorials-app-search-configure-search-ui]
 
@@ -418,10 +406,8 @@ disjunctiveFacets: ["states"],
 
 You should be able to see the results of your search like below:
 
-:::{image} images/completed-ui.png
-:alt: search-ui
-:class: screenshot
-:::
+% TO DO: Use `:class: screenshot`
+![search-ui](images/completed-ui.png)
 
 ## Next Steps [tutorials-app-search-next-steps]
 

--- a/docs/reference/tutorials-elasticsearch-configure-search-ui.md
+++ b/docs/reference/tutorials-elasticsearch-configure-search-ui.md
@@ -165,10 +165,8 @@ yarn start
 
 and then view the results in the browser at [http://localhost:3000/](http://localhost:3000/)
 
-:::{image} images/search-ui.jpeg
-:alt: search-ui
-:class: screenshot
-:::
+% TO DO: Use `:class: screenshot`
+![search-ui](images/search-ui.jpeg)
 
 ## Summary [tutorials-elasticsearch-next-steps]
 

--- a/docs/reference/tutorials-elasticsearch-install-connector.md
+++ b/docs/reference/tutorials-elasticsearch-install-connector.md
@@ -55,10 +55,8 @@ const connector = new ElasticsearchAPIConnector({
 
 If you’re using Elastic Cloud, you can find your cloud id within your deployment’s details.
 
-:::{image} images/copy-cloud-id.jpg
-:alt: copy es endpoint
-:class: screenshot
-:::
+% TO DO: Use `:class: screenshot`
+![copy es endpoint](images/copy-cloud-id.jpg)
 
 alternatively, if you’re using an on-premise Elasticsearch instance, you can connect via specifying the host.
 

--- a/docs/reference/tutorials-elasticsearch-setup-cloud.md
+++ b/docs/reference/tutorials-elasticsearch-setup-cloud.md
@@ -28,17 +28,13 @@ Notice here we are only giving read privileges for this api key. You will need t
 }
 ```
 
-:::{image} images/api-keys.jpeg
-:alt: creating api key
-:class: screenshot
-:::
+% TO DO: Use `:class: screenshot`
+![creating api key](images/api-keys.jpeg)
 
 Once saved, you are presented with the api-key. Copy this and keep it safe. We will need to use this further down in the tutorial.
 
-:::{image} images/api-key-view.jpeg
-:alt: copy api key
-:class: screenshot
-:::
+% TO DO: Use `:class: screenshot`
+![copy api key](images/api-key-view.jpeg)
 
 ## Enabling CORS [tutorials-elasticsearch-enabling-cors]
 
@@ -46,10 +42,8 @@ If you’re going to be accessing Elasticsearch directly from a browser and the 
 
 CORS is a browser mechanism which enables controlled access to resources located outside of the current domain. In order for the browser to make requests to Elasticsearch, CORS configuration headers need to specified in the Elasticsearch configuration.
 
-:::{image} images/edit-settings.png
-:alt: edit-deployment-settings
-:class: screenshot
-:::
+% TO DO: Use `:class: screenshot`
+![edit-deployment-settings](images/edit-settings.png)
 
 You can do this in cloud by going to the deployment settings for your Elasticsearch instance, click "Edit user settings and plugins" and under "user settings", add the CORS configuration below:
 
@@ -61,9 +55,7 @@ http.cors.allow-methods: OPTIONS, HEAD, GET, POST, PUT, DELETE
 http.cors.allow-headers: X-Requested-With, X-Auth-Token, Content-Type, Content-Length, Authorization, Access-Control-Allow-Headers, Accept, x-elastic-client-meta
 ```
 
-:::{image} images/cors-settings.png
-:alt: edit-deployment-settings
-:class: screenshot
-:::
+% TO DO: Use `:class: screenshot`
+![edit-deployment-settings](images/cors-settings.png)
 
 then save. Your Elasticsearch instance will be restarted and the CORS configuration will be active.

--- a/docs/reference/tutorials-elasticsearch-setup-index.md
+++ b/docs/reference/tutorials-elasticsearch-setup-index.md
@@ -13,10 +13,8 @@ First we need to create an index for our data. We can do this simply via the fol
 PUT /my-example-movies
 ```
 
-:::{image} images/create-index.jpeg
-:alt: Create Index
-:class: screenshot
-:::
+% TO DO: Use `:class: screenshot`
+![Create Index](images/create-index.jpeg)
 
 Elasticsearch will acknowledge our request in the response.
 
@@ -157,10 +155,8 @@ PUT /my-example-movies/_mapping
 }
 ```
 
-:::{image} images/update-mapping.jpeg
-:alt: add mapping
-:class: screenshot
-:::
+% TO DO: Use `:class: screenshot`
+![add mapping](images/update-mapping.jpeg)
 
 Elasticsearch will acknowledge the request in the response.
 

--- a/docs/reference/tutorials-workplace-search.md
+++ b/docs/reference/tutorials-workplace-search.md
@@ -111,10 +111,8 @@ You can get both values on the API Keys page in Workplace Search:
 - `kibanaBase` — from the url,
 - `enterpriseSearchBase` — from the Endpoint panel.
 
-:::{image} images/endpoints.png
-:alt: endpoints
-:class: screenshot
-:::
+% TO DO: Use `:class: screenshot`
+![endpoints](images/endpoints.png)
 
 ### `redirectUri` [tutorials-workplace-search-redirecturi]
 
@@ -130,10 +128,8 @@ To get a clientId, you need to create a new OAuth application in Workplace Searc
 4. Save changes.
 5. Copy the `Client id` from the Credentials section.
 
-:::{image} images/oauth-application.png
-:alt: oauth-application
-:class: screenshot
-:::
+% TO DO: Use `:class: screenshot`
+![oauth-application](images/oauth-application.png)
 
 After finishing these steps, you should have a configuration that looks something like this:
 
@@ -154,17 +150,13 @@ You should now be able to authorize.
 
 Click on the "Log in" link in the Search UI and authorize the application to search your data.
 
-:::{image} images/authorize.png
-:alt: authorize
-:class: screenshot
-:::
+% TO DO: Use `:class: screenshot`
+![authorize](images/authorize.png)
 
 Once you click the Authorize button, you should be redirected back to your application and see the search results.
 
-:::{image} images/search-ui-results.png
-:alt: search-ui-results
-:class: screenshot
-:::
+% TO DO: Use `:class: screenshot`
+![search-ui-results](images/search-ui-results.png)
 
 Congratulations! You have successfully connected to Workplace Search.
 


### PR DESCRIPTION
Fixes image paths to work with docs-assembler.

Notes for the reviewer:
* I was not able to get images in reference, extend, or release-notes to work using the `:::{image}` syntax because it seems to resolve differently than the Markdown `![]()` syntax. We should address this in docs-builder, but in order to get images working as soon as possible, I've used Markdown syntax and left us a `TO DO` in a code comment to add back the `screenshot` class where applicable. 

cc @leemthompo 