### PR TITLE
[Elasticsearch Connector] Add fuzziness param

### DIFF
--- a/docs/reference/api-connectors-elasticsearch.md
+++ b/docs/reference/api-connectors-elasticsearch.md
@@ -248,3 +248,11 @@ Below is an example of the mappings for the above example. `title_suggest` is a 
 ```
 
 With a combination of this configuration + the [Searchbox](/reference/api-react-components-search-box.md) component with autocomplete configuration, your users will be able to see suggestions as they type within the search box.
+
+## Fuzziness [api-connectors-elasticsearch-fuzziness]
+
+The Elasticsearch Connector supports typo tolerance through Elasticsearch's `fuzziness` setting. This is enabled by setting `fuzziness: true` in the `searchQuery` configuration (or in `autocomplete` query configurations that follow the same structure).
+
+When enabled, `fuzziness: true` is internally translated to `fuzziness: "AUTO"` in Elasticsearch `multi_match` queries. The `AUTO` mode automatically adjusts the allowed edit distance based on the length of the search term, enabling effective fuzzy matching for both short and long inputs.
+
+For more details, refer to the [Elasticsearch Fuzzy Query documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-fuzzy-query.html).

--- a/docs/reference/api-core-configuration.md
+++ b/docs/reference/api-core-configuration.md
@@ -25,6 +25,7 @@ searchQuery: {
   facets: {
     states: { type: "value", size: 30 },
   }
+  fuzziness: true,
   disjunctiveFacets: ["states"], // Array of field names to use for disjunctive searches
   disjunctiveFacetsAnalyticsTags: ["Ignore"],
   conditionalFacets: {},
@@ -167,6 +168,25 @@ Query time Weights take precedence over Engine level values.
 
 All fields specified within the search relevance section will be used for searching if not specified.
 
+### Fuzziness [api-core-configuration-fuzziness]
+
+::::{important}
+**Supported only by the [Elasticsearch Connector](/reference/api-connectors-elasticsearch.md#api-connectors-elasticsearch-fuzziness).**
+This setting has no effect in other connectors.
+::::
+
+**Type:** `boolean`
+**Default:** `false`
+
+`fuzziness` enables typo tolerance in search results by allowing small differences between the user’s search term and indexed terms. This makes search more forgiving to mistakes or misspellings.
+
+When set to `true`, the connector automatically applies typo-tolerant matching based on the edit distance between terms. For example, the following types of variations are considered:
+
+- **Character substitution**: "**b**ox" → "**f**ox"
+- **Character removal**: "**b**lack" → "lack"
+- **Character insertion**: "sic" → "sic**k**"
+- **Character transposition**: "**ac**t" → "**ca**t"
+
 ### result_fields [api-core-configuration-result_fields]
 
 Select from two ways to render text field values:
@@ -248,6 +268,7 @@ This is the configuration that provide relevant query suggestions for incomplete
 autocompleteQuery: {
   // performs a prefix search on the query
   results: {
+    fuzziness: true, // enables typo tolerance in autocomplete results
     resultsPerPage: 5, // number of results to display. Default is 5.
     result_fields: {
       // Add snippet highlighting within autocomplete suggestions
@@ -274,6 +295,7 @@ autocompleteQuery: {
 ```js
 results: {
   resultsPerPage: 5,
+  fuzziness: true, // enables typo tolerance in autocomplete results
   result_fields: {
     title: { snippet: { size: 100, fallback: true }},
     nps_link: { raw: {} }
@@ -281,12 +303,13 @@ results: {
 },
 ```
 
-| field           | description                                                                                                                                  |
-| --------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
-| `filters`       | Optional. List of filters. Use same configuration as [filters](#api-core-configuration-filters-global-filters)                               |
-| `resultPerPage` | Optional. Number type. Number of results suggested                                                                                           |
-| `result_fields` | Optional. To specify the fields for each result hit. Use same configuration as [result fields](#api-core-configuration-result_fields)        |
-| `search_fields` | Optional. Fields which should be searched for autocomplete. Use same configuration as [search fields](#api-core-configuration-search_fields) |
+| field           | description                                                                                                                                                                                                        |
+| --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `filters`       | Optional. List of filters. Use same configuration as [filters](#api-core-configuration-filters-global-filters)                                                                                                     |
+| `resultPerPage` | Optional. Number type. Number of results suggested                                                                                                                                                                 |
+| `fuzziness`     | Optional. Boolean. When set to `true`, enables typo tolerance in autocomplete results. Only supported by the **Elasticsearch Connector**. Use same configuration as [fuzziness](#api-core-configuration-fuzziness) |
+| `result_fields` | Optional. To specify the fields for each result hit. Use same configuration as [result fields](#api-core-configuration-result_fields)                                                                              |
+| `search_fields` | Optional. Fields which should be searched for autocomplete. Use same configuration as [search fields](#api-core-configuration-search_fields)                                                                       |
 
 ### Suggestions [api-core-configuration-suggestions]
 

--- a/examples/sandbox/src/pages/elasticsearch-basic/index.jsx
+++ b/examples/sandbox/src/pages/elasticsearch-basic/index.jsx
@@ -27,6 +27,7 @@ const config = {
       description: {},
       states: {}
     },
+    fuzziness: true,
     result_fields: {
       visitors: { raw: {} },
       world_heritage_site: { raw: {} },
@@ -113,8 +114,16 @@ const config = {
   },
   autocompleteQuery: {
     results: {
+      fuzziness: true,
       search_fields: {
         parks_search_as_you_type: {}
+      },
+      search_fields: {
+        title: {
+          weight: 3
+        },
+        description: {},
+        states: {}
       },
       resultsPerPage: 5,
       result_fields: {

--- a/packages/search-ui-elasticsearch-connector/src/queryBuilders/ResultsAutocompleteBuilder.ts
+++ b/packages/search-ui-elasticsearch-connector/src/queryBuilders/ResultsAutocompleteBuilder.ts
@@ -12,7 +12,7 @@ export class ResultsAutocompleteBuilder extends BaseQueryBuilder {
     state: RequestState,
     private readonly configuration: Pick<
       ResultSuggestionConfiguration,
-      "result_fields" | "search_fields" | "filters"
+      "result_fields" | "search_fields" | "filters" | "fuzziness"
     >,
     private readonly size: number = 5
   ) {
@@ -61,7 +61,8 @@ export class ResultsAutocompleteBuilder extends BaseQueryBuilder {
               multi_match: {
                 query: this.state.searchTerm,
                 type: "bool_prefix",
-                fields
+                fields,
+                fuzziness: this.configuration.fuzziness ? `AUTO` : undefined
               }
             }
           ]

--- a/packages/search-ui-elasticsearch-connector/src/queryBuilders/SearchQueryBuilder.ts
+++ b/packages/search-ui-elasticsearch-connector/src/queryBuilders/SearchQueryBuilder.ts
@@ -168,7 +168,10 @@ export class SearchQueryBuilder extends BaseQueryBuilder {
                       query: searchQuery,
                       fields: fields,
                       type: "best_fields",
-                      operator: "and"
+                      operator: "and",
+                      fuzziness: this.queryConfig.fuzziness
+                        ? "AUTO"
+                        : undefined
                     }
                   },
                   {

--- a/packages/search-ui-elasticsearch-connector/src/queryBuilders/__tests__/ResultsAutocompleteBuilder.test.ts
+++ b/packages/search-ui-elasticsearch-connector/src/queryBuilders/__tests__/ResultsAutocompleteBuilder.test.ts
@@ -100,4 +100,39 @@ describe("ResultsAutocompleteBuilder", () => {
       type: "bool_prefix"
     });
   });
+
+  describe("fuzziness", () => {
+    it("should not add fuzziness when not configured", () => {
+      const builder = new ResultsAutocompleteBuilder(state, config, 5);
+      const query = builder.build();
+
+      expect(query.query.bool.must[0].multi_match.fuzziness).toBeUndefined();
+    });
+
+    it("should add AUTO fuzziness when configured", () => {
+      const configWithFuzziness = {
+        ...config,
+        fuzziness: true
+      };
+
+      const builder = new ResultsAutocompleteBuilder(
+        state,
+        configWithFuzziness,
+        5
+      );
+      const query = builder.build();
+
+      expect(query.query.bool.must[0].multi_match.fuzziness).toBe("AUTO");
+      expect(query.query.bool.must).toEqual([
+        {
+          multi_match: {
+            fields: ["title^2"],
+            fuzziness: "AUTO",
+            query: "test",
+            type: "bool_prefix"
+          }
+        }
+      ]);
+    });
+  });
 });

--- a/packages/search-ui-elasticsearch-connector/src/queryBuilders/__tests__/SearchQueryBuilder.test.ts
+++ b/packages/search-ui-elasticsearch-connector/src/queryBuilders/__tests__/SearchQueryBuilder.test.ts
@@ -571,5 +571,63 @@ describe("SearchQueryBuilder", () => {
         }
       });
     });
+
+    describe("fuzziness", () => {
+      it("should not add fuzziness when not configured", () => {
+        const builder = new SearchQueryBuilder(state, queryConfig);
+        const query = builder.build();
+
+        expect(
+          query.query.bool.must[0].bool.should[0].multi_match.fuzziness
+        ).toBeUndefined();
+      });
+
+      it("should add AUTO fuzziness when configured", () => {
+        const configWithFuzziness: SearchQuery = {
+          ...queryConfig,
+          fuzziness: true
+        };
+
+        const builder = new SearchQueryBuilder(state, configWithFuzziness);
+        const query = builder.build();
+
+        expect(
+          query.query.bool.must[0].bool.should[0].multi_match.fuzziness
+        ).toBe("AUTO");
+
+        expect(query.query.bool.must[0].bool.should).toEqual([
+          {
+            multi_match: {
+              fields: [],
+              fuzziness: "AUTO",
+              operator: "and",
+              query: "test",
+              type: "best_fields"
+            }
+          },
+          {
+            multi_match: {
+              fields: [],
+              query: "test",
+              type: "cross_fields"
+            }
+          },
+          {
+            multi_match: {
+              fields: [],
+              query: "test",
+              type: "phrase"
+            }
+          },
+          {
+            multi_match: {
+              fields: [],
+              query: "test",
+              type: "phrase_prefix"
+            }
+          }
+        ]);
+      });
+    });
   });
 });

--- a/packages/search-ui/src/types/index.ts
+++ b/packages/search-ui/src/types/index.ts
@@ -124,6 +124,7 @@ export type ResultSuggestionConfiguration = {
   resultsPerPage?: number;
   result_fields?: Record<string, FieldConfiguration>;
   search_fields?: Record<string, SearchFieldConfiguration>;
+  fuzziness?: boolean;
   index?: string;
   queryType: "results";
 };
@@ -162,6 +163,7 @@ export type SearchQuery = {
   conditionalFacets?: Record<string, ConditionalRule>;
   filters?: Filter[];
   facets?: Record<string, FacetConfiguration>;
+  fuzziness?: boolean;
   disjunctiveFacets?: string[];
   disjunctiveFacetsAnalyticsTags?: string[];
   result_fields?: Record<string, FieldConfiguration>;


### PR DESCRIPTION
## Description
Support for a new `fuzziness` configuration option within the **searchQuery** or **autocomplete results** object in Search UI.

When set to `true`, and used with the Elasticsearch Connector, this option enables typo tolerance in search and autocomplete queries by internally applying `fuzziness: "AUTO"` to supported `multi_match` query types. This improves the user experience by allowing results to match despite minor spelling mistakes or typos.

This option is ignored by other connectors (e.g., App Search or Site Search).

**Why a boolean?**

We intentionally chose a boolean format (`fuzziness: true | false`) rather than exposing Elasticsearch-specific values like `"AUTO", 1, or AUTO:4,8` to maintain the abstraction layer of Search UI. Since other connectors do not support fuzziness at all, introducing a more complex format would:
- Break the consistency of the searchQuery config across connectors,
- Introduce Elasticsearch-specific syntax into a connector-agnostic layer,
- Increase the likelihood of misconfiguration and user confusion.

This design keeps the API simple, declarative, and easier to adopt, while still unlocking a useful feature for Elasticsearch query.
If there is demand for more advanced control (e.g., choosing fuzziness level or tuning behavior), this boolean format can be extended in the future to accept an object syntax like:
```
fuzziness: {
  enabled: true,
  mode: "AUTO:4,8"
}
```
or use a mapper: 'on' | 'off' | 'light' | 'high'
But for now, a boolean covers the most common and practical use case without increasing complexity.

## List of changes
- Added support for `fuzziness: true` in searchQuery and autocomplete results configuration.
- Applied **fuzziness: "AUTO"** to eligible multi_match queries when enabled.
- Documented fuzziness support in:
    - Core Search UI API reference
    - Elasticsearch Connector documentation

## Associated Github Issues
#1117 