### PR TITLE
Use correct host and path concatenation

### DIFF
--- a/packages/search-ui-elasticsearch-connector/src/transporter/ApiClientTransporter.ts
+++ b/packages/search-ui-elasticsearch-connector/src/transporter/ApiClientTransporter.ts
@@ -61,7 +61,7 @@ export class ApiClientTransporter implements IApiClientTransporter {
       host = getHostFromCloud(this.config.cloud);
     }
 
-    const searchUrl = new URL(`/${this.config.index}/_search`, host);
+    const searchUrl = new URL(`${this.config.index}/_search`, host);
 
     const response = await fetch(searchUrl.href, {
       method: "POST",

--- a/packages/search-ui-elasticsearch-connector/src/transporter/__tests__/ApiClientTransporter.test.ts
+++ b/packages/search-ui-elasticsearch-connector/src/transporter/__tests__/ApiClientTransporter.test.ts
@@ -178,4 +178,38 @@ describe("ApiClientTransporter", () => {
 
     expect(response).toEqual(mockResponse);
   });
+
+  it("should handle basic host URLs without paths", async () => {
+    const transporter = createTransporter({
+      host: "https://elasticsearch.example.com:9200"
+    });
+
+    mockFetch.mockResolvedValueOnce({
+      json: () => Promise.resolve(mockResponse)
+    });
+
+    await transporter.performRequest({ query: { match_all: {} } });
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://elasticsearch.example.com:9200/test-index/_search",
+      expect.any(Object)
+    );
+  });
+
+  it("should handle hosts with paths (reverse proxy scenarios)", async () => {
+    const transporter = createTransporter({
+      host: "https://some-host.com/apps/elastic/"
+    });
+
+    mockFetch.mockResolvedValueOnce({
+      json: () => Promise.resolve(mockResponse)
+    });
+
+    await transporter.performRequest({ query: { match_all: {} } });
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://some-host.com/apps/elastic/test-index/_search",
+      expect.any(Object)
+    );
+  });
 });


### PR DESCRIPTION
## Description
Fixes incorrect URL construction when using a base path behind a reverse proxy. Removes leading slash from relative _search path to preserve pathname.
Before:
```
new URL('/index/_search', 'https://my-company.com/apps/elastic/')
// → https://my-company.com/index/_search ❌
```
After:
new URL('index/_search', 'https://my-company.com/apps/elastic/')
// → https://my-company.com/apps/elastic/index/_search ✅

## List of changes
- Updated ApiClientTransporter to use `index/_search` instead of `/index/_search` when creating request URL

## Associated Github Issues
#1174 