### PR TITLE
Fix filter types for es connector

### DIFF
--- a/docs/reference/api-connectors-elasticsearch.md
+++ b/docs/reference/api-connectors-elasticsearch.md
@@ -140,57 +140,6 @@ And respond with the standard Search UI response types:
 
 For a full working example with server setup, see the Using in [Production guide](/reference/tutorials-elasticsearch-production-usage.md) or jump to the [CodeSandbox](https://codesandbox.io/p/sandbox/github/elastic/search-ui/tree/main/examples/sandbox?file=/src/pages/elasticsearch-production-ready/index.jsx).
 
-## Differences between App Search and Elasticsearch connector [api-connectors-elasticsearch-differences-between-app-search-and-elasticsearch-connector]
-
-### Applying Filters to Range Facets [api-connectors-elasticsearch-applying-filters-to-range-facets]
-
-Elasticsearch connector differs in the way filters can be applied to facets. Currently its not possible to apply an explicit range filter to range facets. Elasticsearch connector uses the name thats been given to the option to apply the filter. It uses this name to match the option and creates a the range filter query for the option.
-
-#### Example Facet Configuration [api-connectors-elasticsearch-example-facet-configuration]
-
-```js
-{
-  visitors: {
-    type: "range",
-    ranges: [
-      { from: 0, to: 10000, name: "0 - 10000" },
-      { from: 10001, to: 100000, name: "10001 - 100000" },
-      { from: 100001, to: 500000, name: "100001 - 500000" },
-      { from: 500001, to: 1000000, name: "500001 - 1000000" },
-      { from: 1000001, to: 5000000, name: "1000001 - 5000000" },
-      { from: 5000001, to: 10000000, name: "5000001 - 10000000" },
-      { from: 10000001, name: "10000001+" }
-    ]
-  }
-}
-```
-
-#### How to apply the filter [api-connectors-elasticsearch-how-to-apply-the-filter]
-
-```js
-setFilter("visitors", {
-  name: "10001 - 100000", // name of the option
-  from: 10001, // both from and to will be ignored
-  to: 100000
-});
-```
-
-#### Applying a range to a field that isn't a facet [api-connectors-elasticsearch-applying-a-range-to-a-field-that-isnt-a-facet]
-
-If the field isn't a facet, you will be able to apply filters to the search using `value`, `numeric range` and `date range`, depending on the field type.
-
-```js
-setFilter("precio", {
-  name: "precio",
-  from: rangePrices[0],
-  to: rangePrices[1]
-});
-```
-
-### _None_ Filter Type [api-connectors-elasticsearch-none-filter-type]
-
-Currently the None filter type is not supported. If this is a feature thats needed, please mention it in this [issue](https://github.com/elastic/search-ui/issues/783).
-
 ## Autocomplete [api-connectors-elasticsearch-autocomplete]
 
 Search UI supports autocomplete functionality to suggest search terms that provide results. The autocomplete functionality is built on top of the Elasticsearch `suggest` and `bool prefix query` API.

--- a/packages/search-ui-elasticsearch-connector/src/handlers/handleSearch.ts
+++ b/packages/search-ui-elasticsearch-connector/src/handlers/handleSearch.ts
@@ -23,5 +23,5 @@ export const handleSearch = async (
 
   const response = await apiClient.performRequest(requestBody);
 
-  return transformSearchResponse(response, queryBuilder);
+  return transformSearchResponse(response, queryBuilder, queryConfig);
 };

--- a/packages/search-ui-elasticsearch-connector/src/transformer/__tests__/filterTransformer.test.ts
+++ b/packages/search-ui-elasticsearch-connector/src/transformer/__tests__/filterTransformer.test.ts
@@ -165,6 +165,33 @@ describe("filterTransformer", () => {
       });
     });
 
+    it("should transform range facet with custom range values", () => {
+      const filter: SearchUIFilter = {
+        field: "price",
+        values: [{ from: 50, to: 150, name: "base" }, { name: "100-200" }],
+        type: "all"
+      };
+
+      const facetConfig: FacetConfiguration = {
+        type: "range",
+        ranges: [
+          { name: "0-100", from: 0, to: 100 },
+          { name: "100-200", from: 100, to: 200 }
+        ]
+      };
+
+      const result = transformFacet(filter, facetConfig, false);
+
+      expect(result).toEqual({
+        bool: {
+          must: [
+            { range: { price: { from: 50, to: 150 } } },
+            { range: { price: { from: 100, to: 200 } } }
+          ]
+        }
+      });
+    });
+
     it("should transform geo distance facet", () => {
       const filter: SearchUIFilter = {
         field: "location",

--- a/packages/search-ui-elasticsearch-connector/src/transformer/filterTransformer.ts
+++ b/packages/search-ui-elasticsearch-connector/src/transformer/filterTransformer.ts
@@ -89,9 +89,15 @@ export const transformFacet = (
     return {
       bool: {
         [condition]: filter.values.map((value) => {
-          const range = facetConfiguration.ranges.find(
-            (range) => range.name === value
-          );
+          const range = isRangeFilter(value)
+            ? value
+            : // Keep to be backward compatible with passing range name as a string and get from and to from facet configuration.
+              // TODO: Remove this in future versions.
+              facetConfiguration.ranges.find((range) =>
+                typeof value === "object" && "name" in value
+                  ? range.name === value.name
+                  : range.name === value
+              );
 
           return transformFilterValue(filter.field)(range);
         })


### PR DESCRIPTION
## Description
Added support for custom range filter when using the ES connector. This brings back the ability to pre-fill custom range pickers, a behavior that was lost due to connector changes.
**Prev format:**
`setFilter("visitors",      "10001 - 100000");  // directly the name of the option, as string and not wrapped in an object`
**Expected format:**
`setFilter("visitors", { name: "any name", from: 0, to: 1000  });`

Kept previous behavior for backward capability

## List of changes
- Support new format `setFilter("visitors", { name: "any name", from: 0, to: 1000  });`
- Updated response configuration, to save `from` and `to` in search-ui state as expected
- Updated tests
- Remove "difference AppSearch and ES connector" from API reference for ES Connector

## Associated Github Issues
#1113 