### PR TITLE
Enhance facet configuration and sorting options

### DIFF
--- a/packages/search-ui-elasticsearch-connector/src/queryBuilders/__tests__/SearchQueryBuilder.test.ts
+++ b/packages/search-ui-elasticsearch-connector/src/queryBuilders/__tests__/SearchQueryBuilder.test.ts
@@ -22,9 +22,9 @@ describe("SearchQueryBuilder", () => {
       }
     },
     facets: {
-      "category.keyword": { type: "value" }
+      categoryKeyword: { type: "value", field: "category.keyword" }
     },
-    disjunctiveFacets: ["category.keyword"],
+    disjunctiveFacets: ["categoryKeyword"],
     filters: [
       {
         type: "all",
@@ -45,7 +45,7 @@ describe("SearchQueryBuilder", () => {
       aggs: {
         facet_bucket_all: {
           aggs: {
-            "category.keyword": {
+            categoryKeyword: {
               terms: {
                 field: "category.keyword",
                 order: {
@@ -142,7 +142,7 @@ describe("SearchQueryBuilder", () => {
       aggs: {
         facet_bucket_all: {
           aggs: {
-            "category.keyword": {
+            categoryKeyword: {
               terms: {
                 field: "category.keyword",
                 order: { _count: "desc" },

--- a/packages/search-ui-elasticsearch-connector/src/transformer/__tests__/filterTransformer.test.ts
+++ b/packages/search-ui-elasticsearch-connector/src/transformer/__tests__/filterTransformer.test.ts
@@ -258,7 +258,8 @@ describe("filterTransformer", () => {
       const facetConfig: FacetConfiguration = {
         type: "value",
         size: 10,
-        sort: "count"
+        sort: { orderBy: "count" },
+        field: "category"
       };
 
       const result = transformFacetToAggs("category", facetConfig);

--- a/packages/search-ui/src/types/index.ts
+++ b/packages/search-ui/src/types/index.ts
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
-
 import type { SearchDriverActions } from "..";
 
 export type SortOption = {
@@ -153,7 +151,8 @@ export type FacetConfiguration = {
   ranges?: FilterValueRange[];
   center?: string;
   unit?: string;
-  sort?: "count" | "value";
+  sort?: FacetSortOption;
+  field?: string;
 };
 
 export type ConditionalRule = (state: { filters: Filter[] }) => boolean;
@@ -291,3 +290,8 @@ export type Event =
   | ResultSelectedEvent
   | FacetFilterSelectedEvent
   | FacetFilterRemovedEvent;
+
+export type FacetSortOption = {
+  orderBy: "count" | "value";
+  direction?: SortDirection;
+};


### PR DESCRIPTION
- Updated `FacetConfiguration` to include `field` and changed `sort` to use `FacetSortOption`.
- Modified `SearchQueryBuilder` to utilize the new `field` property for facet filtering.
- Adjusted tests to reflect changes in facet configuration and ensure compatibility with the new structure.
- Improved `transformFacetToAggs` to handle the updated facet sorting logic.

Before submitting this PR:

1. Make sure you are PR'ing from a fork, please do not push branches directly
   to this repository.
2. Ensure you've written sufficient tests for your work.
3. Double check that your changes will not break existing connectors (if
   applicable).
4. Double check that your changes do not break the `react-search-ui-views`
   storybook (if applicable).

## Description

## List of changes

## Associated Github Issues
