### PR TITLE
fix: rawResponse hard-coded to null

### DIFF
--- a/packages/search-ui-elasticsearch-connector/src/handlers/__tests__/handleSearch.test.ts
+++ b/packages/search-ui-elasticsearch-connector/src/handlers/__tests__/handleSearch.test.ts
@@ -153,7 +153,67 @@ describe("Search results", () => {
         },
         "pagingEnd": 10,
         "pagingStart": 1,
-        "rawResponse": null,
+        "rawResponse": {
+          "_shards": {
+            "failed": 0,
+            "skipped": 0,
+            "successful": 1,
+            "total": 1,
+          },
+          "aggregations": {
+            "facet_bucket_another_field.keyword": {
+              "another_field.keyword": {
+                "buckets": [
+                  {
+                    "doc_count": 10,
+                    "key": "label1",
+                  },
+                  {
+                    "doc_count": 20,
+                    "key": "label2",
+                  },
+                ],
+              },
+            },
+            "facet_bucket_world_heritage_site.keyword": {
+              "world_heritage_site.keyword": {
+                "buckets": [
+                  {
+                    "doc_count": 10,
+                    "key": "label3",
+                  },
+                  {
+                    "doc_count": 20,
+                    "key": "label4",
+                  },
+                ],
+              },
+            },
+          },
+          "hits": {
+            "hits": [
+              {
+                "_id": "test",
+                "_index": "test",
+                "_source": {
+                  "description": "test",
+                  "title": "hello",
+                },
+                "highlight": {
+                  "title": [
+                    "hello",
+                  ],
+                },
+              },
+            ],
+            "total": {
+              "relation": "eq",
+              "value": 100,
+            },
+          },
+          "timed_out": false,
+          "took": 1,
+        },
         "requestId": "",
         "resultSearchTerm": "test",
         "results": [

--- a/packages/search-ui-elasticsearch-connector/src/transformer/__tests__/responseTransformer.test.ts
+++ b/packages/search-ui-elasticsearch-connector/src/transformer/__tests__/responseTransformer.test.ts
@@ -128,7 +128,51 @@ describe("responseTransformer", () => {
           }
         ],
         requestId: "",
-        rawResponse: null
+        rawResponse: {
+          _shards: {
+            failed: 0,
+            skipped: 0,
+            successful: 1,
+            total: 1
+          },
+          aggregations: {
+            facet_bucket_category: {
+              category: {
+                buckets: [
+                  {
+                    doc_count: 10,
+                    key: "electronics"
+                  },
+                  {
+                    doc_count: 20,
+                    key: "books"
+                  }
+                ]
+              }
+            }
+          },
+          hits: {
+            hits: [
+              {
+                _id: "1",
+                _index: "test",
+                _source: {
+                  description: "Test Description",
+                  title: "Test Title"
+                },
+                highlight: {
+                  title: ["<em>Test</em> Title"]
+                }
+              }
+            ],
+            total: {
+              relation: "eq",
+              value: 100
+            }
+          },
+          timed_out: false,
+          took: 1
+        }
       });
     });
 
@@ -166,7 +210,24 @@ describe("responseTransformer", () => {
         facets: {},
         results: [],
         requestId: "",
-        rawResponse: null
+        rawResponse: {
+          _shards: {
+            failed: 0,
+            skipped: 0,
+            successful: 1,
+            total: 1
+          },
+          aggregations: {},
+          hits: {
+            hits: [],
+            total: {
+              relation: "eq",
+              value: 0
+            }
+          },
+          timed_out: false,
+          took: 1
+        }
       });
     });
 
@@ -210,7 +271,24 @@ describe("responseTransformer", () => {
         facets: {},
         results: [],
         requestId: "",
-        rawResponse: null
+        rawResponse: {
+          _shards: {
+            failed: 0,
+            skipped: 0,
+            successful: 1,
+            total: 1
+          },
+          aggregations: {},
+          hits: {
+            hits: [],
+            total: {
+              relation: "eq",
+              value: 25
+            }
+          },
+          timed_out: false,
+          took: 1
+        }
       });
     });
 

--- a/packages/search-ui-elasticsearch-connector/src/transformer/responseTransformer.ts
+++ b/packages/search-ui-elasticsearch-connector/src/transformer/responseTransformer.ts
@@ -30,7 +30,7 @@ export const transformSearchResponse = (
     facets,
     results: response.hits.hits.map(transformHitToFieldResult),
     requestId: "",
-    rawResponse: null
+    rawResponse: response
   };
 };
 


### PR DESCRIPTION
## Description

While trying to access `rawResponse.took` I noticed `rawResponse` is always `null` in `@elastic/search-ui-elasticsearch-connector`

## List of changes

- updates `rawResponse` to `response` instead of `null`
- updates necessary tests
