### PR TITLE
Restructure Search UI Reference landing page

### DIFF
--- a/docs/reference/advanced-usage.md
+++ b/docs/reference/advanced-usage.md
@@ -4,6 +4,7 @@ mapped_pages:
   - https://www.elastic.co/guide/en/search-ui/current/guides-using-with-vue-js.html
 applies_to:
   stack:
+  serverless:
 ---
 
 # Using with Vue.js [guides-using-with-vue-js]

--- a/docs/reference/api-connectors-elasticsearch.md
+++ b/docs/reference/api-connectors-elasticsearch.md
@@ -3,6 +3,7 @@ mapped_pages:
   - https://www.elastic.co/guide/en/search-ui/current/api-connectors-elasticsearch.html
 applies_to:
   stack:
+  serverless:
 ---
 
 # Elasticsearch Connector [api-connectors-elasticsearch]

--- a/docs/reference/api-connectors-site-search.md
+++ b/docs/reference/api-connectors-site-search.md
@@ -3,6 +3,7 @@ mapped_pages:
   - https://www.elastic.co/guide/en/search-ui/current/api-connectors-site-search.html
 applies_to:
   stack:
+  serverless:
 ---
 
 # Site Search Connector [api-connectors-site-search]

--- a/docs/reference/api-core-actions.md
+++ b/docs/reference/api-core-actions.md
@@ -3,6 +3,7 @@ mapped_pages:
   - https://www.elastic.co/guide/en/search-ui/current/api-core-actions.html
 applies_to:
   stack:
+  serverless:
 ---
 
 # Actions [api-core-actions]

--- a/docs/reference/api-core-configuration.md
+++ b/docs/reference/api-core-configuration.md
@@ -3,6 +3,7 @@ mapped_pages:
   - https://www.elastic.co/guide/en/search-ui/current/api-core-configuration.html
 applies_to:
   stack:
+  serverless:
 ---
 
 # Configuration [api-core-configuration]

--- a/docs/reference/api-core-index.md
+++ b/docs/reference/api-core-index.md
@@ -3,6 +3,7 @@ mapped_pages:
   - https://www.elastic.co/guide/en/search-ui/current/api-core-index.html
 applies_to:
   stack:
+  serverless:
 ---
 
 # Core API

--- a/docs/reference/api-core-state.md
+++ b/docs/reference/api-core-state.md
@@ -3,6 +3,7 @@ mapped_pages:
   - https://www.elastic.co/guide/en/search-ui/current/api-core-state.html
 applies_to:
   stack:
+  serverless:
 ---
 
 # State [api-core-state]

--- a/docs/reference/api-react-components-error-boundary.md
+++ b/docs/reference/api-react-components-error-boundary.md
@@ -3,6 +3,7 @@ mapped_pages:
   - https://www.elastic.co/guide/en/search-ui/current/api-react-components-error-boundary.html
 applies_to:
   stack:
+  serverless:
 ---
 
 # ErrorBoundary [api-react-components-error-boundary]

--- a/docs/reference/api-react-components-facet.md
+++ b/docs/reference/api-react-components-facet.md
@@ -3,6 +3,7 @@ mapped_pages:
   - https://www.elastic.co/guide/en/search-ui/current/api-react-components-facet.html
 applies_to:
   stack:
+  serverless:
 ---
 
 # Facet [api-react-components-facet]

--- a/docs/reference/api-react-components-paging-info.md
+++ b/docs/reference/api-react-components-paging-info.md
@@ -3,6 +3,7 @@ mapped_pages:
   - https://www.elastic.co/guide/en/search-ui/current/api-react-components-paging-info.html
 applies_to:
   stack:
+  serverless:
 ---
 
 # PagingInfo [api-react-components-paging-info]

--- a/docs/reference/api-react-components-paging.md
+++ b/docs/reference/api-react-components-paging.md
@@ -3,6 +3,7 @@ mapped_pages:
   - https://www.elastic.co/guide/en/search-ui/current/api-react-components-paging.html
 applies_to:
   stack:
+  serverless:
 ---
 
 # Paging [api-react-components-paging]

--- a/docs/reference/api-react-components-result.md
+++ b/docs/reference/api-react-components-result.md
@@ -3,6 +3,7 @@ mapped_pages:
   - https://www.elastic.co/guide/en/search-ui/current/api-react-components-result.html
 applies_to:
   stack:
+  serverless:
 ---
 
 # Result [api-react-components-result]

--- a/docs/reference/api-react-components-results-per-page.md
+++ b/docs/reference/api-react-components-results-per-page.md
@@ -3,6 +3,7 @@ mapped_pages:
   - https://www.elastic.co/guide/en/search-ui/current/api-react-components-results-per-page.html
 applies_to:
   stack:
+  serverless:
 ---
 
 # ResultsPerPage [api-react-components-results-per-page]

--- a/docs/reference/api-react-components-results.md
+++ b/docs/reference/api-react-components-results.md
@@ -3,6 +3,7 @@ mapped_pages:
   - https://www.elastic.co/guide/en/search-ui/current/api-react-components-results.html
 applies_to:
   stack:
+  serverless:
 ---
 
 # Results [api-react-components-results]

--- a/docs/reference/api-react-components-search-box.md
+++ b/docs/reference/api-react-components-search-box.md
@@ -4,6 +4,7 @@ mapped_pages:
   - https://www.elastic.co/guide/en/search-ui/current/api-react-components-search-box.html
 applies_to:
   stack:
+  serverless:
 ---
 
 # SearchBox [api-react-components-search-box]

--- a/docs/reference/api-react-components-sorting.md
+++ b/docs/reference/api-react-components-sorting.md
@@ -3,6 +3,7 @@ mapped_pages:
   - https://www.elastic.co/guide/en/search-ui/current/api-react-components-sorting.html
 applies_to:
   stack:
+  serverless:
 ---
 
 # Sorting [api-react-components-sorting]

--- a/docs/reference/api-react-search-provider.md
+++ b/docs/reference/api-react-search-provider.md
@@ -4,6 +4,7 @@ mapped_pages:
   - https://www.elastic.co/guide/en/search-ui/current/api-react-search-provider.html
 applies_to:
   stack:
+  serverless:
 ---
 
 # SearchProvider [api-react-search-provider]

--- a/docs/reference/api-react-use-search.md
+++ b/docs/reference/api-react-use-search.md
@@ -3,6 +3,7 @@ mapped_pages:
   - https://www.elastic.co/guide/en/search-ui/current/api-react-use-search.html
 applies_to:
   stack:
+  serverless:
 ---
 
 # useSearch hook [api-react-use-search]

--- a/docs/reference/api-react-with-search.md
+++ b/docs/reference/api-react-with-search.md
@@ -3,6 +3,7 @@ mapped_pages:
   - https://www.elastic.co/guide/en/search-ui/current/api-react-with-search.html
 applies_to:
   stack:
+  serverless:
 ---
 
 # WithSearch & withSearch [api-react-with-search]

--- a/docs/reference/api-reference.md
+++ b/docs/reference/api-reference.md
@@ -4,6 +4,7 @@ mapped_pages:
   - https://www.elastic.co/guide/en/search-ui/current/api-architecture.html
 applies_to:
   stack:
+  serverless:
 ---
 
 # Architecture [api-architecture]

--- a/docs/reference/basic-usage.md
+++ b/docs/reference/basic-usage.md
@@ -4,6 +4,7 @@ mapped_pages:
   - https://www.elastic.co/guide/en/search-ui/current/guides-customizing-styles-and-html.html
 applies_to:
   stack:
+  serverless:
 ---
 
 # Customizing Styles and HTML [guides-customizing-styles-and-html]

--- a/docs/reference/ecommerce.md
+++ b/docs/reference/ecommerce.md
@@ -4,6 +4,7 @@ mapped_pages:
   - https://www.elastic.co/guide/en/search-ui/current/solutions-ecommerce.html
 applies_to:
   stack:
+  serverless:
 ---
 
 # Overview [solutions-ecommerce]

--- a/docs/reference/guides-adding-search-bar-to-header.md
+++ b/docs/reference/guides-adding-search-bar-to-header.md
@@ -3,6 +3,7 @@ mapped_pages:
   - https://www.elastic.co/guide/en/search-ui/current/guides-adding-search-bar-to-header.html
 applies_to:
   stack:
+  serverless:
 ---
 
 # Adding search bar to header [guides-adding-search-bar-to-header]

--- a/docs/reference/guides-analyzing-performance.md
+++ b/docs/reference/guides-analyzing-performance.md
@@ -3,6 +3,7 @@ mapped_pages:
   - https://www.elastic.co/guide/en/search-ui/current/guides-analyzing-performance.html
 applies_to:
   stack:
+  serverless:
 ---
 
 # Analyzing performance [guides-analyzing-performance]

--- a/docs/reference/guides-building-custom-connector.md
+++ b/docs/reference/guides-building-custom-connector.md
@@ -3,6 +3,7 @@ mapped_pages:
   - https://www.elastic.co/guide/en/search-ui/current/guides-building-a-custom-connector.html
 applies_to:
   stack:
+  serverless:
 ---
 
 # Building a custom connector [guides-building-a-custom-connector]

--- a/docs/reference/guides-changing-component-behavior.md
+++ b/docs/reference/guides-changing-component-behavior.md
@@ -3,6 +3,7 @@ mapped_pages:
   - https://www.elastic.co/guide/en/search-ui/current/guides-changing-component-behavior.html
 applies_to:
   stack:
+  serverless:
 ---
 
 # Changing component behavior [guides-changing-component-behavior]

--- a/docs/reference/guides-conditional-facets.md
+++ b/docs/reference/guides-conditional-facets.md
@@ -3,6 +3,7 @@ mapped_pages:
   - https://www.elastic.co/guide/en/search-ui/current/guides-conditional-facets.html
 applies_to:
   stack:
+  serverless:
 ---
 
 # Conditional Facets [guides-conditional-facets]

--- a/docs/reference/guides-creating-own-components.md
+++ b/docs/reference/guides-creating-own-components.md
@@ -3,6 +3,7 @@ mapped_pages:
   - https://www.elastic.co/guide/en/search-ui/current/guides-creating-your-own-components.html
 applies_to:
   stack:
+  serverless:
 ---
 
 # Creating Components [guides-creating-your-own-components]

--- a/docs/reference/guides-debugging.md
+++ b/docs/reference/guides-debugging.md
@@ -3,6 +3,7 @@ mapped_pages:
   - https://www.elastic.co/guide/en/search-ui/current/guides-debugging.html
 applies_to:
   stack:
+  serverless:
 ---
 
 # Debugging [guides-debugging]

--- a/docs/reference/guides-nextjs-integration.md
+++ b/docs/reference/guides-nextjs-integration.md
@@ -3,6 +3,7 @@ mapped_pages:
   - https://www.elastic.co/guide/en/search-ui/current/guides-nextjs-integration.html
 applies_to:
   stack:
+  serverless:
 ---
 
 # NextJS Integration [guides-nextjs-integration]

--- a/docs/reference/guides-using-search-as-you-type.md
+++ b/docs/reference/guides-using-search-as-you-type.md
@@ -3,6 +3,7 @@ mapped_pages:
   - https://www.elastic.co/guide/en/search-ui/current/guides-using-search-as-you-type.html
 applies_to:
   stack:
+  serverless:
 ---
 
 # Using search-as-you-type [guides-using-search-as-you-type]

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -16,16 +16,15 @@ As a headless library, Search UI separates logic from presentation. It provides 
 
 ### Connectors [overview-connectors]
 
-- [Elasticsearch](https://codesandbox.io/s/github/elastic/search-ui/tree/main/examples/sandbox?from-embed=&initialpath=/elasticsearch&file=/src/pages/elasticsearch/index.js)
-- [Elastic Site Search (Swiftype)](https://codesandbox.io/s/github/elastic/search-ui/tree/main/examples/sandbox?from-embed=&initialpath=/site-search&file=/src/pages/site-search/index.js)
-- ⚠️ DEPRECATED. [Elastic App Search](https://codesandbox.io/s/github/elastic/search-ui/tree/main/examples/sandbox?from-embed=&initialpath=/app-search&file=/src/pages/app-search/index.js)
-- ⚠️ DEPRECATED. [Elastic Workplace Search](https://codesandbox.io/s/github/elastic/search-ui/tree/main/examples/sandbox?from-embed=&initialpath=/workplace-search&file=/src/pages/workplace-search/index.js)
+- [Elasticsearch](https://codesandbox.io/s/github/elastic/search-ui/tree/main/examples/sandbox?file=%2Fsrc%2Fpages%2Felasticsearch-basic%2Findex.jsx): Browser-only implementation
+- [Elasticsearch](https://codesandbox.io/s/github/elastic/search-ui/tree/main/examples/sandbox?file=%2Fsrc%2Fpages%2Felasticsearch-production-ready%2Findex.jsx): Production-ready implementation, using proxy connector
+- [Elastic Site Search (Swiftype)](https://codesandbox.io/s/github/elastic/search-ui/tree/main/examples/sandbox?file=%2Fsrc%2Fpages%2Fsite-search%2Findex.jsx)
 
 ### Examples [overview-examples]
 
-- [Search as you type](https://codesandbox.io/s/github/elastic/search-ui/tree/main/examples/sandbox?from-embed=&initialpath=/search-as-you-type&file=/src/pages/search-as-you-type/index.js)
-- [Search bar in header](https://codesandbox.io/s/github/elastic/search-ui/tree/main/examples/sandbox?from-embed=&initialpath=/search-bar-in-header&file=/src/pages/search-bar-in-header/index.js)
-- [Customizing Styles and Components](https://codesandbox.io/s/github/elastic/search-ui/tree/main/examples/sandbox?from-embed=&initialpath=/customizing-styles-and-html&file=/src/pages/customizing-styles-and-html/index.js)
+- [Search as you type](https://codesandbox.io/s/github/elastic/search-ui/tree/main/examples/sandbox?file=%2Fsrc%2Fpages%2Fsearch-as-you-type%2Findex.jsx)
+- [Search bar in header](https://codesandbox.io/s/github/elastic/search-ui/tree/main/examples/sandbox?file=%2Fsrc%2Fpages%2Fsearch-bar-in-header%2Findex.jsx&from-embed=&initialpath=%2Fsearch-bar-in-header)
+- [Customizing Styles and Components](https://codesandbox.io/s/github/elastic/search-ui/tree/main/examples/sandbox?file=%2Fsrc%2Fpages%2Fcustomizing-styles-and-html%2Findex.jsx)
 
 ## Get Started 🌟 [overview-get-started]
 

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -32,47 +32,52 @@ Get started quickly with Search UI and your favorite Elastic product by followin
 ## [Ecommerce 📦](./ecommerce.md)
 
 Guides for implementing ecommerce use cases using Search UI components.
+
 - [Autocomplete](./solutions-ecommerce-autocomplete.md): Add real-time query and product suggestions to your search box.
 - [Product Carousels](./solutions-ecommerce-carousel.md): Display horizontal lists of products, like 'Best Rated' or 'On Sale'.
 - [Category Page](./solutions-ecommerce-category-page.md): Filter and explore products in a specific category using facets.
 - [Product Detail Page](./solutions-ecommerce-product-detail-page.md): Enrich product pages with cross-sell suggestions and related items.
 - [Search Page](./solutions-ecommerce-search-page.md): Show full search results with options for sorting, filters, and variants.
 
-
 ## [Basic usage ⚙️](./basic-usage.md)
 
 Quick-start guides for common Search UI tasks like styling, header placement, search behavior, and debugging.
+
 - [Using search-as-you-type](./guides-using-search-as-you-type.md): Trigger a search request with each keystroke using the `searchAsYouType` prop.
 - [Adding a search bar to a header](./guides-adding-search-bar-to-header.md): Place a search bar in the site header and redirect queries to a results page.
 - [Debugging](./guides-debugging.md): Enable debug mode to inspect actions and state changes in the browser console.
 
-
 ## [Advanced usage 🛠️](./advanced-usage.md)
 
 Learn how to customize component behavior, build your own UI components, connect to any backend, and integrate Search UI with frameworks like Vue and Next.js.
+
 - [Conditional Facets](./guides-conditional-facets.md): Show or hide facets based on selected filters.
 - [Changing component behavior](./guides-changing-component-behavior.md): Override default logic using `mapContextToProps` or custom props.
 - [Analyzing performance](./guides-analyzing-performance.md): Measure and analyze your search experience’s performance using browser and React profiling tools.
 - [Building a custom connector](./guides-building-custom-connector.md): Use Search UI with any backend by implementing a connector.
 - [Next.js integration](./guides-nextjs-integration.md): Use Search UI with server-side rendering in Next.js apps.
 
-
 ## [API reference 📚](./api-reference.md)
 
 ### [Core API](./api-core-index.md)
+
 Configuration, state, and actions that power the search experience.
+
 - [Configuration](./api-core-configuration.md)
 - [State](./api-core-state.md)
 - [Actions](./api-core-actions.md)
 
 ### [React API](./api-react-search-provider.md)
+
 React-specific utilities for accessing and interacting with the Core API.
+
 - [WithSearch & withSearch](./api-react-with-search.md)
 - [useSearch hook](./api-react-use-search.md)
 
-
 ## [React components 🧩](./api-react-components-search-box.md)
+
 Search UI includes a set of ready-to-use React components for building your search interface. This section documents each component's API and customization options.
+
 - [Results](./api-react-components-results.md)
 - [Result](./api-react-components-result.md)
 - [ResultsPerPage](./api-react-components-results-per-page.md)
@@ -82,20 +87,18 @@ Search UI includes a set of ready-to-use React components for building your sear
 - [PagingInfo](./api-react-components-paging-info.md)
 - [ErrorBoundary](./api-react-components-error-boundary.md)
 
-
 ## Connectors API 🔌
 
 Built-in connectors let Search UI talk to Elastic backends. This section documents how to configure each connector, including usage examples and integration details.
+
 - [Elasticsearch Connector](./api-connectors-elasticsearch.md): Connect directly to Elasticsearch indices using cloud or self-managed instances.
 - [Site Search Connector](./api-connectors-site-search.md): Use Elastic Site Search as a backend. Note: Some advanced Search UI features are not supported.
 - ⚠️ DEPRECATED [Workplace Search Connector](./api-connectors-workplace-search.md): Legacy connector for Elastic Workplace Search.
 - ⚠️ DEPRECATED [App Search Connector](./api-connectors-app-search.md): Legacy connector for Elastic App Search.
 
-
 ## Plugins 🧪
 
 - ⚠️ DEPRECATED [Analytics Plugin](./api-core-plugins-analytics-plugin.md): Track user behavior and send events to Elastic Behavioral Analytics.
-
 
 ## Known issues 🛠️
 

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -15,17 +15,16 @@ As a headless library, Search UI separates logic from presentation. It provides 
 
 ### Connectors [overview-connectors]
 
-* [Elasticsearch](https://codesandbox.io/s/github/elastic/search-ui/tree/main/examples/sandbox?from-embed=&initialpath=/elasticsearch&file=/src/pages/elasticsearch/index.js)
-* [Elastic Site Search (Swiftype)](https://codesandbox.io/s/github/elastic/search-ui/tree/main/examples/sandbox?from-embed=&initialpath=/site-search&file=/src/pages/site-search/index.js)
-* ⚠️ DEPRECATED. [Elastic App Search](https://codesandbox.io/s/github/elastic/search-ui/tree/main/examples/sandbox?from-embed=&initialpath=/app-search&file=/src/pages/app-search/index.js)
-* ⚠️ DEPRECATED. [Elastic Workplace Search](https://codesandbox.io/s/github/elastic/search-ui/tree/main/examples/sandbox?from-embed=&initialpath=/workplace-search&file=/src/pages/workplace-search/index.js)
-
+- [Elasticsearch](https://codesandbox.io/s/github/elastic/search-ui/tree/main/examples/sandbox?from-embed=&initialpath=/elasticsearch&file=/src/pages/elasticsearch/index.js)
+- [Elastic Site Search (Swiftype)](https://codesandbox.io/s/github/elastic/search-ui/tree/main/examples/sandbox?from-embed=&initialpath=/site-search&file=/src/pages/site-search/index.js)
+- ⚠️ DEPRECATED. [Elastic App Search](https://codesandbox.io/s/github/elastic/search-ui/tree/main/examples/sandbox?from-embed=&initialpath=/app-search&file=/src/pages/app-search/index.js)
+- ⚠️ DEPRECATED. [Elastic Workplace Search](https://codesandbox.io/s/github/elastic/search-ui/tree/main/examples/sandbox?from-embed=&initialpath=/workplace-search&file=/src/pages/workplace-search/index.js)
 
 ### Examples [overview-examples]
 
-* [Search as you type](https://codesandbox.io/s/github/elastic/search-ui/tree/main/examples/sandbox?from-embed=&initialpath=/search-as-you-type&file=/src/pages/search-as-you-type/index.js)
-* [Search bar in header](https://codesandbox.io/s/github/elastic/search-ui/tree/main/examples/sandbox?from-embed=&initialpath=/search-bar-in-header&file=/src/pages/search-bar-in-header/index.js)
-* [Customizing Styles and Components](https://codesandbox.io/s/github/elastic/search-ui/tree/main/examples/sandbox?from-embed=&initialpath=/customizing-styles-and-html&file=/src/pages/customizing-styles-and-html/index.js)
+- [Search as you type](https://codesandbox.io/s/github/elastic/search-ui/tree/main/examples/sandbox?from-embed=&initialpath=/search-as-you-type&file=/src/pages/search-as-you-type/index.js)
+- [Search bar in header](https://codesandbox.io/s/github/elastic/search-ui/tree/main/examples/sandbox?from-embed=&initialpath=/search-bar-in-header&file=/src/pages/search-bar-in-header/index.js)
+- [Customizing Styles and Components](https://codesandbox.io/s/github/elastic/search-ui/tree/main/examples/sandbox?from-embed=&initialpath=/customizing-styles-and-html&file=/src/pages/customizing-styles-and-html/index.js)
 
 ## Get Started 🌟 [overview-get-started]
 

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -23,7 +23,7 @@ As a headless library, Search UI separates logic from presentation. It provides 
 ### Examples [overview-examples]
 
 - [Search as you type](https://codesandbox.io/s/github/elastic/search-ui/tree/main/examples/sandbox?file=%2Fsrc%2Fpages%2Fsearch-as-you-type%2Findex.jsx)
-- [Search bar in header](https://codesandbox.io/s/github/elastic/search-ui/tree/main/examples/sandbox?file=%2Fsrc%2Fpages%2Fsearch-bar-in-header%2Findex.jsx&from-embed=&initialpath=%2Fsearch-bar-in-header)
+- [Search bar in header](https://codesandbox.io/s/github/elastic/search-ui/tree/main/examples/sandbox?file=%2Fsrc%2Fpages%2Fsearch-bar-in-header%2Findex.jsx)
 - [Customizing Styles and Components](https://codesandbox.io/s/github/elastic/search-ui/tree/main/examples/sandbox?file=%2Fsrc%2Fpages%2Fcustomizing-styles-and-html%2Findex.jsx)
 
 ## Get Started 🌟 [overview-get-started]

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -11,6 +11,22 @@ Search UI is a JavaScript library for building modern, customizable search exper
 
 As a headless library, Search UI separates logic from presentation. It provides search state and actions you can use with React, vanilla JavaScript, or other frameworks like Vue.
 
+## Live demos 👀 [overview-live-demos]
+
+### Connectors [overview-connectors]
+
+* [Elasticsearch](https://codesandbox.io/s/github/elastic/search-ui/tree/main/examples/sandbox?from-embed=&initialpath=/elasticsearch&file=/src/pages/elasticsearch/index.js)
+* [Elastic Site Search (Swiftype)](https://codesandbox.io/s/github/elastic/search-ui/tree/main/examples/sandbox?from-embed=&initialpath=/site-search&file=/src/pages/site-search/index.js)
+* ⚠️ DEPRECATED. [Elastic App Search](https://codesandbox.io/s/github/elastic/search-ui/tree/main/examples/sandbox?from-embed=&initialpath=/app-search&file=/src/pages/app-search/index.js)
+* ⚠️ DEPRECATED. [Elastic Workplace Search](https://codesandbox.io/s/github/elastic/search-ui/tree/main/examples/sandbox?from-embed=&initialpath=/workplace-search&file=/src/pages/workplace-search/index.js)
+
+
+### Examples [overview-examples]
+
+* [Search as you type](https://codesandbox.io/s/github/elastic/search-ui/tree/main/examples/sandbox?from-embed=&initialpath=/search-as-you-type&file=/src/pages/search-as-you-type/index.js)
+* [Search bar in header](https://codesandbox.io/s/github/elastic/search-ui/tree/main/examples/sandbox?from-embed=&initialpath=/search-bar-in-header&file=/src/pages/search-bar-in-header/index.js)
+* [Customizing Styles and Components](https://codesandbox.io/s/github/elastic/search-ui/tree/main/examples/sandbox?from-embed=&initialpath=/customizing-styles-and-html&file=/src/pages/customizing-styles-and-html/index.js)
+
 ## Get Started 🌟 [overview-get-started]
 
 ### Installation [overview-installation]

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -12,7 +12,7 @@ Search UI is a JavaScript library for building modern, customizable search exper
 
 As a headless library, Search UI separates logic from presentation. It provides search state and actions you can use with React, vanilla JavaScript, or other frameworks like Vue.
 
-## Live demos 👀 [overview-live-demos]
+## Live demos [overview-live-demos]
 
 ### Connectors [overview-connectors]
 
@@ -26,7 +26,7 @@ As a headless library, Search UI separates logic from presentation. It provides 
 - [Search bar in header](https://codesandbox.io/s/github/elastic/search-ui/tree/main/examples/sandbox?file=%2Fsrc%2Fpages%2Fsearch-bar-in-header%2Findex.jsx)
 - [Customizing Styles and Components](https://codesandbox.io/s/github/elastic/search-ui/tree/main/examples/sandbox?file=%2Fsrc%2Fpages%2Fcustomizing-styles-and-html%2Findex.jsx)
 
-## Get Started 🌟 [overview-get-started]
+## Get Started [overview-get-started]
 
 ### Installation [overview-installation]
 
@@ -51,7 +51,7 @@ Get started quickly with Search UI and your favorite Elastic product by followin
 - ⚠️ DEPRECATED [Elastic App Search](./tutorials-app-search.md)
 - ⚠️ DEPRECATED [Elastic Workplace Search](./tutorials-workplace-search.md)
 
-## [Ecommerce 📦](./ecommerce.md)
+## [Ecommerce](./ecommerce.md)
 
 Guides for implementing ecommerce use cases using Search UI components.
 
@@ -61,7 +61,7 @@ Guides for implementing ecommerce use cases using Search UI components.
 - [Product Detail Page](./solutions-ecommerce-product-detail-page.md): Enrich product pages with cross-sell suggestions and related items.
 - [Search Page](./solutions-ecommerce-search-page.md): Show full search results with options for sorting, filters, and variants.
 
-## [Basic usage ⚙️](./basic-usage.md)
+## [Basic usage](./basic-usage.md)
 
 Quick-start guides for common Search UI tasks like styling, header placement, search behavior, and debugging.
 
@@ -69,7 +69,7 @@ Quick-start guides for common Search UI tasks like styling, header placement, se
 - [Adding a search bar to a header](./guides-adding-search-bar-to-header.md): Place a search bar in the site header and redirect queries to a results page.
 - [Debugging](./guides-debugging.md): Enable debug mode to inspect actions and state changes in the browser console.
 
-## [Advanced usage 🛠️](./advanced-usage.md)
+## [Advanced usage](./advanced-usage.md)
 
 Learn how to customize component behavior, build your own UI components, connect to any backend, and integrate Search UI with frameworks like Vue and Next.js.
 
@@ -79,7 +79,7 @@ Learn how to customize component behavior, build your own UI components, connect
 - [Building a custom connector](./guides-building-custom-connector.md): Use Search UI with any backend by implementing a connector.
 - [Next.js integration](./guides-nextjs-integration.md): Use Search UI with server-side rendering in Next.js apps.
 
-## [API reference 📚](./api-reference.md)
+## [API reference](./api-reference.md)
 
 ### [Core API](./api-core-index.md)
 
@@ -96,7 +96,7 @@ React-specific utilities for accessing and interacting with the Core API.
 - [WithSearch & withSearch](./api-react-with-search.md)
 - [useSearch hook](./api-react-use-search.md)
 
-## [React components 🧩](./api-react-components-search-box.md)
+## [React components](./api-react-components-search-box.md)
 
 Search UI includes a set of ready-to-use React components for building your search interface. This section documents each component's API and customization options.
 
@@ -109,7 +109,7 @@ Search UI includes a set of ready-to-use React components for building your sear
 - [PagingInfo](./api-react-components-paging-info.md)
 - [ErrorBoundary](./api-react-components-error-boundary.md)
 
-## Connectors API 🔌
+## Connectors API
 
 Built-in connectors let Search UI talk to Elastic backends. This section documents how to configure each connector, including usage examples and integration details.
 
@@ -118,15 +118,15 @@ Built-in connectors let Search UI talk to Elastic backends. This section documen
 - ⚠️ DEPRECATED [Workplace Search Connector](./api-connectors-workplace-search.md): Legacy connector for Elastic Workplace Search.
 - ⚠️ DEPRECATED [App Search Connector](./api-connectors-app-search.md): Legacy connector for Elastic App Search.
 
-## Plugins 🧪
+## Plugins
 
 - ⚠️ DEPRECATED [Analytics Plugin](./api-core-plugins-analytics-plugin.md): Track user behavior and send events to Elastic Behavioral Analytics.
 
-## Known issues 🛠️
+## Known issues
 
 - [Known issues](./known-issues.md)
 
-## License 📗 [overview-license]
+## License [overview-license]
 
 [Apache-2.0](https://github.com/elastic/search-ui/blob/main/LICENSE.txt) © [Elastic](https://github.com/elastic)
 

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -3,6 +3,7 @@ mapped_pages:
   - https://www.elastic.co/guide/en/search-ui/current/overview.html
 applies_to:
   stack:
+  serverless:
 ---
 
 # Search UI
@@ -37,6 +38,13 @@ yarn add @elastic/search-ui @elastic/react-search-ui @elastic/react-search-ui-vi
 ```
 
 ### Tutorials 📘 [overview-tutorials]
+
+:::{note}
+
+Search UI can connect to Serverless using a backend proxy. In this setup, the frontend uses the `ApiProxyConnector` to send requests to your backend, which then forwards them to Elasticsearch. Direct browser connections to Serverless are not supported due to CORS restrictions.
+
+[See our guide for using Search UI in production](./tutorials-elasticsearch-production-usage.md) for a full example of this setup.
+:::
 
 Get started quickly with Search UI and your favorite Elastic product by following one of the tutorials below:
 

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -7,29 +7,9 @@ applies_to:
 
 # Search UI
 
-A JavaScript library for the fast development of modern, engaging search experiences with [Elastic](https://www.elastic.co/). Get up and running quickly without re-inventing the wheel.
+Search UI is a JavaScript library for building modern, customizable search experiences using Elastic as a backend. Maintained by the Elastic team, it helps you implement search interfaces with minimal boilerplate.
 
-## Features 👍 [overview-features]
-
-- **You know, for search** - Maintained by [Elastic](https://elastic.co), the team behind Elasticsearch.
-- **Speedy Implementation** - Build a complete search experience with a few lines of code.
-- **Customizable** - Tune the components, markup, styles, and behaviors to your liking.
-- **Smart URLs** - Searches, paging, filtering, and more, are captured in the URL for direct result linking.
-- **Flexible front-end** - Not just for React. Use with any JavaScript library, even vanilla JavaScript.
-- **Flexible back-end** - Use it with Elasticsearch, Elastic Enterprise Search, or any other search API.
-
-## Live demos 👀 [overview-live-demos]
-
-### Connectors [overview-connectors]
-
-- [Elasticsearch](https://codesandbox.io/s/github/elastic/search-ui/tree/main/examples/sandbox?from-embed=&initialpath=/elasticsearch&file=/src/pages/elasticsearch/index.jsx)
-- [Elastic Site Search (Swiftype)](https://codesandbox.io/s/github/elastic/search-ui/tree/main/examples/sandbox?from-embed=&initialpath=/site-search&file=/src/pages/site-search/index.jsx)
-
-### Examples [overview-examples]
-
-- [Search as you type](https://codesandbox.io/s/github/elastic/search-ui/tree/main/examples/sandbox?from-embed=&initialpath=/search-as-you-type&file=/src/pages/search-as-you-type/index.jsx)
-- [Search bar in header](https://codesandbox.io/s/github/elastic/search-ui/tree/main/examples/sandbox?from-embed=&initialpath=/search-bar-in-header&file=/src/pages/search-bar-in-header/index.jsx)
-- [Customizing Styles and Components](https://codesandbox.io/s/github/elastic/search-ui/tree/main/examples/sandbox?from-embed=&initialpath=/customizing-styles-and-html&file=/src/pages/customizing-styles-and-html/index.jsx)
+As a headless library, Search UI separates logic from presentation. It provides search state and actions you can use with React, vanilla JavaScript, or other frameworks like Vue.
 
 ## Get Started 🌟 [overview-get-started]
 
@@ -41,71 +21,85 @@ npm install @elastic/search-ui @elastic/react-search-ui @elastic/react-search-ui
 yarn add @elastic/search-ui @elastic/react-search-ui @elastic/react-search-ui-views
 ```
 
-### Tutorials [overview-tutorials]
+### Tutorials 📘 [overview-tutorials]
 
 Get started quickly with Search UI and your favorite Elastic product by following one of the tutorials below:
 
-- [Elasticsearch](/reference/tutorials-elasticsearch.md)
-- ⚠️ DEPRECATED [Elastic App Search](/reference/tutorials-app-search.md)
-- ⚠️ DEPRECATED [Elastic Workplace Search](/reference/tutorials-workplace-search.md)
+- [Elasticsearch](./tutorials-elasticsearch.md)
+- ⚠️ DEPRECATED [Elastic App Search](./tutorials-app-search.md)
+- ⚠️ DEPRECATED [Elastic Workplace Search](./tutorials-workplace-search.md)
 
-## Use Cases 🛠️ [overview-use-cases]
+## [Ecommerce 📦](./ecommerce.md)
 
-### Ecommerce [overview-ecommerce]
+Guides for implementing ecommerce use cases using Search UI components.
+- [Autocomplete](./solutions-ecommerce-autocomplete.md): Add real-time query and product suggestions to your search box.
+- [Product Carousels](./solutions-ecommerce-carousel.md): Display horizontal lists of products, like 'Best Rated' or 'On Sale'.
+- [Category Page](./solutions-ecommerce-category-page.md): Filter and explore products in a specific category using facets.
+- [Product Detail Page](./solutions-ecommerce-product-detail-page.md): Enrich product pages with cross-sell suggestions and related items.
+- [Search Page](./solutions-ecommerce-search-page.md): Show full search results with options for sorting, filters, and variants.
 
-Search UI works great in the ecommerce use-case. Check out our [ecommerce guide](/reference/ecommerce.md) that includes demo and code examples, as well as general guidance for ecommerce search.
 
-## FAQ 🔮 [overview-faq]
+## [Basic usage ⚙️](./basic-usage.md)
 
-### Is Search UI only for React? [overview-is-search-ui-only-for-react]
+Quick-start guides for common Search UI tasks like styling, header placement, search behavior, and debugging.
+- [Using search-as-you-type](./guides-using-search-as-you-type.md): Trigger a search request with each keystroke using the `searchAsYouType` prop.
+- [Adding a search bar to a header](./guides-adding-search-bar-to-header.md): Place a search bar in the site header and redirect queries to a results page.
+- [Debugging](./guides-debugging.md): Enable debug mode to inspect actions and state changes in the browser console.
 
-Search UI is "headless". You can use vanilla JavaScript or write support for it into any JavaScript framework.
 
-[Read about the search-ui package](https://github.com/elastic/search-ui/tree/main/packages/search-ui) for more information, or check out the [Vue.js Example](https://github.com/elastic/vue-search-ui-demo).
+## [Advanced usage 🛠️](./advanced-usage.md)
 
-### Can I use my own styles? [overview-can-i-use-my-own-styles]
+Learn how to customize component behavior, build your own UI components, connect to any backend, and integrate Search UI with frameworks like Vue and Next.js.
+- [Conditional Facets](./guides-conditional-facets.md): Show or hide facets based on selected filters.
+- [Changing component behavior](./guides-changing-component-behavior.md): Override default logic using `mapContextToProps` or custom props.
+- [Analyzing performance](./guides-analyzing-performance.md): Measure and analyze your search experience’s performance using browser and React profiling tools.
+- [Building a custom connector](./guides-building-custom-connector.md): Use Search UI with any backend by implementing a connector.
+- [Next.js integration](./guides-nextjs-integration.md): Use Search UI with server-side rendering in Next.js apps.
 
-You can!
 
-Read the [Custom Styles and Layout Guide](/reference/basic-usage.md) to learn more, or check out the [Seattle Indies Expo Demo](https://github.com/elastic/seattle-indies-expo-search).
+## [API reference 📚](./api-reference.md)
 
-### Can I build my own Components? [overview-can-i-build-my-own-components]
+### [Core API](./api-core-index.md)
+Configuration, state, and actions that power the search experience.
+- [Configuration](./api-core-configuration.md)
+- [State](./api-core-state.md)
+- [Actions](./api-core-actions.md)
 
-Yes! Absolutely.
+### [React API](./api-react-search-provider.md)
+React-specific utilities for accessing and interacting with the Core API.
+- [WithSearch & withSearch](./api-react-with-search.md)
+- [useSearch hook](./api-react-use-search.md)
 
-Check out the [Build Your Own Component Guide](/reference/guides-creating-own-components.md).
 
-### Does Search UI only work with Elasticsearch? [overview-does-search-ui-only-work-with-app-search]
+## [React components 🧩](./api-react-components-search-box.md)
+Search UI includes a set of ready-to-use React components for building your search interface. This section documents each component's API and customization options.
+- [Results](./api-react-components-results.md)
+- [Result](./api-react-components-result.md)
+- [ResultsPerPage](./api-react-components-results-per-page.md)
+- [Facet](./api-react-components-facet.md)
+- [Sorting](./api-react-components-sorting.md)
+- [Paging](./api-react-components-paging.md)
+- [PagingInfo](./api-react-components-paging-info.md)
+- [ErrorBoundary](./api-react-components-error-boundary.md)
 
-Nope! We do have some first party connectors: Site Search and Elasticsearch Connector.
 
-But Search UI is headless. You can use _any_ Search API.
+## Connectors API 🔌
 
-Read the [Building a custom connector](/reference/guides-building-custom-connector.md) to learn more about building your own connector for your API.
+Built-in connectors let Search UI talk to Elastic backends. This section documents how to configure each connector, including usage examples and integration details.
+- [Elasticsearch Connector](./api-connectors-elasticsearch.md): Connect directly to Elasticsearch indices using cloud or self-managed instances.
+- [Site Search Connector](./api-connectors-site-search.md): Use Elastic Site Search as a backend. Note: Some advanced Search UI features are not supported.
+- ⚠️ DEPRECATED [Workplace Search Connector](./api-connectors-workplace-search.md): Legacy connector for Elastic Workplace Search.
+- ⚠️ DEPRECATED [App Search Connector](./api-connectors-app-search.md): Legacy connector for Elastic App Search.
 
-### How do I use this with Elasticsearch? [overview-how-do-i-use-this-with-elasticsearch]
 
-Read the [Elasticsearch Connector](/reference/api-connectors-elasticsearch.md) docs.
+## Plugins 🧪
 
-### Where do I report issues with the Search UI? [overview-where-do-i-report-issues-with-the-search-ui]
+- ⚠️ DEPRECATED [Analytics Plugin](./api-core-plugins-analytics-plugin.md): Track user behavior and send events to Elastic Behavioral Analytics.
 
-If something is not working as expected, please open an [issue](https://github.com/elastic/search-ui/issues/new).
 
-### Where can I go to get help? [overview-where-can-i-go-to-get-help]
+## Known issues 🛠️
 
-The Enterprise Search team at Elastic maintains this library and are happy to help. Try posting your question to the [Elastic Enterprise Search](https://discuss.elastic.co/c/enterprise-search/84) discuss forums. Be sure to mention that you’re using Search UI and also let us know what backend your using; whether it’s App Search, Site Search, Elasticsearch, or something else entirely.
-
-## Contribute 🚀 [overview-contribute]
-
-We welcome contributors to the project. Before you begin, a couple notes…​
-
-- Read the [Search UI Contributor’s Guide](https://github.com/elastic/search-ui/blob/main/CONTRIBUTING.md).
-- Prior to opening a pull request, please:
-
-  - Create an issue to [discuss the scope of your proposal](https://github.com/elastic/search-ui/issues).
-  - Sign the [Contributor License Agreement](https://www.elastic.co/contributor-agreement/). We are not asking you to assign copyright to us, but to give us the right to distribute your code without restriction. We ask this of all contributors in order to assure our users of the origin and continuing existence of the code. You only need to sign the CLA once.
-
-- Please write simple code and concise documentation, when appropriate.
+- [Known issues](./known-issues.md)
 
 ## License 📗 [overview-license]
 

--- a/docs/reference/known-issues.md
+++ b/docs/reference/known-issues.md
@@ -5,6 +5,7 @@ mapped_pages:
 navigation_title: "Troubleshooting"
 applies_to:
   stack:
+  serverless:
 ---
 
 # Search known issues [search-known-issues]

--- a/docs/reference/solutions-ecommerce-autocomplete.md
+++ b/docs/reference/solutions-ecommerce-autocomplete.md
@@ -3,6 +3,7 @@ mapped_pages:
   - https://www.elastic.co/guide/en/search-ui/current/solutions-ecommerce-autocomplete.html
 applies_to:
   stack:
+  serverless:
 ---
 
 # Autocomplete [solutions-ecommerce-autocomplete]

--- a/docs/reference/solutions-ecommerce-carousel.md
+++ b/docs/reference/solutions-ecommerce-carousel.md
@@ -3,6 +3,7 @@ mapped_pages:
   - https://www.elastic.co/guide/en/search-ui/current/solutions-ecommerce-carousel.html
 applies_to:
   stack:
+  serverless:
 ---
 
 # Product Carousels [solutions-ecommerce-carousel]

--- a/docs/reference/solutions-ecommerce-category-page.md
+++ b/docs/reference/solutions-ecommerce-category-page.md
@@ -3,6 +3,7 @@ mapped_pages:
   - https://www.elastic.co/guide/en/search-ui/current/solutions-ecommerce-category-page.html
 applies_to:
   stack:
+  serverless:
 ---
 
 # Category Page [solutions-ecommerce-category-page]

--- a/docs/reference/solutions-ecommerce-product-detail-page.md
+++ b/docs/reference/solutions-ecommerce-product-detail-page.md
@@ -3,6 +3,7 @@ mapped_pages:
   - https://www.elastic.co/guide/en/search-ui/current/solutions-ecommerce-product-detail-page.html
 applies_to:
   stack:
+  serverless:
 ---
 
 # Product Detail Page [solutions-ecommerce-product-detail-page]

--- a/docs/reference/solutions-ecommerce-search-page.md
+++ b/docs/reference/solutions-ecommerce-search-page.md
@@ -3,6 +3,7 @@ mapped_pages:
   - https://www.elastic.co/guide/en/search-ui/current/solutions-ecommerce-search-page.html
 applies_to:
   stack:
+  serverless:
 ---
 
 # Search Page [solutions-ecommerce-search-page]

--- a/docs/reference/tutorials-elasticsearch-configure-search-ui.md
+++ b/docs/reference/tutorials-elasticsearch-configure-search-ui.md
@@ -3,6 +3,7 @@ mapped_pages:
   - https://www.elastic.co/guide/en/search-ui/current/tutorials-elasticsearch-configure-search-ui.html
 applies_to:
   stack:
+  serverless:
 ---
 
 # Configure and Run Search UI [tutorials-elasticsearch-configure-search-ui-and-run]

--- a/docs/reference/tutorials-elasticsearch-customise-query.md
+++ b/docs/reference/tutorials-elasticsearch-customise-query.md
@@ -3,6 +3,7 @@ mapped_pages:
   - https://www.elastic.co/guide/en/search-ui/current/tutorials-elasticsearch-customise-request.html
 applies_to:
   stack:
+  serverless:
 ---
 
 # Customise Request [api-connectors-elasticsearch-customise-the-elasticsearch-request-body]

--- a/docs/reference/tutorials-elasticsearch-install-connector.md
+++ b/docs/reference/tutorials-elasticsearch-install-connector.md
@@ -3,6 +3,7 @@ mapped_pages:
   - https://www.elastic.co/guide/en/search-ui/current/tutorials-elasticsearch-install-connector.html
 applies_to:
   stack:
+  serverless:
 ---
 
 # Install Connector [tutorials-elasticsearch-installing-connector]

--- a/docs/reference/tutorials-elasticsearch-production-usage.md
+++ b/docs/reference/tutorials-elasticsearch-production-usage.md
@@ -3,6 +3,7 @@ mapped_pages:
   - https://www.elastic.co/guide/en/search-ui/current/tutorials-elasticsearch-production-usage.html
 applies_to:
   stack:
+  serverless:
 ---
 
 # Using in Production [tutorials-elasticsearch-production-usage]

--- a/docs/reference/tutorials-elasticsearch-setup-cloud.md
+++ b/docs/reference/tutorials-elasticsearch-setup-cloud.md
@@ -3,6 +3,7 @@ mapped_pages:
   - https://www.elastic.co/guide/en/search-ui/current/tutorials-elasticsearch-setup-cloud.html
 applies_to:
   stack:
+  serverless:
 ---
 
 # Setup Elasticsearch [tutorials-elasticsearch-step-1-setup-elasticsearch]

--- a/docs/reference/tutorials-elasticsearch-setup-index.md
+++ b/docs/reference/tutorials-elasticsearch-setup-index.md
@@ -3,6 +3,7 @@ mapped_pages:
   - https://www.elastic.co/guide/en/search-ui/current/tutorials-elasticsearch-setup-index.html
 applies_to:
   stack:
+  serverless:
 ---
 
 # Setup an Index [tutorials-elasticsearch-setting-up-an-index]

--- a/docs/reference/tutorials-elasticsearch.md
+++ b/docs/reference/tutorials-elasticsearch.md
@@ -3,6 +3,7 @@ mapped_pages:
   - https://www.elastic.co/guide/en/search-ui/current/tutorials-elasticsearch.html
 applies_to:
   stack:
+  serverless:
 ---
 
 # Search UI with Elasticsearch [tutorials-elasticsearch]

--- a/docs/reference/tutorials.md
+++ b/docs/reference/tutorials.md
@@ -4,6 +4,7 @@ mapped_pages:
   - https://www.elastic.co/guide/en/search-ui/current/tutorials-connectors.html
 applies_to:
   stack:
+  serverless:
 ---
 
 # Which connector to choose? [tutorials-connectors]


### PR DESCRIPTION
## Description
This PR restructures the Search UI Reference landing page to improve clarity, navigability, and alignment with documentation best practices.

This restructure is a first step toward eliminating duplication between the two main Search UI documentation pages:
- https://www.elastic.co/docs/reference/search-ui
- https://www.elastic.co/docs/solutions/search/site-or-app/search-ui

## List of changes
- Reorganized content into clearly labeled sections 
- Updated descriptions for each section

- Added information on Serverless being compatible with Search UI but not with CORS

## Associated Github Issues
 https://github.com/elastic/developer-docs-team/issues/295
 
 This PR restructures the Search UI landing page in the docs-content repo: https://github.com/elastic/docs-content/pull/1628