### PR TITLE
Update facets filtering

### DIFF
--- a/docs/reference/api-connectors-elasticsearch.md
+++ b/docs/reference/api-connectors-elasticsearch.md
@@ -328,7 +328,7 @@ The Elasticsearch Connector supports additional facet properties that are not av
 
 **For value facets:**
 
-- `direction` - Sort direction when `sort` is set to "value". Either "asc" or "desc". Defaults to "asc".
+- `direction` - Sort direction for facet. Either "asc" or "desc". Defaults to "asc". **Note:** When using sort by "count" with ascending direction the results may be inaccurate.
 - `include` - Regex pattern or array of values to include in facet results. Can be used to filter facet values.
 - `exclude` - Regex pattern or array of values to exclude from facet results. Can be used to filter out unwanted facet values.
 
@@ -367,7 +367,7 @@ facets: {
     type: "value",
     size: 30,
     sort: "value",
-    direction: "desc", // Sort direction for value facets
+    direction: "desc", // Sort direction for facet
     include: "North\\s+\\w+", // Regex pattern to include specific values
     exclude: ["excluded_state"] // Array of values to exclude
   }

--- a/docs/reference/api-core-configuration.md
+++ b/docs/reference/api-core-configuration.md
@@ -134,24 +134,24 @@ Tells Search UI to fetch facet data that can be used with Facet Components.
   }
 ```
 
-| field       | type         | description                                                                                                                                                                                                       |
-| ----------- | ------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `type`      | string       | **Required.** Type of facet. Either "value" or "range".                                                                                                                                                           |
-| `size`      | number       | **Optional.** Number of facet values to return. Defaults to 20.                                                                                                                                                   |
-| `sort`      | string       | **Optional.** Sort order for facet values. Either "count" or "value". Defaults to "count".                                                                                                                        |
-| `ranges`    | array        | **Required for range facets.** Array of range objects with `from`, `to`, and `name` properties.                                                                                                                   |
-| `center`    | string       | **Required for geo range facets.** Center point coordinates (e.g., "37.7749, -122.4194").                                                                                                                         |
-| `unit`      | string       | **Required for geo range facets.** Distance unit (e.g., "mi", "km").                                                                                                                                              |
-| `direction` | string       | **Optional.** **Only available in the [Elasticsearch Connector](/reference/api-connectors-elasticsearch.md).** Sort direction for value facets when `sort` is "value". Either "asc" or "desc". Defaults to "asc". |
-| `include`   | string/array | **Optional.** **Only available in the [Elasticsearch Connector](/reference/api-connectors-elasticsearch.md).** Regex pattern or array of values to include in facet results.                                      |
-| `exclude`   | string/array | **Optional.** **Only available in the [Elasticsearch Connector](/reference/api-connectors-elasticsearch.md).** Regex pattern or array of values to exclude from facet results.                                    |
+| field       | type         | description                                                                                                                                                                                                                                                                      |
+| ----------- | ------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `type`      | string       | **Required.** Type of facet. Either "value" or "range".                                                                                                                                                                                                                          |
+| `size`      | number       | **Optional.** Number of facet values to return. Defaults to 20.                                                                                                                                                                                                                  |
+| `sort`      | string       | **Optional.** Sort order for facet values. Either "count" or "value". Defaults to "count".                                                                                                                                                                                       |
+| `ranges`    | array        | **Required for range facets.** Array of range objects with `from`, `to`, and `name` properties.                                                                                                                                                                                  |
+| `center`    | string       | **Required for geo range facets.** Center point coordinates (e.g., "37.7749, -122.4194").                                                                                                                                                                                        |
+| `unit`      | string       | **Required for geo range facets.** Distance unit (e.g., "mi", "km").                                                                                                                                                                                                             |
+| `direction` | string       | **Optional.** **Only available in the [Elasticsearch Connector](/reference/api-connectors-elasticsearch.md).** Sort direction for facet. Either "asc" or "desc". Defaults to "asc". **Note:** When using sort by "count" with ascending direction the results may be inaccurate. |
+| `include`   | string/array | **Optional.** **Only available in the [Elasticsearch Connector](/reference/api-connectors-elasticsearch.md).** Regex pattern or array of values to include in facet results.                                                                                                     |
+| `exclude`   | string/array | **Optional.** **Only available in the [Elasticsearch Connector](/reference/api-connectors-elasticsearch.md).** Regex pattern or array of values to exclude from facet results.                                                                                                   |
 
 ::::{important}
 **Elasticsearch Connector Only Properties**
 
 The following facet properties are only supported by the [Elasticsearch Connector](/reference/api-connectors-elasticsearch.md):
 
-- `direction` - Sort direction for value facets
+- `direction` - Sort direction for facet values. **Note:** When using sort by "count" with ascending direction the results may be inaccurate.
 - `include` - Regex pattern or array of values to include in facet results
 - `exclude` - Regex pattern or array of values to exclude from facet results
 

--- a/packages/search-ui-elasticsearch-connector/src/transformer/__tests__/filterTransformer.test.ts
+++ b/packages/search-ui-elasticsearch-connector/src/transformer/__tests__/filterTransformer.test.ts
@@ -343,7 +343,7 @@ describe("filterTransformer", () => {
       });
     });
 
-    it("should show warning when sort is count and direction is not desc", () => {
+    it("should transform value facet with count sort and direction asc", () => {
       const consoleSpy = jest.spyOn(console, "warn").mockImplementation();
 
       const facetConfig: FacetConfiguration = {
@@ -354,14 +354,11 @@ describe("filterTransformer", () => {
 
       const result = transformFacetToAggs("category", facetConfig);
 
-      expect(consoleSpy).toHaveBeenCalledWith(
-        "Sorting by count and direction ascending is not supported due to Elasticsearch warnings. Direction will be ignored."
-      );
       expect(result).toEqual({
         terms: {
           field: "category",
           size: 20,
-          order: { _count: "desc" }
+          order: { _count: "asc" }
         }
       });
 

--- a/packages/search-ui-elasticsearch-connector/src/transformer/filterTransformer.ts
+++ b/packages/search-ui-elasticsearch-connector/src/transformer/filterTransformer.ts
@@ -163,18 +163,9 @@ export const transformFacetToAggs = (
 ) => {
   if (facetConfiguration.type === "value") {
     const orderMap = {
-      count: { _count: "desc" },
+      count: { _count: facetConfiguration.direction || "desc" },
       value: { _key: facetConfiguration.direction || "asc" }
     };
-
-    if (
-      facetConfiguration.direction !== "desc" &&
-      facetConfiguration.sort === "count"
-    ) {
-      console.warn(
-        "Sorting by count and direction ascending is not supported due to Elasticsearch warnings. Direction will be ignored."
-      );
-    }
 
     return {
       terms: {


### PR DESCRIPTION
## Description
Allow to user `sort: "count"` with `direction: "asc"` for facets in Elasticsearch connector and added warnings to documentation about potential inaccuracy when using it.

## List of changes
- Allow to user `sort: "count"` with `direction: "asc" | "desc"` 
- Updated tests
- Updated documentation with potential inaccuracy

## Associated Github Issues
#1184 
