### PR TITLE
prevent in-progress requests pushing to URL after teardown

### DIFF
--- a/packages/search-ui/src/SearchDriver.ts
+++ b/packages/search-ui/src/SearchDriver.ts
@@ -574,6 +574,7 @@ class SearchDriver {
     this.subscriptions = [];
     this.URLManager && this.URLManager.tearDown();
     this.debounceManager.cancelByName("pushStateToURL");
+    this.searchRequestSequencer.completed(Infinity);
   }
 
   /**

--- a/packages/search-ui/src/__tests__/SearchDriver.test.ts
+++ b/packages/search-ui/src/__tests__/SearchDriver.test.ts
@@ -466,6 +466,8 @@ describe("tearDown", () => {
     driver.setSearchTerm("test");
     expect(called1).toBe(false); // Did not call, unsubscribed
     expect(called2).toBe(false); // Did not call, unsubscribed
+    expect(driver.searchRequestSequencer.lastCompleted).toBe(Infinity);
+
     expect(
       (MockedURLManager.mock.instances[0].tearDown as jest.Mock).mock.calls
         .length


### PR DESCRIPTION
Duplicate of #1177 due to Formatting CI issues and updating test
## Description
After the search driver is torn down a still-running search request can still come and blat the URL under the following sequence of events:

Search request is made
tearDown called while request in flight
Search request resolves
push state to URL debounced by 500ms
half a second later - URLManager pushes garbage into URL.

## List of changes
- Set lastCompleted to Infinity in tearDown to prevent processing any resolved searches after tearDown (since they will all be considered old)
## Associated Github Issues
