### PR TITLE
#1190 handle errors from response in search-ui-elasticsearch-connector

### DIFF
--- a/packages/search-ui-elasticsearch-connector/src/types.ts
+++ b/packages/search-ui-elasticsearch-connector/src/types.ts
@@ -61,3 +61,31 @@ export type RequestModifiers = {
     queryConfig: QueryConfig
   ) => Query | Promise<Query>;
 };
+
+export interface ElasticsearchErrorCause {
+  type: string;
+  reason: string;
+  index_uuid?: string;
+  index?: string;
+  caused_by?: ElasticsearchErrorCause;
+}
+
+export interface ElasticsearchFailedShard {
+  shard: number;
+  index: string;
+  node: string;
+  reason: ElasticsearchErrorCause;
+}
+
+export interface ElasticsearchError {
+  root_cause?: ElasticsearchErrorCause[];
+  type: string;
+  reason: string;
+  phase?: string;
+  grouped?: boolean;
+  failed_shards?: ElasticsearchFailedShard[];
+}
+
+export interface SearchResponseWithError extends ResponseBody {
+  error?: ElasticsearchError;
+}


### PR DESCRIPTION
Before submitting this PR:

1. Make sure you are PR'ing from a fork, please do not push branches directly
   to this repository.
2. Ensure you've written sufficient tests for your work.
3. Double check that your changes will not break existing connectors (if
   applicable).
4. Double check that your changes do not break the `react-search-ui-views`
   storybook (if applicable).

## Description
Handle api error in ElasticsearchAPIConnector
## List of changes
If an error is found, throw it instead of failing silently.
## Associated Github Issues
https://github.com/elastic/search-ui/issues/1190