### PR TITLE
Fix open bug issues in Search UI

### DIFF
--- a/packages/react-search-ui-views/src/SingleSelectFacet.tsx
+++ b/packages/react-search-ui-views/src/SingleSelectFacet.tsx
@@ -69,7 +69,7 @@ function SingleSelectFacet({
             return Option(props);
           }
         }}
-        value={selectedSelectBoxOption}
+        value={selectedSelectBoxOption ?? null}
         onChange={(o) => onChange(o.value)}
         options={selectBoxOptions}
         isSearchable={false}

--- a/packages/react-search-ui-views/src/__tests__/SingleSelectFacet.test.tsx
+++ b/packages/react-search-ui-views/src/__tests__/SingleSelectFacet.test.tsx
@@ -99,6 +99,25 @@ describe("determining selected option", () => {
       container.querySelector(".sui-select__placeholder")
     ).toHaveTextContent("Select...");
   });
+
+  it("will clear the selected value after it is removed", () => {
+    const { container, rerender } = render(<SingleSelectFacet {...params} />);
+
+    rerender(
+      <SingleSelectFacet
+        {...params}
+        options={params.options.map((option) => ({
+          ...option,
+          selected: false
+        }))}
+      />
+    );
+
+    expect(container.querySelector(".sui-select__single-value")).toBeNull();
+    expect(
+      container.querySelector(".sui-select__placeholder")
+    ).toHaveTextContent("Select...");
+  });
 });
 
 it("renders with className prop applied", () => {

--- a/packages/react-search-ui-views/src/__tests__/layouts/LayoutSidebar.test.tsx
+++ b/packages/react-search-ui-views/src/__tests__/layouts/LayoutSidebar.test.tsx
@@ -37,3 +37,14 @@ it("updates isSidebarToggled state on button click", () => {
   fireEvent.click(toggleButton);
   expect(sidebar).not.toHaveClass("sui-layout-sidebar--toggled");
 });
+
+it("does not render toggle buttons when sidebar content is empty", () => {
+  render(
+    <LayoutSidebar className="sui-layout-sidebar">
+      <div />
+    </LayoutSidebar>
+  );
+
+  expect(screen.queryByText("Show Filters")).not.toBeInTheDocument();
+  expect(screen.queryByText("Save Filters")).not.toBeInTheDocument();
+});

--- a/packages/react-search-ui-views/src/layouts/LayoutSidebar.tsx
+++ b/packages/react-search-ui-views/src/layouts/LayoutSidebar.tsx
@@ -9,15 +9,26 @@ interface LayoutSidebarProps {
 
 interface LayoutSidebarState {
   isSidebarToggled: boolean;
+  hasSidebarContent: boolean;
 }
 
 class LayoutSidebar extends React.Component<
   LayoutSidebarProps,
   LayoutSidebarState
 > {
+  private sidebarRef = React.createRef<HTMLDivElement>();
+
   constructor(props) {
     super(props);
-    this.state = { isSidebarToggled: false };
+    this.state = { isSidebarToggled: false, hasSidebarContent: false };
+  }
+
+  componentDidMount() {
+    this.syncSidebarContentState();
+  }
+
+  componentDidUpdate() {
+    this.syncSidebarContentState();
   }
 
   toggleSidebar = () => {
@@ -26,8 +37,44 @@ class LayoutSidebar extends React.Component<
     }));
   };
 
+  syncSidebarContentState = () => {
+    const sidebar = this.sidebarRef.current;
+    const hasSidebarContent = Array.from(sidebar?.childNodes ?? [])
+      .filter((node) => {
+        return !(
+          node instanceof HTMLButtonElement &&
+          node.classList.contains("sui-layout-sidebar-toggle")
+        );
+      })
+      .some((node) => {
+        if (node.nodeType === Node.TEXT_NODE) {
+          return Boolean(node.textContent?.trim());
+        }
+
+        if (!(node instanceof HTMLElement)) return false;
+
+        return (
+          Boolean(node.textContent?.trim()) ||
+          node.matches("input,select,textarea,button,a") ||
+          Boolean(node.querySelector("input,select,textarea,button,a"))
+        );
+      });
+
+    if (
+      hasSidebarContent !== this.state.hasSidebarContent ||
+      (!hasSidebarContent && this.state.isSidebarToggled)
+    ) {
+      this.setState({
+        hasSidebarContent,
+        isSidebarToggled: hasSidebarContent
+          ? this.state.isSidebarToggled
+          : false
+      });
+    }
+  };
+
   renderToggleButton = (label) => {
-    if (!this.props.children) return null;
+    if (!this.state.hasSidebarContent) return null;
 
     return (
       <button
@@ -53,7 +100,7 @@ class LayoutSidebar extends React.Component<
     return (
       <>
         {this.renderToggleButton("Show Filters")}
-        <div className={classes}>
+        <div className={classes} ref={this.sidebarRef}>
           {this.renderToggleButton("Save Filters")}
           {children}
         </div>

--- a/packages/search-ui/src/SearchDriver.ts
+++ b/packages/search-ui/src/SearchDriver.ts
@@ -310,13 +310,30 @@ class SearchDriver {
       })
     };
 
-    return this.events
-      .autocomplete({ searchTerm }, queryConfig)
+    return Promise.resolve(
+      this.events.autocomplete({ searchTerm }, queryConfig)
+    )
       .then((autocompleted) => {
         if (this.autocompleteRequestSequencer.isOldRequest(requestId)) return;
         this.autocompleteRequestSequencer.completed(requestId);
 
         this._setState(autocompleted);
+      })
+      .catch((error) => {
+        if (this.debug) {
+          console.error(error);
+        }
+
+        if (error.message === INVALID_CREDENTIALS) {
+          this._setState({
+            ...(this.apiConnector?.state && { ...this.apiConnector.state })
+          });
+          return;
+        }
+
+        this._setState({
+          error: `An unexpected error occurred: ${error.message}`
+        });
       });
   };
 

--- a/packages/search-ui/src/SearchDriver.ts
+++ b/packages/search-ui/src/SearchDriver.ts
@@ -310,16 +310,14 @@ class SearchDriver {
       })
     };
 
-    return Promise.resolve(
-      this.events.autocomplete({ searchTerm }, queryConfig)
-    )
-      .then((autocompleted) => {
+    return this.events.autocomplete({ searchTerm }, queryConfig).then(
+      (autocompleted) => {
         if (this.autocompleteRequestSequencer.isOldRequest(requestId)) return;
         this.autocompleteRequestSequencer.completed(requestId);
 
         this._setState(autocompleted);
-      })
-      .catch((error) => {
+      },
+      (error) => {
         if (this.debug) {
           console.error(error);
         }
@@ -334,7 +332,8 @@ class SearchDriver {
         this._setState({
           error: `An unexpected error occurred: ${error.message}`
         });
-      });
+      }
+    );
   };
 
   /**

--- a/packages/search-ui/src/__tests__/SearchDriver.test.ts
+++ b/packages/search-ui/src/__tests__/SearchDriver.test.ts
@@ -378,6 +378,30 @@ describe("autocompleteQuery config", () => {
       search_fields
     );
   });
+
+  it("will store autocomplete errors in state", async () => {
+    const mockApiConnector = getMockApiConnector();
+    (mockApiConnector.onAutocomplete as jest.Mock).mockRejectedValue(
+      new Error("Failed to fetch")
+    );
+
+    const driver = new SearchDriver({
+      apiConnector: mockApiConnector,
+      trackUrlState: false
+    });
+
+    driver.setSearchTerm("test", {
+      autocompleteResults: true,
+      refresh: false
+    });
+    jest.runAllTimers();
+    await Promise.resolve();
+    await waitATick();
+
+    expect(driver.getState().error).toEqual(
+      "An unexpected error occurred: Failed to fetch"
+    );
+  });
 });
 
 describe("#getState", () => {


### PR DESCRIPTION
## Summary
This PR fixes the currently open bug issues that were actionable in code:

- closes #555 by surfacing autocomplete request failures through SearchDriver error state
- closes #567 by clearing SingleSelectFacet correctly after filters are removed
- closes #587 by hiding mobile filter toggle buttons when the sidebar has no rendered content

## Root cause
- SingleSelectFacet passed undefined back to eact-select, which preserved the previous selection instead of resetting to the placeholder.
- autocomplete request failures were not handled in _updateAutocomplete, so errors never reached ErrorBoundary.
- LayoutSidebar only checked whether children existed, not whether the sidebar actually rendered any usable content.

## Validation
- packages/react-search-ui-views: SingleSelectFacet.test.tsx, LayoutSidebar.test.tsx
- packages/search-ui: SearchDriver.test.ts

## Notes
I also checked the open PR set for unresolved review-thread blockers on the still-open review/conflict items and did not find outstanding review threads that required additional local code changes in this branch.
