### PR TITLE
Fix ESM import resolution error by adding missing file extension

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -6,7 +6,13 @@
   "command": {
     "publish": {
       "npmClient": "npm",
-      "ignoreChanges": ["**/__tests__/**", "**/*.md", "**/src/test/**"],
+      "ignoreChanges": [
+        "**/__tests__/**",
+        "**/*.md",
+        "**/src/test/**",
+        "packages/search-ui-workplace-search-connector/**",
+        "packages/search-ui-app-search-connector/**"
+      ],
       "registry": "https://registry.npmjs.org/",
       "message": "Release: %s"
     },

--- a/packages/react-search-ui-views/src/Paging.tsx
+++ b/packages/react-search-ui-views/src/Paging.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import RCPagination from "rc-pagination";
-import enUsLocale from "rc-pagination/lib/locale/en_US";
+import enUsLocale from "rc-pagination/lib/locale/en_US.js";
 
 import { appendClassName } from "./view-helpers";
 import type { SearchContextState } from "@elastic/search-ui";

--- a/yarn.lock
+++ b/yarn.lock
@@ -10496,7 +10496,7 @@ react-clientside-effect@^1.2.6:
   dependencies:
     "@babel/runtime" "^7.12.13"
 
-react-dom@18.3.0, react-dom@^18.3.0:
+react-dom@^18.3.0:
   version "18.3.0"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-18.3.0.tgz#98a3a1cc4e471d517c2a084f38ab1d58d02cada7"
   integrity sha512-zaKdLBftQJnvb7FtDIpZtsAIb2MZU087RM8bRDZU8LVCCFYjPTsDZJNFUWPcVz3HFSN1n/caxi0ca4B/aaVQGQ==
@@ -10700,7 +10700,7 @@ react-window@^1.8.6:
     "@babel/runtime" "^7.0.0"
     memoize-one ">=3.1.1 <6"
 
-react@18.3.0, react@^18.3.0:
+react@^18.3.0:
   version "18.3.0"
   resolved "https://registry.yarnpkg.com/react/-/react-18.3.0.tgz#84386d0a36fdf5ef50fa5755b7812bdfb76194a5"
   integrity sha512-RPutkJftSAldDibyrjuku7q11d3oy6wKOyPe5K1HA/HwwrXcEqBdHsLypkC2FFYjP7bPUa6gbzSBhw4sY2JcDg==


### PR DESCRIPTION
## Description
This PR fixes a runtime error caused by a missing .js file extension in an ESM import path.
Since strict ESM environments (e.g. Node.js with "type": "module" or .mjs files) require fully specified import paths, this change ensures compatibility by explicitly adding the .js extension where needed.

## Associated Github Issues
#1135 