### PR TITLE
Prevent in-progress requests pushing to URL after teardown

### DIFF
--- a/packages/search-ui/src/SearchDriver.ts
+++ b/packages/search-ui/src/SearchDriver.ts
@@ -574,6 +574,7 @@ class SearchDriver {
     this.subscriptions = [];
     this.URLManager && this.URLManager.tearDown();
     this.debounceManager.cancelByName("pushStateToURL");
+    this.searchRequestSequencer.lastCompleted = Infinity
   }
 
   /**


### PR DESCRIPTION
## Description

After the search driver is torn down a still-running search request can still come and blat the URL under the following sequence of events:

1. Search request is made
2. tearDown called while request in flight
3. Search request _resolves_
4. push state to URL debounced by 500ms
5. half a second later - URLManager pushes garbage into URL.

## List of changes

* Set lastCompleted to Infinity in tearDown to prevent processing any resolved searches after tearDown (since they will all be considered old)

## Associated Github Issues
