### PR TITLE
Fix queries with filtering types

### DIFF
--- a/docs/reference/api-connectors-elasticsearch.md
+++ b/docs/reference/api-connectors-elasticsearch.md
@@ -78,8 +78,8 @@ const connector = new ElasticsearchAPIConnector(
 
 | Param             | Type   | Description                                                                                                                                                                                                                                                                                                                                            |
 | ----------------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| cloud             | object | **Required if `host` or custom `apiClient` not provided.** Object type. The cloud id for the deployment within elastic cloud. Format: `{ id: 'cloud:id' }`. You can find your cloud id in the Elastic Cloud deployment overview page.                                                                                                                                        |
-| host              | string | **Required if `cloud` or custom `apiClient` not provided.** String type. The host url to the Elasticsearch instance                                                                                                                                                                                                                                                          |
+| cloud             | object | **Required if `host` or custom `apiClient` not provided.** Object type. The cloud id for the deployment within elastic cloud. Format: `{ id: 'cloud:id' }`. You can find your cloud id in the Elastic Cloud deployment overview page.                                                                                                                  |
+| host              | string | **Required if `cloud` or custom `apiClient` not provided.** String type. The host url to the Elasticsearch instance                                                                                                                                                                                                                                    |
 | index             | string | **Required.** String type. The search index name                                                                                                                                                                                                                                                                                                       |
 | apiKey            | string | **Optional.** a credential used to access the Elasticsearch instance. See [Connection & Authentication](/reference/tutorials-elasticsearch-production-usage.md#api-connectors-elasticsearch-connection-and-authentication)                                                                                                                             |
 | connectionOptions | object | **Optional.** Object containing `headers` dictionary of header name to header value.                                                                                                                                                                                                                                                                   |
@@ -189,7 +189,23 @@ setFilter("precio", {
 
 ### _None_ Filter Type [api-connectors-elasticsearch-none-filter-type]
 
-Currently the None filter type is not supported. If this is a feature thats needed, please mention it in this [issue](https://github.com/elastic/search-ui/issues/783).
+You can use the `none` filter type to exclude documents that match certain values (works as a must_not filter in Elasticsearch).
+
+#### Example
+
+```js
+searchQuery: {
+  filters: [
+    {
+      type: "none", // Exclude documents where brand.keyword is "apple"
+      field: "brand.keyword",
+      values: ["apple"]
+    }
+  ];
+}
+```
+
+This filter will exclude all documents where the field `brand.keyword` is equal to `"apple"`.
 
 ## Autocomplete [api-connectors-elasticsearch-autocomplete]
 

--- a/packages/search-ui-elasticsearch-connector/src/transformer/__tests__/filterTransformer.test.ts
+++ b/packages/search-ui-elasticsearch-connector/src/transformer/__tests__/filterTransformer.test.ts
@@ -103,11 +103,11 @@ describe("filterTransformer", () => {
         type: "value"
       };
 
-      const result = transformFacet(filter, facetConfig, false);
+      const result = transformFacet(filter, facetConfig);
 
       expect(result).toEqual({
         bool: {
-          must: [
+          filter: [
             { term: { category: "electronics" } },
             { term: { category: "books" } }
           ]
@@ -119,14 +119,14 @@ describe("filterTransformer", () => {
       const filter: SearchUIFilter = {
         field: "category",
         values: ["electronics", "books"],
-        type: "all"
+        type: "any"
       };
 
       const facetConfig: FacetConfiguration = {
         type: "value"
       };
 
-      const result = transformFacet(filter, facetConfig, true);
+      const result = transformFacet(filter, facetConfig);
 
       expect(result).toEqual({
         bool: {
@@ -153,11 +153,11 @@ describe("filterTransformer", () => {
         ]
       };
 
-      const result = transformFacet(filter, facetConfig, false);
+      const result = transformFacet(filter, facetConfig);
 
       expect(result).toEqual({
         bool: {
-          must: [
+          filter: [
             { range: { price: { from: 0, to: 100 } } },
             { range: { price: { from: 100, to: 200 } } }
           ]
@@ -169,7 +169,7 @@ describe("filterTransformer", () => {
       const filter: SearchUIFilter = {
         field: "location",
         values: ["0-1km", "1-2km"],
-        type: "all"
+        type: "none"
       };
 
       const facetConfig: FacetConfiguration = {
@@ -183,11 +183,11 @@ describe("filterTransformer", () => {
         ]
       };
 
-      const result = transformFacet(filter, facetConfig, false);
+      const result = transformFacet(filter, facetConfig);
 
       expect(result).toEqual({
         bool: {
-          must: [
+          must_not: [
             {
               bool: {
                 must: [

--- a/packages/search-ui-elasticsearch-connector/src/transformer/filterTransformer.ts
+++ b/packages/search-ui-elasticsearch-connector/src/transformer/filterTransformer.ts
@@ -55,8 +55,11 @@ const transformFilterValue =
     };
   };
 
+export const getBoolTypeByFilterType = (type: SearchUIFilter["type"] = "all") =>
+  mapFilterTypeToBoolType[type];
+
 export const transformFilter = (filter: SearchUIFilter): Filter => {
-  const boolType = mapFilterTypeToBoolType[filter.type || "all"];
+  const boolType = getBoolTypeByFilterType(filter.type);
 
   return {
     bool: {
@@ -69,26 +72,19 @@ export const transformFilter = (filter: SearchUIFilter): Filter => {
 
 export const transformFacet = (
   filter: SearchUIFilter,
-  facetConfiguration: FacetConfiguration,
-  isDisjunctive: boolean
+  facetConfiguration: FacetConfiguration
 ): Filter => {
-  const condition = isDisjunctive ? "should" : "must";
+  const boolType = getBoolTypeByFilterType(filter.type);
 
   if (facetConfiguration.type === "value") {
-    return {
-      bool: {
-        [condition]: filter.values.map((value) => ({
-          term: { [filter.field]: value }
-        }))
-      }
-    };
+    return transformFilter(filter);
   } else if (
     facetConfiguration.type === "range" &&
     !facetConfiguration.center
   ) {
     return {
       bool: {
-        [condition]: filter.values.map((value) => {
+        [boolType]: filter.values.map((value) => {
           const range = facetConfiguration.ranges.find(
             (range) => range.name === value
           );
@@ -100,7 +96,7 @@ export const transformFacet = (
   } else if (facetConfiguration.type === "range" && facetConfiguration.center) {
     return {
       bool: {
-        [condition]: filter.values.map((value) => {
+        [boolType]: filter.values.map((value) => {
           const range = facetConfiguration.ranges.find(
             (range) => range.name === value
           );


### PR DESCRIPTION
## Description
Fixes the issue where filterType="none" and filterType="any" on facet filters were not properly translated in the Elasticsearch Connector.

The update ensures that:
- filterType="none" is correctly translated to a must_not clause.
- filterType="any" is correctly translated to a should clause.
- filterType="all" continues to behave as must (default).


## List of changes
- Updated `aggs` and `post_filters` builder to include filterType on facet filters.
- Introduced proper handling for `none` and any filter types using `must_not` and `should`.
- Updated related tests.

## Associated Github Issues
#783 
