### PR TITLE
Advanced query handling

### DIFF
--- a/docs/reference/api-connectors-elasticsearch.md
+++ b/docs/reference/api-connectors-elasticsearch.md
@@ -56,34 +56,213 @@ const connector = new ElasticsearchAPIConnector(
     // If not provided, a default ApiClientTransporter will be used.
     // This allows you to customize how requests are made to Elasticsearch.
     apiClient: customApiClient
-  },
-  (requestBody, requestState, queryConfig) => {
-    // Optional: modify the query before sending to Elasticsearch
-    return {
-      ...requestBody,
-      custom_field: "value"
-    };
   }
 );
 ```
 
 **Constructor Parameters**
 
-| Argument                  | Type     | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
-| ------------------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| config                    | object   | Elasticsearch connection options (see table below).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
-| postProcessRequestBodyFn? | function | **Optional** function to customize the Elasticsearch request body.<br>**Params:**<br>`requestBody` - [Search API Request](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-search.html)<br>`requestState` - [RequestState](https://github.com/elastic/search-ui/blob/main/packages/search-ui/src/types/index.ts#L50)<br>`queryConfig` - [QueryConfig](https://github.com/elastic/search-ui/blob/main/packages/search-ui/src/types/index.ts#L188)<br>**Return:**<br>`requestBody` - [Search API Request](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-search.html) |
+| Argument | Type   | Description                                         |
+| -------- | ------ | --------------------------------------------------- |
+| config   | object | Elasticsearch connection and modification options (see table below). |
 
 **Config**
 
-| Param             | Type   | Description                                                                                                                                                                                                                                                                                                                                            |
-| ----------------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| cloud             | object | **Required if `host` or custom `apiClient` not provided.** Object type. The cloud id for the deployment within elastic cloud. Format: `{ id: 'cloud:id' }`. You can find your cloud id in the Elastic Cloud deployment overview page.                                                                                                                  |
-| host              | string | **Required if `cloud` or custom `apiClient` not provided.** String type. The host url to the Elasticsearch instance                                                                                                                                                                                                                                    |
-| index             | string | **Required.** String type. The search index name                                                                                                                                                                                                                                                                                                       |
-| apiKey            | string | **Optional.** a credential used to access the Elasticsearch instance. See [Connection & Authentication](/reference/tutorials-elasticsearch-production-usage.md#api-connectors-elasticsearch-connection-and-authentication)                                                                                                                             |
-| connectionOptions | object | **Optional.** Object containing `headers` dictionary of header name to header value.                                                                                                                                                                                                                                                                   |
-| apiClient         | object | **Optional.** Custom API client implementation. If not provided, a default ApiClientTransporter will be used. This allows you to customize how requests are made to Elasticsearch. The object must implement the `IApiClientTransporter` interface with a `performRequest` method that takes a search request and returns a promise with the response. |
+| Param                             | Type     | Description                                                                                                                                                                                                                                                                                                                                            |
+| --------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| cloud                             | object   | **Required if `host` or custom `apiClient` not provided.** Object type. The cloud id for the deployment within elastic cloud. Format: `{ id: 'cloud:id' }`. You can find your cloud id in the Elastic Cloud deployment overview page.                                                                                                                  |
+| host                              | string   | **Required if `cloud` or custom `apiClient` not provided.** String type. The host url to the Elasticsearch instance                                                                                                                                                                                                                                    |
+| index                             | string   | **Required.** String type. The search index name                                                                                                                                                                                                                                                                                                       |
+| apiKey                            | string   | **Optional.** a credential used to access the Elasticsearch instance. See [Connection & Authentication](/reference/tutorials-elasticsearch-production-usage.md#api-connectors-elasticsearch-connection-and-authentication)                                                                                                                             |
+| connectionOptions                 | object   | **Optional.** Object containing `headers` dictionary of header name to header value.                                                                                                                                                                                                                                                                   |
+| apiClient                         | object   | **Optional.** Custom API client implementation. If not provided, a default ApiClientTransporter will be used. This allows you to customize how requests are made to Elasticsearch. The object must implement the `IApiClientTransporter` interface with a `performRequest` method that takes a search request and returns a promise with the response. |
+| beforeSearchCall                  | function | **Optional.** Hook to intercept and modify search requests before they are sent. See [Request Lifecycle Hooks](#request-lifecycle-hooks) for details.                                                                                                                                                                                                  |
+| beforeAutocompleteResultsCall     | function | **Optional.** Hook to intercept and modify autocomplete results requests before they are sent. See [Request Lifecycle Hooks](#request-lifecycle-hooks) for details.                                                                                                                                                                                    |
+| beforeAutocompleteSuggestionsCall | function | **Optional.** Hook to intercept and modify autocomplete suggestions requests before they are sent. See [Request Lifecycle Hooks](#request-lifecycle-hooks) for details.                                                                                                                                                                                |
+| getQueryFn                        | function | **Optional.** Function to completely override query generation. See [Custom Query Builder](#custom-query-builder) for details.                                                                                                                                                                                                                         |
+
+### Request Lifecycle Hooks
+
+The connector provides hooks to intercept and modify requests at different stages of the search lifecycle. Each hook has the following type signature:
+
+```ts
+type SearchQueryHook<T> = (
+  params: {
+    requestBody: SearchRequest;
+    requestState: RequestState;
+    queryConfig: T;
+  },
+  next: (newQueryOptions: SearchRequest) => Promise<ResponseBody>
+) => Promise<ResponseBody>;
+```
+
+Where:
+
+- `RequestState` contains the current search ui state ([RequestState](https://github.com/elastic/search-ui/blob/main/packages/search-ui/src/types/index.ts#L51))
+- `queryConfig` is either [QueryConfig](https://github.com/elastic/search-ui/blob/main/packages/search-ui/src/types/index.ts#L188) for search requests or [AutocompleteQueryConfig](https://github.com/elastic/search-ui/blob/main/packages/search-ui/src/types/index.ts#L136) for autocomplete requests
+- `SearchRequest` is the Elasticsearch request body ([Search API Request](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-search.html))
+- `ResponseBody` is the Elasticsearch response ([Search API Response](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-search.html))
+
+The hooks can be configured in the connector config options:
+
+```ts
+const connector = new ElasticsearchAPIConnector({
+  // ... other config options ...
+  beforeSearchCall: async (
+    { requestBody, requestState, queryConfig },
+    next
+  ) => {
+    console.log("Search request:", requestBody);
+    const response = await next(requestBody);
+    console.log("Search response:", response);
+    return response;
+  },
+  beforeAutocompleteResultsCall: async (
+    { requestBody, requestState, queryConfig },
+    next
+  ) => {
+    console.log("Autocomplete results request:", requestBody);
+    const response = await next(requestBody);
+    console.log("Autocomplete results response:", response);
+    return response;
+  },
+  beforeAutocompleteSuggestionsCall: async (
+    { requestBody, requestState, queryConfig },
+    next
+  ) => {
+    console.log("Autocomplete suggestions request:", requestBody);
+    const response = await next(requestBody);
+    console.log("Autocomplete suggestions response:", response);
+    return response;
+  }
+});
+```
+
+Each hook **must** call `next(requestBody)` with the request body and return its result. This is required because:
+
+1. The `next` function is responsible for actually sending the request to Elasticsearch
+2. Without calling `next`, the request will never reach Elasticsearch
+3. The response from `next` contains the search results that need to be returned to the UI
+
+You can modify the request body before passing it to `next`, but you must always call `next` and return its result.
+
+These hooks can be used for:
+
+- Request/response logging
+- Injecting custom fields
+- Dynamically modifying requests based on state
+- A/B testing and fallbacks (e.g., KNN fallback)
+
+### Custom Query Builder
+
+You can completely customize the query generation using the `getQueryFn` hook. The hook has the following type signature:
+
+```ts
+type GetQueryFn = (
+  state: RequestState,
+  queryConfig: QueryConfig
+) => SearchRequest["query"];
+```
+
+Where:
+
+- `RequestState` - [RequestState](https://github.com/elastic/search-ui/blob/main/packages/search-ui/src/types/index.ts#L51) - search UI state
+- `QueryConfig` - [QueryConfig](https://github.com/elastic/search-ui/blob/main/packages/search-ui/src/types/index.ts#L191) - search configuration
+- `SearchRequest["query"]` - [Query DSL](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl.html) - query part of the Elasticsearch request body
+
+Example usage:
+
+::::{tab-set}
+:group: query-examples
+
+:::{tab-item} KNN Search
+:sync: knn
+
+```ts
+const connector = new ElasticsearchAPIConnector({
+  // ... other config options ...
+  getQueryFn: (state, config) => ({
+    knn: {
+      field: "embedding",
+      query_vector: [
+        /* embedding array */
+      ],
+      k: 10,
+      num_candidates: 100
+    }
+  });
+});
+```
+
+:::
+
+:::{tab-item} Semantic Search
+:sync: semantic
+
+```ts
+const connector = new ElasticsearchAPIConnector({
+  // ... other config options ...
+  getQueryFn: (state, config) => ({
+    semantic: {
+      field: "inference_field",
+      query: state.searchTerm
+    }
+  });
+});
+```
+
+:::
+
+:::{tab-item} Sparse Vector
+:sync: sparse
+
+```ts
+const connector = new ElasticsearchAPIConnector({
+  // ... other config options ...
+  getQueryFn: (state, config) => ({
+    sparse_vector: {
+      field: "description_semantic",
+      inference_id: ".elser-2-elasticsearch",
+      query: state.searchTerm
+    }
+  });
+});
+```
+
+:::
+
+:::{tab-item} Multi Match
+:sync: multi-match
+
+```ts
+const connector = new ElasticsearchAPIConnector({
+  // ... other config options ...
+  getQueryFn: (state, config) => ({
+    multi_match: {
+      query: state.searchTerm,
+      fields: ["title^3", "description"],
+      type: "best_fields",
+      fuzziness: "AUTO"
+    }
+  });
+});
+```
+
+:::
+
+::::
+
+The `getQueryFn` allows you to:
+
+- Override the default query generation logic
+- Implement custom multi_match, match, term and other DSL queries
+- Use KNN and text_expansion queries for semantic search
+
+::::{admonition} Note
+:class: important
+
+This hook only replaces the query part of the request body. Filters are still added separately and automatically mixed in.
+::::
 
 ## ApiProxyConnector [api-connectors-elasticsearch-api-proxy-doc-reference]
 

--- a/docs/reference/api-connectors-elasticsearch.md
+++ b/docs/reference/api-connectors-elasticsearch.md
@@ -35,35 +35,33 @@ class CustomApiClientTransporter implements IApiClientTransporter {
 
 const customApiClient = new CustomApiClientTransporter();
 
-const connector = new ElasticsearchAPIConnector(
-  {
-    // Either specify the cloud id or host or apiClient to connect to elasticsearch
-    cloud: {
-      id: "<elastic-cloud-id>" // cloud id found under your cloud deployment overview page
-    },
-    host: "http://localhost:9200", // host url for the Elasticsearch instance
-    index: "<index-name>", // index name where the search documents are contained
-    apiKey: "<api-key>", // Optional. apiKey used to authorize a connection to Elasticsearch instance.
-    // This key will be visible to everyone so ensure its setup with restricted privileges.
-    // See Authentication section for more details.
-    connectionOptions: {
-      // Optional connection options.
-      headers: {
-        "x-custom-header": "value" // Optional. Specify custom headers to send with the request
-      }
-    },
-    // Optional. Custom API client implementation.
-    // If not provided, a default ApiClientTransporter will be used.
-    // This allows you to customize how requests are made to Elasticsearch.
-    apiClient: customApiClient
-  }
-);
+const connector = new ElasticsearchAPIConnector({
+  // Either specify the cloud id or host or apiClient to connect to elasticsearch
+  cloud: {
+    id: "<elastic-cloud-id>" // cloud id found under your cloud deployment overview page
+  },
+  host: "http://localhost:9200", // host url for the Elasticsearch instance
+  index: "<index-name>", // index name where the search documents are contained
+  apiKey: "<api-key>", // Optional. apiKey used to authorize a connection to Elasticsearch instance.
+  // This key will be visible to everyone so ensure its setup with restricted privileges.
+  // See Authentication section for more details.
+  connectionOptions: {
+    // Optional connection options.
+    headers: {
+      "x-custom-header": "value" // Optional. Specify custom headers to send with the request
+    }
+  },
+  // Optional. Custom API client implementation.
+  // If not provided, a default ApiClientTransporter will be used.
+  // This allows you to customize how requests are made to Elasticsearch.
+  apiClient: customApiClient
+});
 ```
 
 **Constructor Parameters**
 
-| Argument | Type   | Description                                         |
-| -------- | ------ | --------------------------------------------------- |
+| Argument | Type   | Description                                                          |
+| -------- | ------ | -------------------------------------------------------------------- |
 | config   | object | Elasticsearch connection and modification options (see table below). |
 
 **Config**
@@ -155,7 +153,7 @@ These hooks can be used for:
 
 ### Custom Query Builder
 
-You can completely customize the query generation using the `getQueryFn` hook. The hook has the following type signature:
+You can completely customize the query generation using the `getQueryFn` hook. The hook is called only when there is a search query, so you don't need to handle empty search terms. The hook has the following type signature:
 
 ```ts
 type GetQueryFn = (
@@ -175,6 +173,23 @@ Example usage:
 ::::{tab-set}
 :group: query-examples
 
+:::{tab-item} Semantic Search
+:sync: semantic
+
+```ts
+const connector = new ElasticsearchAPIConnector({
+  // ... other config options ...
+  getQueryFn: (state, config) => ({
+    semantic: {
+      field: "inference_field",
+      query: state.searchTerm
+    }
+  })
+});
+```
+
+:::
+
 :::{tab-item} KNN Search
 :sync: knn
 
@@ -190,24 +205,7 @@ const connector = new ElasticsearchAPIConnector({
       k: 10,
       num_candidates: 100
     }
-  });
-});
-```
-
-:::
-
-:::{tab-item} Semantic Search
-:sync: semantic
-
-```ts
-const connector = new ElasticsearchAPIConnector({
-  // ... other config options ...
-  getQueryFn: (state, config) => ({
-    semantic: {
-      field: "inference_field",
-      query: state.searchTerm
-    }
-  });
+  })
 });
 ```
 
@@ -225,7 +223,7 @@ const connector = new ElasticsearchAPIConnector({
       inference_id: ".elser-2-elasticsearch",
       query: state.searchTerm
     }
-  });
+  })
 });
 ```
 
@@ -244,7 +242,7 @@ const connector = new ElasticsearchAPIConnector({
       type: "best_fields",
       fuzziness: "AUTO"
     }
-  });
+  })
 });
 ```
 
@@ -256,7 +254,7 @@ The `getQueryFn` allows you to:
 
 - Override the default query generation logic
 - Implement custom multi_match, match, term and other DSL queries
-- Use KNN and text_expansion queries for semantic search
+- Use semantic search, KNN and text_expansion queries for AI-powered search
 
 ::::{admonition} Note
 :class: important

--- a/docs/reference/tutorials-elasticsearch-customise-query.md
+++ b/docs/reference/tutorials-elasticsearch-customise-query.md
@@ -9,32 +9,68 @@ Elasticsearch connector allows you to customise the Elasticsearch request body b
 
 This is an advanced option, the underlying query may change between versions and reading from / mutating the query is brittle, so please be aware to use this sparingly and let us know what you want to achieve through github issues.
 
-Example below is overriding the `query` section of the Elasticsearch request body.
+## Using beforeSearchCall Hook
+
+The `beforeSearchCall` hook allows you to modify the entire request body before it's sent to Elasticsearch. This is useful when you need to modify multiple parts of the request or add custom fields.
 
 ```js
-const connector = new ElasticsearchAPIConnector(
-  {
-    host: "https://example-host.es.us-central1.gcp.cloud.es.io:9243",
-    index: "national-parks",
-    apiKey: "exampleApiKey"
-  },
-  (requestBody, requestState, queryConfig) => {
-    console.log("postProcess requestBody Call", requestBody); // logging out the requestBody before sending to Elasticsearch
-    if (!requestState.searchTerm) return requestBody;
+const connector = new ElasticsearchAPIConnector({
+  host: "https://example-host.es.us-central1.gcp.cloud.es.io:9243",
+  index: "national-parks",
+  apiKey: "exampleApiKey",
+  beforeSearchCall: async (
+    { requestBody, requestState, queryConfig },
+    next
+  ) => {
+    console.log("Search request:", requestBody); // logging out the requestBody before sending to Elasticsearch
+
+    if (!requestState.searchTerm) {
+      return next(requestBody);
+    }
 
     const searchFields = queryConfig.search_fields;
-
-    requestBody.query = {
-      multi_match: {
-        query: requestState.searchTerm,
-        fields: Object.keys(searchFields).map((fieldName) => {
-          const weight = searchFields[fieldName].weight || 1;
-          return `${fieldName}^${weight}`;
-        })
+    const modifiedBody = {
+      ...requestBody,
+      query: {
+        multi_match: {
+          query: requestState.searchTerm,
+          fields: Object.keys(searchFields).map((fieldName) => {
+            const weight = searchFields[fieldName].weight || 1;
+            return `${fieldName}^${weight}`;
+          })
+        }
       }
-    }; // transforming the query before sending to Elasticsearch using the requestState and queryConfig
+    };
 
-    return requestBody;
+    return next(modifiedBody);
   }
-);
+});
 ```
+
+The hook receives the current request state and configuration, allowing you to modify the request before it's sent to Elasticsearch. Always call `next()` with the modified request body to ensure the request is sent to Elasticsearch.
+
+## Using getQueryFn Hook
+
+The `getQueryFn` hook allows you to completely override the query generation. This is useful when you want to implement custom query logic or use advanced Elasticsearch features like semantic search. The hook is called only when there is a search query, so you don't need to handle empty search terms.
+
+```js
+const connector = new ElasticsearchAPIConnector({
+  host: "https://example-host.es.us-central1.gcp.cloud.es.io:9243",
+  index: "national-parks",
+  apiKey: "exampleApiKey",
+  getQueryFn: (state, config) => ({
+    semantic: {
+      field: "inference_field",
+      query: state.searchTerm
+    }
+  })
+});
+```
+
+The `getQueryFn` hook only replaces the query part of the request body. Filters are still added separately and automatically mixed in. This makes it perfect for implementing custom search algorithms while maintaining compatibility with Search UI's filtering system.
+
+::::{admonition} Note
+:class: important
+
+This example uses Elasticsearch's built-in semantic search. Make sure you have configured the inference pipeline and the field is properly mapped in your index. See [Semantic Search](https://www.elastic.co/docs/solutions/search/semantic-search) documentation for setup instructions.
+::::

--- a/packages/search-ui-elasticsearch-connector/src/connectors/ElasticsearchAPIConnector.ts
+++ b/packages/search-ui-elasticsearch-connector/src/connectors/ElasticsearchAPIConnector.ts
@@ -9,8 +9,7 @@ import type {
 import {
   PostProcessRequestBodyFn,
   ConnectionOptions,
-  RequestModifiers,
-  SearchQueryHook
+  RequestModifiers
 } from "../types";
 import {
   ApiClientTransporter,
@@ -21,10 +20,10 @@ import { handleSearch } from "../handlers/handleSearch";
 
 export default class ElasticsearchAPIConnector implements APIConnector {
   private apiClient: IApiClientTransporter;
-  private beforeSearchCall?: SearchQueryHook;
+  private beforeSearchCall?: RequestModifiers["beforeSearchCall"];
   private getQueryFn?: RequestModifiers["getQueryFn"];
-  private beforeAutocompleteResultsCall?: SearchQueryHook;
-  private beforeAutocompleteSuggestionsCall?: SearchQueryHook;
+  private beforeAutocompleteResultsCall?: RequestModifiers["beforeAutocompleteResultsCall"];
+  private beforeAutocompleteSuggestionsCall?: RequestModifiers["beforeAutocompleteSuggestionsCall"];
 
   constructor(
     config: ConnectionOptions & RequestModifiers,
@@ -77,6 +76,12 @@ export default class ElasticsearchAPIConnector implements APIConnector {
     state: RequestState,
     queryConfig: AutocompleteQueryConfig
   ): Promise<AutocompleteResponseState> {
-    return handleAutocomplete(state, queryConfig, this.apiClient);
+    return handleAutocomplete(
+      state,
+      queryConfig,
+      this.apiClient,
+      this.beforeAutocompleteSuggestionsCall,
+      this.beforeAutocompleteResultsCall
+    );
   }
 }

--- a/packages/search-ui-elasticsearch-connector/src/handlers/__tests__/handleSearch.test.ts
+++ b/packages/search-ui-elasticsearch-connector/src/handlers/__tests__/handleSearch.test.ts
@@ -109,6 +109,8 @@ describe("Search results", () => {
       state,
       queryConfig,
       apiClient,
+      undefined,
+      undefined,
       postProcessRequestBodyFn
     );
 
@@ -308,5 +310,40 @@ describe("Search results", () => {
 
     expect(results.pagingStart).toBe(6);
     expect(results.pagingEnd).toBe(10);
+  });
+
+  it("should modify request body using custom beforeSearchCall", async () => {
+    const modifiedRequestBody = {
+      query: {
+        match_all: {}
+      }
+    };
+
+    const mockPerformRequest = jest.fn().mockResolvedValue(mockResponse);
+    const customApiClient = {
+      ...apiClient,
+      performRequest: mockPerformRequest
+    };
+
+    const customBeforeSearchCall = jest.fn(({ requestBody }, next) => {
+      return next(modifiedRequestBody);
+    });
+
+    await handleSearch(
+      state,
+      queryConfig,
+      customApiClient,
+      customBeforeSearchCall
+    );
+
+    expect(customBeforeSearchCall).toHaveBeenCalledWith(
+      expect.objectContaining({
+        requestBody: expect.any(Object),
+        requestState: state,
+        queryConfig
+      }),
+      expect.any(Function)
+    );
+    expect(mockPerformRequest).toHaveBeenCalledWith(modifiedRequestBody);
   });
 });

--- a/packages/search-ui-elasticsearch-connector/src/handlers/handleAutocomplete.ts
+++ b/packages/search-ui-elasticsearch-connector/src/handlers/handleAutocomplete.ts
@@ -11,105 +11,113 @@ import { ResultsAutocompleteBuilder } from "../queryBuilders/ResultsAutocomplete
 import { SuggestionsAutocompleteBuilder } from "../queryBuilders/SuggestionsAutocompleteBuilder";
 import { transformHitToFieldResult } from "../transformer/responseTransformer";
 import type { IApiClientTransporter } from "../transporter/ApiClientTransporter";
-import type { SearchResponse } from "@elastic/elasticsearch/lib/api/types";
-import type { SearchRequest } from "../types";
-
-type SuggestionConfig = {
-  searchRequest: SearchRequest;
-  handler: (response: SearchResponse) => void;
-};
+import type { SearchQueryHook } from "../types";
 
 const isResultSuggestionConfiguration = (
   config: QueryConfig | ResultSuggestionConfiguration | SuggestionConfiguration
 ): config is ResultSuggestionConfiguration =>
   "queryType" in config && config.queryType === "results";
 
+const defaultHook = ({ requestBody }, next) => next(requestBody);
+
 export const handleAutocomplete = async (
   state: RequestState,
   queryConfig: AutocompleteQueryConfig,
-  apiClient: IApiClientTransporter
+  apiClient: IApiClientTransporter,
+  onBeforeAutocompleteSuggestionsCall: SearchQueryHook<AutocompleteQueryConfig> = defaultHook,
+  onBeforeAutocompleteResultsCall: SearchQueryHook<AutocompleteQueryConfig> = defaultHook
 ): Promise<AutocompleteResponseState> => {
-  const suggestionConfigurations: SuggestionConfig[] = [];
+  const suggestionTasks: Promise<void>[] = [];
   const result: AutocompleteResponseState = {
     autocompletedResults: [],
     autocompletedSuggestions: {},
     autocompletedResultsRequestId: "",
     autocompletedSuggestionsRequestId: ""
   };
+  const next = (requestBody: RequestState) =>
+    apiClient.performRequest(requestBody);
 
-  const buildResultConfig = (
+  const buildResultHandler = (
     config: QueryConfig | ResultSuggestionConfiguration,
     type?: string
-  ): SuggestionConfig => {
+  ): void => {
     const builder = new ResultsAutocompleteBuilder(
       state,
       config,
       config.resultsPerPage || queryConfig.suggestions?.size || 5
     );
 
-    return {
-      searchRequest: builder.build(),
-      handler(response) {
+    const request = builder.build();
+
+    suggestionTasks.push(
+      onBeforeAutocompleteResultsCall(
+        { requestBody: request, requestState: state, queryConfig },
+        next
+      ).then((response) => {
         const hits = response.hits.hits.map(transformHitToFieldResult);
         if (type && isResultSuggestionConfiguration(config)) {
           result.autocompletedSuggestions[type] = hits.map((hit) => ({
             queryType: config.queryType,
-            result: hit
+            result: Object.keys(config.result_fields || {}).reduce(
+              (acc, field) => ({
+                ...acc,
+                [field]: hit[field]
+              }),
+              {}
+            )
           }));
         } else {
           result.autocompletedResults.push(...hits);
         }
-      }
-    };
+      })
+    );
   };
 
-  const buildSuggestionConfig = (
+  const buildSuggestionHandler = (
     config: SuggestionConfiguration,
     type: string
-  ): SuggestionConfig => {
+  ): void => {
     const builder = new SuggestionsAutocompleteBuilder(
       state,
       config,
       queryConfig.suggestions?.size || 5
     );
 
-    return {
-      searchRequest: builder.build(),
-      handler(response) {
+    const request = builder.build();
+
+    suggestionTasks.push(
+      onBeforeAutocompleteSuggestionsCall(
+        { requestBody: request, requestState: state, queryConfig },
+        next
+      ).then((response) => {
         const options = response.suggest.suggest[0].options;
         const suggestions = Array.isArray(options)
           ? options.map(({ text }) => ({ suggestion: text }))
           : [{ suggestion: options.text }];
 
         result.autocompletedSuggestions[type] = suggestions;
-      }
-    };
+      })
+    );
   };
 
   if (queryConfig.results) {
-    suggestionConfigurations.push(buildResultConfig(queryConfig.results));
+    buildResultHandler(queryConfig.results);
   }
 
   Object.entries(queryConfig.suggestions?.types || {}).forEach(
     ([type, configuration]) => {
       if (isResultSuggestionConfiguration(configuration)) {
-        suggestionConfigurations.push(buildResultConfig(configuration, type));
+        buildResultHandler(configuration, type);
       } else if (
         !configuration.queryType ||
         configuration.queryType === "suggestions"
       ) {
-        suggestionConfigurations.push(
-          buildSuggestionConfig(configuration, type)
-        );
+        buildSuggestionHandler(configuration, type);
       }
     }
   );
 
-  await Promise.all(
-    suggestionConfigurations.map(({ searchRequest, handler }) =>
-      apiClient.performRequest(searchRequest).then(handler)
-    )
-  );
+  await Promise.all(suggestionTasks);
 
   return result;
 };

--- a/packages/search-ui-elasticsearch-connector/src/handlers/handleAutocomplete.ts
+++ b/packages/search-ui-elasticsearch-connector/src/handlers/handleAutocomplete.ts
@@ -11,7 +11,7 @@ import { ResultsAutocompleteBuilder } from "../queryBuilders/ResultsAutocomplete
 import { SuggestionsAutocompleteBuilder } from "../queryBuilders/SuggestionsAutocompleteBuilder";
 import { transformHitToFieldResult } from "../transformer/responseTransformer";
 import type { IApiClientTransporter } from "../transporter/ApiClientTransporter";
-import type { SearchQueryHook } from "../types";
+import type { SearchQueryHook, SearchRequest } from "../types";
 
 const isResultSuggestionConfiguration = (
   config: QueryConfig | ResultSuggestionConfiguration | SuggestionConfiguration
@@ -34,7 +34,7 @@ export const handleAutocomplete = async (
     autocompletedResultsRequestId: "",
     autocompletedSuggestionsRequestId: ""
   };
-  const next = (requestBody: RequestState) =>
+  const next = (requestBody: SearchRequest) =>
     apiClient.performRequest(requestBody);
 
   const buildResultHandler = (

--- a/packages/search-ui-elasticsearch-connector/src/handlers/handleSearch.ts
+++ b/packages/search-ui-elasticsearch-connector/src/handlers/handleSearch.ts
@@ -6,22 +6,37 @@ import type {
 import { SearchQueryBuilder } from "../queryBuilders/SearchQueryBuilder";
 import { transformSearchResponse } from "../transformer/responseTransformer";
 import type { IApiClientTransporter } from "../transporter/ApiClientTransporter";
-import type { PostProcessRequestBodyFn } from "../types";
+import type {
+  PostProcessRequestBodyFn,
+  RequestModifiers,
+  SearchQueryHook,
+  SearchRequest
+} from "../types";
 
 export const handleSearch = async (
   state: RequestState,
   queryConfig: QueryConfig,
   apiClient: IApiClientTransporter,
+  beforeSearchCall?: SearchQueryHook,
+  getQueryFn?: RequestModifiers["getQueryFn"],
   postProcessRequestBodyFn?: PostProcessRequestBodyFn
 ): Promise<ResponseState> => {
-  const queryBuilder = new SearchQueryBuilder(state, queryConfig);
+  const queryBuilder = new SearchQueryBuilder(state, queryConfig, getQueryFn);
   let requestBody = queryBuilder.build();
+  const next = async (requestBody: SearchRequest) => {
+    return await apiClient.performRequest(requestBody);
+  };
+  let response;
 
-  if (postProcessRequestBodyFn) {
+  if (beforeSearchCall) {
+    response = await beforeSearchCall(requestBody, state, queryConfig, next);
+  } else if (postProcessRequestBodyFn) {
     requestBody = postProcessRequestBodyFn(requestBody, state, queryConfig);
-  }
 
-  const response = await apiClient.performRequest(requestBody);
+    response = await apiClient.performRequest(requestBody);
+  } else {
+    response = await apiClient.performRequest(requestBody);
+  }
 
   return transformSearchResponse(response, queryBuilder);
 };

--- a/packages/search-ui-elasticsearch-connector/src/handlers/handleSearch.ts
+++ b/packages/search-ui-elasticsearch-connector/src/handlers/handleSearch.ts
@@ -23,19 +23,22 @@ export const handleSearch = async (
 ): Promise<ResponseState> => {
   const queryBuilder = new SearchQueryBuilder(state, queryConfig, getQueryFn);
   let requestBody = queryBuilder.build();
-  const next = async (requestBody: SearchRequest) => {
-    return await apiClient.performRequest(requestBody);
+  const next = async (body: SearchRequest) => {
+    return await apiClient.performRequest(body);
   };
   let response;
 
-  if (beforeSearchCall) {
-    response = await beforeSearchCall(requestBody, state, queryConfig, next);
-  } else if (postProcessRequestBodyFn) {
+  if (postProcessRequestBodyFn) {
     requestBody = postProcessRequestBodyFn(requestBody, state, queryConfig);
 
     response = await apiClient.performRequest(requestBody);
+  } else if (beforeSearchCall) {
+    response = await beforeSearchCall(
+      { requestBody, requestState: state, queryConfig },
+      next
+    );
   } else {
-    response = await apiClient.performRequest(requestBody);
+    response = await next(requestBody);
   }
 
   return transformSearchResponse(response, queryBuilder);

--- a/packages/search-ui-elasticsearch-connector/src/handlers/handleSearch.ts
+++ b/packages/search-ui-elasticsearch-connector/src/handlers/handleSearch.ts
@@ -6,7 +6,11 @@ import type {
 import { SearchQueryBuilder } from "../queryBuilders/SearchQueryBuilder";
 import { transformSearchResponse } from "../transformer/responseTransformer";
 import type { IApiClientTransporter } from "../transporter/ApiClientTransporter";
-import type { PostProcessRequestBodyFn, RequestModifiers } from "../types";
+import type {
+  PostProcessRequestBodyFn,
+  RequestModifiers,
+  SearchRequest
+} from "../types";
 
 export const handleSearch = async (
   state: RequestState,
@@ -30,7 +34,7 @@ export const handleSearch = async (
   } else {
     response = await beforeSearchCall(
       { requestBody, requestState: state, queryConfig },
-      (requestBody: RequestState) => apiClient.performRequest(requestBody)
+      (requestBody: SearchRequest) => apiClient.performRequest(requestBody)
     );
   }
 

--- a/packages/search-ui-elasticsearch-connector/src/handlers/handleSearch.ts
+++ b/packages/search-ui-elasticsearch-connector/src/handlers/handleSearch.ts
@@ -6,39 +6,32 @@ import type {
 import { SearchQueryBuilder } from "../queryBuilders/SearchQueryBuilder";
 import { transformSearchResponse } from "../transformer/responseTransformer";
 import type { IApiClientTransporter } from "../transporter/ApiClientTransporter";
-import type {
-  PostProcessRequestBodyFn,
-  RequestModifiers,
-  SearchQueryHook,
-  SearchRequest
-} from "../types";
+import type { PostProcessRequestBodyFn, RequestModifiers } from "../types";
 
 export const handleSearch = async (
   state: RequestState,
   queryConfig: QueryConfig,
   apiClient: IApiClientTransporter,
-  beforeSearchCall?: SearchQueryHook,
+  beforeSearchCall: RequestModifiers["beforeSearchCall"] = (
+    { requestBody },
+    next
+  ) => next(requestBody),
   getQueryFn?: RequestModifiers["getQueryFn"],
   postProcessRequestBodyFn?: PostProcessRequestBodyFn
 ): Promise<ResponseState> => {
   const queryBuilder = new SearchQueryBuilder(state, queryConfig, getQueryFn);
   let requestBody = queryBuilder.build();
-  const next = async (body: SearchRequest) => {
-    return await apiClient.performRequest(body);
-  };
   let response;
 
   if (postProcessRequestBodyFn) {
     requestBody = postProcessRequestBodyFn(requestBody, state, queryConfig);
 
     response = await apiClient.performRequest(requestBody);
-  } else if (beforeSearchCall) {
+  } else {
     response = await beforeSearchCall(
       { requestBody, requestState: state, queryConfig },
-      next
+      (requestBody: RequestState) => apiClient.performRequest(requestBody)
     );
-  } else {
-    response = await next(requestBody);
   }
 
   return transformSearchResponse(response, queryBuilder);

--- a/packages/search-ui-elasticsearch-connector/src/queryBuilders/SearchQueryBuilder.ts
+++ b/packages/search-ui-elasticsearch-connector/src/queryBuilders/SearchQueryBuilder.ts
@@ -177,8 +177,7 @@ export class SearchQueryBuilder extends BaseQueryBuilder {
                     query: searchQuery,
                     fields: fields,
                     type: "best_fields",
-                    operator: "and",
-                    fuzziness: this.queryConfig.fuzziness ? "AUTO" : undefined
+                    operator: "and"
                   }
                 },
                 {

--- a/packages/search-ui-elasticsearch-connector/src/queryBuilders/SearchQueryBuilder.ts
+++ b/packages/search-ui-elasticsearch-connector/src/queryBuilders/SearchQueryBuilder.ts
@@ -6,7 +6,7 @@ import {
   transformFilter
 } from "../transformer/filterTransformer";
 import { RequestModifiers, SearchRequest } from "../types";
-import { deepMergeObjects, getQueryFields, mergeObjects } from "../utils";
+import { deepMergeObjects, getQueryFields } from "../utils";
 
 export class SearchQueryBuilder extends BaseQueryBuilder {
   constructor(

--- a/packages/search-ui-elasticsearch-connector/src/transformer/__tests__/filterTransformer.test.ts
+++ b/packages/search-ui-elasticsearch-connector/src/transformer/__tests__/filterTransformer.test.ts
@@ -83,8 +83,8 @@ describe("filterTransformer", () => {
       expect(result).toEqual({
         bool: {
           filter: [
-            { range: { price: { from: 10, to: 20 } } },
-            { range: { price: { from: 30, to: 40 } } }
+            { range: { price: { gte: 10, lte: 20 } } },
+            { range: { price: { gte: 30, lte: 40 } } }
           ]
         }
       });
@@ -158,8 +158,8 @@ describe("filterTransformer", () => {
       expect(result).toEqual({
         bool: {
           must: [
-            { range: { price: { from: 0, to: 100 } } },
-            { range: { price: { from: 100, to: 200 } } }
+            { range: { price: { gte: 0, lte: 100 } } },
+            { range: { price: { gte: 100, lte: 200 } } }
           ]
         }
       });
@@ -259,8 +259,8 @@ describe("filterTransformer", () => {
       expect(result).toEqual({
         filters: {
           filters: {
-            "0-100": { range: { price: { from: 0, to: 100 } } },
-            "100-200": { range: { price: { from: 100, to: 200 } } }
+            "0-100": { range: { price: { gte: 0, lte: 100 } } },
+            "100-200": { range: { price: { gte: 100, lte: 200 } } }
           }
         }
       });

--- a/packages/search-ui-elasticsearch-connector/src/transformer/filterTransformer.ts
+++ b/packages/search-ui-elasticsearch-connector/src/transformer/filterTransformer.ts
@@ -27,12 +27,12 @@ const transformRangeFilterValue = (
 ): QueryRangeValue => ({
   ...("from" in value
     ? {
-        from: isValidDateString(value.from) ? value.from : Number(value.from)
+        gte: isValidDateString(value.from) ? value.from : Number(value.from)
       }
     : {}),
   ...("to" in value
     ? {
-        to: isValidDateString(value.to) ? value.to : Number(value.to)
+        lte: isValidDateString(value.to) ? value.to : Number(value.to)
       }
     : {})
 });

--- a/packages/search-ui-elasticsearch-connector/src/types.ts
+++ b/packages/search-ui-elasticsearch-connector/src/types.ts
@@ -1,5 +1,9 @@
 import type { estypes } from "@elastic/elasticsearch";
-import type { QueryConfig, RequestState } from "@elastic/search-ui";
+import type {
+  AutocompleteQueryConfig,
+  QueryConfig,
+  RequestState
+} from "@elastic/search-ui";
 import type { IApiClientTransporter } from "./transporter/ApiClientTransporter";
 
 export type SearchRequest = estypes.SearchRequest;
@@ -23,11 +27,11 @@ export type PostProcessRequestBodyFn = (
   queryConfig: QueryConfig
 ) => SearchRequest;
 
-export type SearchQueryHook = (
+export type SearchQueryHook<T> = (
   params: {
     requestBody: SearchRequest;
     requestState: RequestState;
-    queryConfig: QueryConfig;
+    queryConfig: T;
   },
   next: (newQueryOptions: SearchRequest) => Promise<ResponseBody>
 ) => Promise<ResponseBody>;
@@ -48,8 +52,8 @@ export type ConnectionOptions = {
 };
 
 export type RequestModifiers = {
-  beforeSearchCall?: SearchQueryHook;
-  beforeAutocompleteResultsCall?: SearchQueryHook;
-  beforeAutocompleteSuggestionsCall?: SearchQueryHook;
+  beforeSearchCall?: SearchQueryHook<QueryConfig>;
+  beforeAutocompleteResultsCall?: SearchQueryHook<AutocompleteQueryConfig>;
+  beforeAutocompleteSuggestionsCall?: SearchQueryHook<AutocompleteQueryConfig>;
   getQueryFn?: (state: RequestState, queryConfig: QueryConfig) => SearchRequest;
 };

--- a/packages/search-ui-elasticsearch-connector/src/types.ts
+++ b/packages/search-ui-elasticsearch-connector/src/types.ts
@@ -23,6 +23,15 @@ export type PostProcessRequestBodyFn = (
   queryConfig: QueryConfig
 ) => SearchRequest;
 
+export type SearchQueryHook = (
+  params: {
+    requestBody: SearchRequest;
+    requestState: RequestState;
+    queryConfig: QueryConfig;
+  },
+  next: (newQueryOptions: SearchRequest) => Promise<ResponseBody>
+) => Promise<ResponseBody>;
+
 export interface CloudHost {
   id: string;
 }
@@ -36,4 +45,11 @@ export type ConnectionOptions = {
   connectionOptions?: {
     headers?: Record<string, string>;
   };
+};
+
+export type RequestModifiers = {
+  beforeSearchCall?: SearchQueryHook;
+  beforeAutocompleteResultsCall?: SearchQueryHook;
+  beforeAutocompleteSuggestionsCall?: SearchQueryHook;
+  getQueryFn?: (state: RequestState, queryConfig: QueryConfig) => SearchRequest;
 };

--- a/packages/search-ui-elasticsearch-connector/src/utils.ts
+++ b/packages/search-ui-elasticsearch-connector/src/utils.ts
@@ -47,3 +47,42 @@ export const getHostFromCloud = (cloud: { id: string }): string => {
   const cloudUrls = decodeBase64(id.split(":")[1]).split("$");
   return `https://${cloudUrls[1]}.${cloudUrls[0]}`;
 };
+
+export const deepMergeObjects = (
+  target: Record<string, unknown> | null,
+  source: Record<string, unknown> | null
+): Record<string, unknown> => {
+  if (!target && !source) {
+    return null;
+  }
+
+  if (!target || Object.keys(target).length === 0) {
+    return { ...source };
+  }
+
+  if (!source || Object.keys(source).length === 0) {
+    return { ...target };
+  }
+
+  const result = { ...target };
+
+  for (const key in source) {
+    if (source[key] && typeof source[key] === "object") {
+      if (Array.isArray(source[key])) {
+        result[key] = [
+          ...(Array.isArray(result[key]) ? (result[key] as unknown[]) : []),
+          ...(source[key] as unknown[])
+        ];
+      } else {
+        result[key] = deepMergeObjects(
+          (result[key] as Record<string, unknown>) || {},
+          source[key] as Record<string, unknown>
+        );
+      }
+    } else {
+      result[key] = source[key];
+    }
+  }
+
+  return result;
+};


### PR DESCRIPTION
## Description

This PR adds support for customizing how search and autocomplete queries are built and executed. It introduces new hooks (`beforeSearchCall`, `beforeAutocompleteResultsCall`, and `beforeAutocompleteSuggestionsCall`) for modifying requests and responses, and a `getQueryFn` function to override how the query DSL is built.

We also deprecated `postProcessRequestBodyFn` in favor of the new hooks, which are more powerful and easier to work with.

## List of changes

- Added `getQueryFn` for overriding query generation logic
- Added `beforeSearchCall`, `beforeAutocompleteResultsCall`, and `beforeAutocompleteSuggestionsCall` hooks
- Updated `SearchQueryBuilder` to support merging filters with custom queries
- Added `deepMergeObjects` utility for merging query DSL parts
- Deprecated `postProcessRequestBodyFn` (with console warning in dev mode)
- Updated docs:
  - Documented `getQueryFn` and hook usage with examples
  - Added new sections to Elasticsearch connector docs
  - Marked `postProcessRequestBodyFn` as deprecated
- Added tests for:
  - `getQueryFn` logic
  - all lifecycle hooks
  - query merging behavior
- Cleaned up autocomplete query handling and made result/suggestion hooks consistent