### PR TITLE
Allow getQueryFn to return a promise.

### DIFF
--- a/packages/search-ui-elasticsearch-connector/src/handlers/handleSearch.ts
+++ b/packages/search-ui-elasticsearch-connector/src/handlers/handleSearch.ts
@@ -24,7 +24,7 @@ export const handleSearch = async (
   postProcessRequestBodyFn?: PostProcessRequestBodyFn
 ): Promise<ResponseState> => {
   const queryBuilder = new SearchQueryBuilder(state, queryConfig, getQueryFn);
-  let requestBody = queryBuilder.build();
+  let requestBody = await queryBuilder.build();
   let response;
 
   if (postProcessRequestBodyFn) {

--- a/packages/search-ui-elasticsearch-connector/src/queryBuilders/BaseQueryBuilder.ts
+++ b/packages/search-ui-elasticsearch-connector/src/queryBuilders/BaseQueryBuilder.ts
@@ -11,7 +11,7 @@ export abstract class BaseQueryBuilder {
 
   constructor(protected readonly state: RequestState) {}
 
-  abstract build(): SearchRequest;
+  abstract build(): Promise<SearchRequest>;
 
   getSize(): number {
     return this.query.size || 0;

--- a/packages/search-ui-elasticsearch-connector/src/queryBuilders/ResultsAutocompleteBuilder.ts
+++ b/packages/search-ui-elasticsearch-connector/src/queryBuilders/ResultsAutocompleteBuilder.ts
@@ -19,7 +19,7 @@ export class ResultsAutocompleteBuilder extends BaseQueryBuilder {
     super(state);
   }
 
-  build() {
+  async build() {
     this.setSize(this.size);
     this.setSourceFields(Object.keys(this.configuration.result_fields || {}));
     this.setHighlight(this.buildHighlight());

--- a/packages/search-ui-elasticsearch-connector/src/queryBuilders/SearchQueryBuilder.ts
+++ b/packages/search-ui-elasticsearch-connector/src/queryBuilders/SearchQueryBuilder.ts
@@ -21,14 +21,14 @@ export class SearchQueryBuilder extends BaseQueryBuilder {
     super(state);
   }
 
-  build() {
+  async build() {
     this.setPagination(this.state.current, this.state.resultsPerPage);
     this.setSourceFields(Object.keys(this.queryConfig.result_fields || {}));
     this.setSort(this.buildSort());
     this.setHighlight(this.buildHighlight());
     this.setAggregations(this.buildAggregations());
     this.setPostFilter(this.buildPostFilter());
-    this.setQuery(this.buildQuery());
+    this.setQuery(await this.buildQuery());
 
     return this.query;
   }
@@ -129,14 +129,14 @@ export class SearchQueryBuilder extends BaseQueryBuilder {
     return postFilter?.length ? { bool: { must: postFilter } } : null;
   }
 
-  private buildQuery(): SearchRequest["query"] | null {
+  private async buildQuery(): Promise<SearchRequest["query"] | null> {
     const filtersDsl = this.buildQueryDslFilters();
-    const searchDsl = this.buildSearchDslQuery();
+    const searchDsl = await this.buildSearchDslQuery();
 
     return deepMergeObjects(searchDsl as Record<string, unknown>, filtersDsl);
   }
 
-  private buildSearchDslQuery() {
+  private async buildSearchDslQuery() {
     const searchQuery = this.state.searchTerm;
 
     if (!searchQuery) {

--- a/packages/search-ui-elasticsearch-connector/src/queryBuilders/SuggestionsAutocompleteBuilder.ts
+++ b/packages/search-ui-elasticsearch-connector/src/queryBuilders/SuggestionsAutocompleteBuilder.ts
@@ -11,7 +11,7 @@ export class SuggestionsAutocompleteBuilder extends BaseQueryBuilder {
     super(state);
   }
 
-  build() {
+  async build() {
     this.setSize(0);
     this.setSourceFields([]);
     this.setSuggest(this.buildSuggestion());

--- a/packages/search-ui-elasticsearch-connector/src/queryBuilders/__tests__/BaseQueryBuilder.test.ts
+++ b/packages/search-ui-elasticsearch-connector/src/queryBuilders/__tests__/BaseQueryBuilder.test.ts
@@ -15,7 +15,7 @@ describe("BaseQueryBuilder", () => {
       return 0;
     }
 
-    build() {
+    async build() {
       return {};
     }
   }

--- a/packages/search-ui-elasticsearch-connector/src/queryBuilders/__tests__/ResultsAutocompleteBuilder.test.ts
+++ b/packages/search-ui-elasticsearch-connector/src/queryBuilders/__tests__/ResultsAutocompleteBuilder.test.ts
@@ -23,9 +23,9 @@ describe("ResultsAutocompleteBuilder", () => {
     }
   };
 
-  it("should build results autocomplete query", () => {
+  it("should build results autocomplete query", async () => {
     const builder = new ResultsAutocompleteBuilder(state, config, 5);
-    const query = builder.build();
+    const query = await builder.build();
 
     expect(query).toEqual({
       size: 5,
@@ -53,14 +53,14 @@ describe("ResultsAutocompleteBuilder", () => {
     });
   });
 
-  it("should handle empty search term", () => {
+  it("should handle empty search term", async () => {
     const emptyState: RequestState = {
       ...state,
       searchTerm: ""
     };
 
     const builder = new ResultsAutocompleteBuilder(emptyState, config, 5);
-    const query = builder.build();
+    const query = await builder.build();
 
     expect(query).toEqual({
       _source: {
@@ -75,14 +75,14 @@ describe("ResultsAutocompleteBuilder", () => {
     });
   });
 
-  it("should handle custom size", () => {
+  it("should handle custom size", async () => {
     const builder = new ResultsAutocompleteBuilder(state, config, 10);
-    const query = builder.build();
+    const query = await builder.build();
 
     expect(query.size).toBe(10);
   });
 
-  it("should handle multiple search fields", () => {
+  it("should handle multiple search fields", async () => {
     const multiFieldConfig = {
       ...config,
       search_fields: {
@@ -92,7 +92,7 @@ describe("ResultsAutocompleteBuilder", () => {
     };
 
     const builder = new ResultsAutocompleteBuilder(state, multiFieldConfig, 5);
-    const query = builder.build();
+    const query = await builder.build();
 
     expect(query.query.bool.must[0].multi_match).toEqual({
       query: "test",
@@ -102,14 +102,14 @@ describe("ResultsAutocompleteBuilder", () => {
   });
 
   describe("fuzziness", () => {
-    it("should not add fuzziness when not configured", () => {
+    it("should not add fuzziness when not configured", async () => {
       const builder = new ResultsAutocompleteBuilder(state, config, 5);
-      const query = builder.build();
+      const query = await builder.build();
 
       expect(query.query.bool.must[0].multi_match.fuzziness).toBeUndefined();
     });
 
-    it("should add AUTO fuzziness when configured", () => {
+    it("should add AUTO fuzziness when configured", async () => {
       const configWithFuzziness = {
         ...config,
         fuzziness: true
@@ -120,7 +120,7 @@ describe("ResultsAutocompleteBuilder", () => {
         configWithFuzziness,
         5
       );
-      const query = builder.build();
+      const query = await builder.build();
 
       expect(query.query.bool.must[0].multi_match.fuzziness).toBe("AUTO");
       expect(query.query.bool.must).toEqual([

--- a/packages/search-ui-elasticsearch-connector/src/queryBuilders/__tests__/SearchQueryBuilder.test.ts
+++ b/packages/search-ui-elasticsearch-connector/src/queryBuilders/__tests__/SearchQueryBuilder.test.ts
@@ -34,9 +34,9 @@ describe("SearchQueryBuilder", () => {
     ]
   };
 
-  it("should build search query", () => {
+  it("should build search query", async () => {
     const builder = new SearchQueryBuilder(state, queryConfig);
-    const query = builder.build();
+    const query = await builder.build();
 
     expect(query).toEqual({
       _source: {
@@ -128,14 +128,14 @@ describe("SearchQueryBuilder", () => {
     });
   });
 
-  it("should handle empty search term", () => {
+  it("should handle empty search term", async () => {
     const emptyState: RequestState = {
       ...state,
       searchTerm: ""
     };
 
     const builder = new SearchQueryBuilder(emptyState, queryConfig);
-    const query = builder.build();
+    const query = await builder.build();
 
     expect(query).toEqual({
       _source: { includes: ["title"] },
@@ -177,7 +177,7 @@ describe("SearchQueryBuilder", () => {
     });
   });
 
-  it("should handle custom search fields", () => {
+  it("should handle custom search fields", async () => {
     const customConfig: SearchQuery = {
       ...queryConfig,
       search_fields: {
@@ -187,7 +187,7 @@ describe("SearchQueryBuilder", () => {
     };
 
     const builder = new SearchQueryBuilder(state, customConfig);
-    const query = builder.build();
+    const query = await builder.build();
 
     expect(query.query.bool.must[0].bool.should).toEqual([
       {
@@ -222,7 +222,7 @@ describe("SearchQueryBuilder", () => {
     ]);
   });
 
-  it("should handle multiple filters", () => {
+  it("should handle multiple filters", async () => {
     const multiFilterConfig: SearchQuery = {
       ...queryConfig,
       filters: [
@@ -243,7 +243,7 @@ describe("SearchQueryBuilder", () => {
     };
 
     const builder = new SearchQueryBuilder(state, multiFilterConfig);
-    const query = builder.build();
+    const query = await builder.build();
 
     expect(query.query.bool.filter).toEqual([
       {
@@ -283,7 +283,7 @@ describe("SearchQueryBuilder", () => {
   });
 
   describe("aggregations", () => {
-    it("should handle range facet", () => {
+    it("should handle range facet", async () => {
       const rangeConfig: SearchQuery = {
         ...queryConfig,
         facets: {
@@ -298,7 +298,7 @@ describe("SearchQueryBuilder", () => {
       };
 
       const builder = new SearchQueryBuilder(state, rangeConfig);
-      const query = builder.build();
+      const query = await builder.build();
 
       expect(query.aggs).toEqual({
         facet_bucket_all: {
@@ -321,7 +321,7 @@ describe("SearchQueryBuilder", () => {
       });
     });
 
-    it("should handle geo distance facet", () => {
+    it("should handle geo distance facet", async () => {
       const geoConfig: SearchQuery = {
         ...queryConfig,
         facets: {
@@ -338,7 +338,7 @@ describe("SearchQueryBuilder", () => {
       };
 
       const builder = new SearchQueryBuilder(state, geoConfig);
-      const query = builder.build();
+      const query = await builder.build();
 
       expect(query.aggs).toEqual({
         facet_bucket_all: {
@@ -365,7 +365,7 @@ describe("SearchQueryBuilder", () => {
       });
     });
 
-    it("should handle multiple facets", () => {
+    it("should handle multiple facets", async () => {
       const multiFacetConfig: SearchQuery = {
         ...queryConfig,
         facets: {
@@ -381,7 +381,7 @@ describe("SearchQueryBuilder", () => {
       };
 
       const builder = new SearchQueryBuilder(state, multiFacetConfig);
-      const query = builder.build();
+      const query = await builder.build();
 
       expect(query.aggs).toEqual({
         facet_bucket_all: {
@@ -411,7 +411,7 @@ describe("SearchQueryBuilder", () => {
       });
     });
 
-    it("should handle custom facet size", () => {
+    it("should handle custom facet size", async () => {
       const customSizeConfig: SearchQuery = {
         ...queryConfig,
         facets: {
@@ -420,14 +420,14 @@ describe("SearchQueryBuilder", () => {
       };
 
       const builder = new SearchQueryBuilder(state, customSizeConfig);
-      const query = builder.build();
+      const query = await builder.build();
 
       expect(
         query.aggs.facet_bucket_all.aggs["category.keyword"].terms.size
       ).toBe(50);
     });
 
-    it("should handle facet sorting", () => {
+    it("should handle facet sorting", async () => {
       const sortedConfig: SearchQuery = {
         ...queryConfig,
         facets: {
@@ -436,14 +436,14 @@ describe("SearchQueryBuilder", () => {
       };
 
       const builder = new SearchQueryBuilder(state, sortedConfig);
-      const query = builder.build();
+      const query = await builder.build();
 
       expect(
         query.aggs.facet_bucket_all.aggs["category.keyword"].terms.order
       ).toEqual({ _key: "asc" });
     });
 
-    it("should handle disjunctive facets", () => {
+    it("should handle disjunctive facets", async () => {
       const disjunctiveConfig: SearchQuery = {
         ...queryConfig,
         disjunctiveFacets: ["category.keyword", "price"],
@@ -460,7 +460,7 @@ describe("SearchQueryBuilder", () => {
       };
 
       const builder = new SearchQueryBuilder(state, disjunctiveConfig);
-      const query = builder.build();
+      const query = await builder.build();
 
       expect(query.aggs).toEqual({
         facet_bucket_all: {
@@ -490,7 +490,7 @@ describe("SearchQueryBuilder", () => {
       });
     });
 
-    it("should handle must, must_not, and should filters in aggregations", () => {
+    it("should handle must, must_not, and should filters in aggregations", async () => {
       const stateWithFilters: RequestState = {
         searchTerm: "",
         resultsPerPage: 10,
@@ -510,7 +510,7 @@ describe("SearchQueryBuilder", () => {
         }
       };
       const builder = new SearchQueryBuilder(stateWithFilters, config);
-      const aggs = builder.build().aggs;
+      const aggs = (await builder.build()).aggs;
       expect(aggs).toEqual({
         facet_bucket_all: {
           aggs: {
@@ -592,7 +592,7 @@ describe("SearchQueryBuilder", () => {
   });
 
   describe("buildQuery", () => {
-    it("should not add filters that are also facets", () => {
+    it("should not add filters that are also facets", async () => {
       const stateWithFilters: RequestState = {
         ...state,
         searchTerm: "",
@@ -608,12 +608,12 @@ describe("SearchQueryBuilder", () => {
         stateWithFilters,
         configWithoutFilters
       );
-      const query = builder.build();
+      const query = await builder.build();
 
       expect(query.query).toBeUndefined();
     });
 
-    it("should combine state filters and base filters when search term is empty", () => {
+    it("should combine state filters and base filters when search term is empty", async () => {
       const stateWithFilters: RequestState = {
         ...state,
         searchTerm: "",
@@ -646,7 +646,7 @@ describe("SearchQueryBuilder", () => {
         stateWithFilters,
         configWithFilters
       );
-      const query = builder.build();
+      const query = await builder.build();
 
       expect(query.query).toEqual({
         bool: {
@@ -679,23 +679,23 @@ describe("SearchQueryBuilder", () => {
     });
 
     describe("fuzziness", () => {
-      it("should not add fuzziness when not configured", () => {
+      it("should not add fuzziness when not configured", async () => {
         const builder = new SearchQueryBuilder(state, queryConfig);
-        const query = builder.build();
+        const query = await builder.build();
 
         expect(
           query.query.bool.must[0].bool.should[0].multi_match.fuzziness
         ).toBeUndefined();
       });
 
-      it("should add AUTO fuzziness when configured", () => {
+      it("should add AUTO fuzziness when configured", async () => {
         const configWithFuzziness: SearchQuery = {
           ...queryConfig,
           fuzziness: true
         };
 
         const builder = new SearchQueryBuilder(state, configWithFuzziness);
-        const query = builder.build();
+        const query = await builder.build();
 
         expect(
           query.query.bool.must[0].bool.should[0].multi_match.fuzziness
@@ -738,7 +738,7 @@ describe("SearchQueryBuilder", () => {
   });
 
   describe("getQueryFn", () => {
-    it("should use custom query function when provided", () => {
+    it("should use custom query function when provided", async () => {
       const customQuery = {
         bool: {
           match: {
@@ -752,7 +752,7 @@ describe("SearchQueryBuilder", () => {
 
       const getQueryFn = jest.fn().mockReturnValue(customQuery);
       const builder = new SearchQueryBuilder(state, queryConfig, getQueryFn);
-      const query = builder.build();
+      const query = await builder.build();
 
       expect(getQueryFn).toHaveBeenCalledWith(state, queryConfig);
       expect(query.query).toEqual({
@@ -780,7 +780,7 @@ describe("SearchQueryBuilder", () => {
       });
     });
 
-    it("should combine custom query with filters", () => {
+    it("should combine custom query with filters", async () => {
       const customQuery = {
         bool: {
           must: [
@@ -810,7 +810,7 @@ describe("SearchQueryBuilder", () => {
         queryConfig,
         getQueryFn
       );
-      const query = builder.build();
+      const query = await builder.build();
 
       expect(query.query).toEqual({
         bool: {

--- a/packages/search-ui-elasticsearch-connector/src/queryBuilders/__tests__/SuggestionsAutocompleteBuilder.test.ts
+++ b/packages/search-ui-elasticsearch-connector/src/queryBuilders/__tests__/SuggestionsAutocompleteBuilder.test.ts
@@ -12,9 +12,9 @@ describe("SuggestionsAutocompleteBuilder", () => {
     queryType: "suggestions"
   };
 
-  it("should build suggestions autocomplete query", () => {
+  it("should build suggestions autocomplete query", async () => {
     const builder = new SuggestionsAutocompleteBuilder(state, config, 5);
-    const query = builder.build();
+    const query = await builder.build();
 
     expect(query).toEqual({
       size: 0,
@@ -37,28 +37,28 @@ describe("SuggestionsAutocompleteBuilder", () => {
     });
   });
 
-  it("should handle empty search term", () => {
+  it("should handle empty search term", async () => {
     const emptyState: RequestState = {
       ...state,
       searchTerm: ""
     };
 
     const builder = new SuggestionsAutocompleteBuilder(emptyState, config, 5);
-    const query = builder.build();
+    const query = await builder.build();
 
     expect(query.suggest).toBeUndefined();
   });
 
-  it("should handle custom size", () => {
+  it("should handle custom size", async () => {
     const builder = new SuggestionsAutocompleteBuilder(state, config, 10);
-    const query = builder.build();
+    const query = await builder.build();
 
     expect(
       (query.suggest.suggest as SearchFieldSuggester).completion.size
     ).toBe(10);
   });
 
-  it("should handle multiple fields", () => {
+  it("should handle multiple fields", async () => {
     const multiFieldConfig: SuggestionConfiguration = {
       ...config,
       fields: ["title", "description"]
@@ -69,7 +69,7 @@ describe("SuggestionsAutocompleteBuilder", () => {
       multiFieldConfig,
       5
     );
-    const query = builder.build();
+    const query = await builder.build();
 
     expect(query).toEqual({
       size: 0,

--- a/packages/search-ui-elasticsearch-connector/src/types.ts
+++ b/packages/search-ui-elasticsearch-connector/src/types.ts
@@ -56,5 +56,8 @@ export type RequestModifiers = {
   interceptSearchRequest?: SearchQueryHook<QueryConfig>;
   interceptAutocompleteResultsRequest?: SearchQueryHook<AutocompleteQueryConfig>;
   interceptAutocompleteSuggestionsRequest?: SearchQueryHook<AutocompleteQueryConfig>;
-  getQueryFn?: (state: RequestState, queryConfig: QueryConfig) => Query;
+  getQueryFn?: (
+    state: RequestState,
+    queryConfig: QueryConfig
+  ) => Query | Promise<Query>;
 };


### PR DESCRIPTION
## Description
Converts `getQueryFn` to an `async` function so that asynchronous work can be done when creating the query.

## Associated Github Issues
#1178 
