### PR TITLE
update transformRangeFilterValue to use gte and lte over from and to

### DIFF
--- a/packages/search-ui-elasticsearch-connector/src/queryBuilders/__tests__/SearchQueryBuilder.test.ts
+++ b/packages/search-ui-elasticsearch-connector/src/queryBuilders/__tests__/SearchQueryBuilder.test.ts
@@ -263,16 +263,16 @@ describe("SearchQueryBuilder", () => {
             {
               range: {
                 price: {
-                  from: 10,
-                  to: 20
+                  gte: 10,
+                  lte: 20
                 }
               }
             },
             {
               range: {
                 price: {
-                  from: 30,
-                  to: 40
+                  gte: 30,
+                  lte: 40
                 }
               }
             }
@@ -306,8 +306,8 @@ describe("SearchQueryBuilder", () => {
             price: {
               filters: {
                 filters: {
-                  "0-100": { range: { price: { from: 0, to: 100 } } },
-                  "100-200": { range: { price: { from: 100, to: 200 } } }
+                  "0-100": { range: { price: { gte: 0, lte: 100 } } },
+                  "100-200": { range: { price: { gte: 100, lte: 200 } } }
                 }
               }
             }
@@ -396,8 +396,8 @@ describe("SearchQueryBuilder", () => {
             price: {
               filters: {
                 filters: {
-                  "0-100": { range: { price: { from: 0, to: 100 } } },
-                  "100-200": { range: { price: { from: 100, to: 200 } } }
+                  "0-100": { range: { price: { gte: 0, lte: 100 } } },
+                  "100-200": { range: { price: { gte: 100, lte: 200 } } }
                 }
               }
             }
@@ -475,8 +475,8 @@ describe("SearchQueryBuilder", () => {
             price: {
               filters: {
                 filters: {
-                  "0-100": { range: { price: { from: 0, to: 100 } } },
-                  "100-200": { range: { price: { from: 100, to: 200 } } }
+                  "0-100": { range: { price: { gte: 0, lte: 100 } } },
+                  "100-200": { range: { price: { gte: 100, lte: 200 } } }
                 }
               }
             }

--- a/packages/search-ui-elasticsearch-connector/src/transformer/__tests__/filterTransformer.test.ts
+++ b/packages/search-ui-elasticsearch-connector/src/transformer/__tests__/filterTransformer.test.ts
@@ -83,8 +83,8 @@ describe("filterTransformer", () => {
       expect(result).toEqual({
         bool: {
           filter: [
-            { range: { price: { from: 10, to: 20 } } },
-            { range: { price: { from: 30, to: 40 } } }
+            { range: { price: { gte: 10, lte: 20 } } },
+            { range: { price: { gte: 30, lte: 40 } } }
           ]
         }
       });
@@ -158,8 +158,8 @@ describe("filterTransformer", () => {
       expect(result).toEqual({
         bool: {
           filter: [
-            { range: { price: { from: 0, to: 100 } } },
-            { range: { price: { from: 100, to: 200 } } }
+            { range: { price: { gte: 0, lte: 100 } } },
+            { range: { price: { gte: 100, lte: 200 } } }
           ]
         }
       });
@@ -286,8 +286,8 @@ describe("filterTransformer", () => {
       expect(result).toEqual({
         filters: {
           filters: {
-            "0-100": { range: { price: { from: 0, to: 100 } } },
-            "100-200": { range: { price: { from: 100, to: 200 } } }
+            "0-100": { range: { price: { gte: 0, lte: 100 } } },
+            "100-200": { range: { price: { gte: 100, lte: 200 } } }
           }
         }
       });

--- a/packages/search-ui-elasticsearch-connector/src/transformer/__tests__/filterTransformer.test.ts
+++ b/packages/search-ui-elasticsearch-connector/src/transformer/__tests__/filterTransformer.test.ts
@@ -185,8 +185,8 @@ describe("filterTransformer", () => {
       expect(result).toEqual({
         bool: {
           filter: [
-            { range: { price: { from: 50, to: 150 } } },
-            { range: { price: { from: 100, to: 200 } } }
+            { range: { price: { gte: 50, lte: 150 } } },
+            { range: { price: { gte: 100, lte: 200 } } }
           ]
         }
       });

--- a/packages/search-ui-elasticsearch-connector/src/transformer/filterTransformer.ts
+++ b/packages/search-ui-elasticsearch-connector/src/transformer/filterTransformer.ts
@@ -27,12 +27,12 @@ const transformRangeFilterValue = (
 ): QueryRangeValue => ({
   ...("from" in value
     ? {
-        from: isValidDateString(value.from) ? value.from : Number(value.from)
+        gte: isValidDateString(value.from) ? value.from : Number(value.from)
       }
     : {}),
   ...("to" in value
     ? {
-        to: isValidDateString(value.to) ? value.to : Number(value.to)
+        lte: isValidDateString(value.to) ? value.to : Number(value.to)
       }
     : {})
 });


### PR DESCRIPTION
Before submitting this PR:

1. Make sure you are PR'ing from a fork, please do not push branches directly
   to this repository.
2. Ensure you've written sufficient tests for your work.
3. Double check that your changes will not break existing connectors (if
   applicable).
4. Double check that your changes do not break the `react-search-ui-views`
   storybook (if applicable).

## Description
previously when this package leveraged searchkit set gte: and lte: inside the request body for range queries.
https://github.com/searchkit/searchkit/blob/3805f655363e8a72a534807026aee67d01536d3a/packages/searchkit-sdk/src/facets/MultiQueryOptionsFacet.ts#L20

Apparently there is an issue with the type declarations in @elastic/elasticsearch where it says from: and to: are valid properties of a range query (they aren't)
https://github.com/elastic/elasticsearch-js/blob/0a14ecca4e10f18ec25e358a38bdb23c44b0d374/src/api/types.ts#L9391


## List of changes
This PR updates the transformRangeFilterValue to set gte and lte as required by the elasticsearch DSL.

## Associated Github Issues
https://github.com/elastic/elasticsearch-js/issues/2846
