### PR TITLE
docs: update security url to link to central policy

### DIFF
--- a/SECURITY.txt
+++ b/SECURITY.txt
@@ -6,4 +6,4 @@ The latest minor version will receive security updates.
 
 ## Reporting a Vulnerability
 
-If you notice a security vulnerability in our code, please use the instructions on this page to report it: https://www.elastic.co/community/security. Please do not create an issue in this repository. It can compromise the security of others.
+If you notice a security vulnerability in our code, please use the instructions on this page to report it: https://github.com/elastic/.github/blob/main/SECURITY.md. Please do not create an issue in this repository. It can compromise the security of others.


### PR DESCRIPTION
This PR replaces security URLs with a link to the central security policy.